### PR TITLE
fix(meta-kit): refresh slugs after REST sync rename (v1.59.3)

### DIFF
--- a/plugins/actian-design-system/.claude-plugin/plugin.json
+++ b/plugins/actian-design-system/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "actian-design-system",
   "description": "Actian Design System toolkit — sync tokens from Figma, generate wireframe flows with prototype wiring, create component briefs, audit designs, compare flows, and build presentations. 9 skills (with tiered generation: recognized / adapted / improvised), 8 agents, 155 tokens (3 themes, 8 collections), WCAG 2.1 AA.",
-  "version": "1.59.2",
+  "version": "1.59.3",
   "author": {
     "name": "Actian UX Team"
   },

--- a/plugins/actian-design-system/scripts/shared-constants.js
+++ b/plugins/actian-design-system/scripts/shared-constants.js
@@ -133,26 +133,32 @@ function buildKeyMapFromRegistry(registryName, prefix, section, overrides) {
 // Ref-name → registry-slug mappings (only source of duplication)
 // ---------------------------------------------------------------------------
 
+// Slug values match the canonical keys in docs/metakit.json. The REST sync
+// orchestrator (Sprint 1) normalizes Figma component names through a single
+// slugify pass that collapses runs of non-alphanumeric chars to "-", which
+// dropped the legacy "meta-/-X-/-Y" form on 2026-04-30. Keep this table in
+// step with metakit.json — adding a slug here that doesn't exist there will
+// cause buildKeyMap to silently drop the entry.
 const META_SLUGS = {
-  genLog: "meta-/-chrome-/-generation-log",
-  divider: "meta-/-utility-/-card-divider",
-  codeBlock: "meta-/-content-/-code-block",
-  flowCoverCard: "meta-/-chrome-/-flow-cover-card",
-  researchFrame: "meta-/-content-/-research-frame",
-  feedback: "meta-/-chrome-/-feedback",
-  flowScreen: "meta-/-chrome-/-flow-screen",
+  genLog: "meta-chrome-generation-log",
+  divider: "meta-utility-card-divider",
+  codeBlock: "meta-content-code-block",
+  flowCoverCard: "meta-chrome-flow-cover-card",
+  researchFrame: "meta-content-research-frame",
+  feedback: "meta-chrome-feedback",
+  flowScreen: "meta-chrome-flow-screen",
 };
 
 const BRIEF_SLUGS = {
-  briefCard: "meta-/-chrome-/-brief-card",
-  doDontPair: "meta-/-content-/-do-don't-pair",
-  contrastBadge: "meta-/-content-/-contrast-badge",
-  pointerBadge: "meta-/-content-/-pointer-badge",
-  dimAnnotation: "meta-/-content-/-dimension-annotation",
-  a11yCard: "meta-/-chrome-/-accessibility-card",
-  colorSwatch: "meta-/-content-/-color-swatch",
-  themeCard: "meta-/-chrome-/-theme-card",
-  statCard: "meta-/-content-/-stat-card",
+  briefCard: "meta-chrome-brief-card",
+  doDontPair: "meta-content-do-don-t-pair",
+  contrastBadge: "meta-content-contrast-badge",
+  pointerBadge: "meta-content-pointer-badge",
+  dimAnnotation: "meta-content-dimension-annotation",
+  a11yCard: "meta-chrome-accessibility-card",
+  colorSwatch: "meta-content-color-swatch",
+  themeCard: "meta-chrome-theme-card",
+  statCard: "meta-content-stat-card",
 };
 
 const TEMPLATE_SLUGS = {
@@ -162,11 +168,11 @@ const TEMPLATE_SLUGS = {
 };
 
 const SLIDE_SLUGS = {
-  slideCover: "meta-/-slide-/-cover",
-  slideBodyFull: "meta-/-slide-/-body-full",
-  slideBodyTV: "meta-/-slide-/-body-text-visual",
-  slideSection: "meta-/-slide-/-section",
-  slideBack: "meta-/-slide-/-back-cover",
+  slideCover: "meta-slide-cover",
+  slideBodyFull: "meta-slide-body-full",
+  slideBodyTV: "meta-slide-body-text-visual",
+  slideSection: "meta-slide-section",
+  slideBack: "meta-slide-back-cover",
 };
 
 const FM_SLUGS = buildSlugMap("fmkit", "fm");

--- a/plugins/actian-design-system/scripts/transform-to-hifi.js
+++ b/plugins/actian-design-system/scripts/transform-to-hifi.js
@@ -21,6 +21,7 @@
 var fs = require("fs");
 var path = require("path");
 var resolver = require("./intent-resolver.js");
+var shared = require("./shared-constants.js");
 
 // ---------------------------------------------------------------------------
 // Paths
@@ -78,36 +79,6 @@ function serializeVariant(obj) {
 }
 
 // ---------------------------------------------------------------------------
-// Slug-to-ref helper
-// ---------------------------------------------------------------------------
-
-/**
- * Convert a DS slug like "button" or "dropdown-select-default" to a DS ref name.
- * Pattern: "ds" + PascalCase(slug)
- *
- * Examples:
- *   "button"                  → "dsButton"
- *   "dropdown-select-default" → "dsDropdownSelectDefault"
- *   "checkbox-with-label"     → "dsCheckboxWithLabel"
- *   "alert-banner"            → "dsAlertBanner"
- *
- * @param {string} slug
- * @returns {string}
- */
-function slugToRef(slug) {
-  if (!slug) return "";
-  var parts = slug.split("-");
-  var ref = "ds";
-  for (var i = 0; i < parts.length; i++) {
-    var part = parts[i];
-    if (part.length > 0) {
-      ref += part.charAt(0).toUpperCase() + part.substring(1);
-    }
-  }
-  return ref;
-}
-
-// ---------------------------------------------------------------------------
 // Core transform: single INSTANCE node
 // ---------------------------------------------------------------------------
 
@@ -144,9 +115,12 @@ function transformInstance(node, mapData, dsRegistry, effectiveIntent) {
     return unmappedNode;
   }
 
-  // Build DS ref name from slug
+  // Build DS ref name from slug — shared.slugToRef strips a leading "ds-"
+  // prefix if present, then PascalCases the rest. dsSlug values in
+  // fm-to-ds-map.json don't currently start with "ds-" but the shared
+  // helper handles that case correctly if a future entry does.
   var dsSlug = mapping.dsSlug;
-  var dsRef = slugToRef(dsSlug);
+  var dsRef = shared.slugToRef(dsSlug, "ds");
 
   // Validate that the DS component exists in the registry
   var dsComponents = dsRegistry.components || {};


### PR DESCRIPTION
## Summary

- Refreshes 21 stale slug references in `META_SLUGS` / `BRIEF_SLUGS` / `SLIDE_SLUGS` that broke when yesterday's REST sync auto-merged a slug-normalization pass (`meta-/-X-/-Y` → `meta-X-Y`).
- Recovers the failing `shared-constants.test.js` (was: `META_KEYS.genLog` returned undefined for 7 Meta Kit components, 5 brief cards, 5 slide templates).
- Also dedupes `slugToRef` between `shared-constants.js` and `transform-to-hifi.js` (cleanup #3 from the paused cleanup sprint — harmless, both implementations were functionally equivalent for current inputs).

## What this does NOT fix

Pre-existing `fm-to-ds-map.test.js` failures (8) remain — those need Fix A (`dsKey` switch) per `project_fm_kit_alignment_proposal.md`. Out of scope for this hotfix.

## Test plan

- [x] `shared-constants.test.js` — passes (was: 1 fail)
- [x] Full test suite — 8 fails remaining, all in `fm-to-ds-map.test.js` (pre-existing, unrelated)
- [ ] CI passes on this PR

## Version

`1.59.2 → 1.59.3` (patch — regression fix)

🤖 Generated with [Claude Code](https://claude.com/claude-code)