### PR TITLE
feat: UX flags-to-gates (v1.63.0) — discovery via interactive gates

### DIFF
--- a/plugins/actian-design-system/.claude-plugin/plugin.json
+++ b/plugins/actian-design-system/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "actian-design-system",
   "description": "Actian Design System toolkit — sync tokens from Figma, generate wireframe flows with prototype wiring, create component briefs, audit designs, compare flows, and build presentations. 9 skills (with tiered generation: recognized / adapted / improvised), 8 agents, 155 tokens (3 themes, 8 collections), WCAG 2.1 AA.",
-  "version": "1.62.4",
+  "version": "1.63.0",
   "author": {
     "name": "Actian UX Team"
   },

--- a/plugins/actian-design-system/references/context/companion-context.md
+++ b/plugins/actian-design-system/references/context/companion-context.md
@@ -112,6 +112,10 @@ Before building custom frames, check: `docs/generated/dskit-components.md`, `doc
 
 **Common FM wireframe components:** fmButton, fmTextInput, fmDropdown, fmSearchInput, fmTableCell, fmCheckbox, fmRadioButton, fmToggle, fmAlert, fmBanner, fmDialog, fmEmptyState, fmPlaceholder, fmTab, fmStepper, fmBadge, fmTag, fmToast, fmPageHeader, fmAppHeader, fmNavItem
 
+## Interactive Gates
+
+`/generate-flow`, `/design-audit`, and `/convert-to-hifi` use interactive gates to surface options to designers without removing the `--flag` API. Companion appends `--no-prompt` when ALL relevant flags are extracted from prose; otherwise lets the downstream skill gate the designer. Convention: `references/ds-rules/interactive-gates.md`.
+
 ## Figma Output
 
 All skills push to Figma using direct `use_figma` calls. No codegen scripts at push time.

--- a/plugins/actian-design-system/references/ds-rules/interactive-gates.md
+++ b/plugins/actian-design-system/references/ds-rules/interactive-gates.md
@@ -1,0 +1,148 @@
+# Interactive Gates Convention
+
+How DS skills surface options to designers without losing the `--flag` API for power users + automation.
+
+## The problem this solves
+
+Today most plugin skills accept `--flag` arguments with silent defaults. Designers who don't know a flag exists never get its option; designers who do know must remember the exact name and value format. Beyond ergonomics, this hides capability — variants, refs, breakpoints, state coverage, post-gen audit go unused because nothing surfaces them at invocation time.
+
+Interactive gates fix both: every meaningful choice is surfaced at the moment it matters, in plain prose, with a documented default. The flags stay; they suppress the gate when explicitly passed.
+
+## Pattern: flag-first with gate fallback
+
+In each skill that adopts this convention:
+
+```
+Step 0 — Parse args (including --no-prompt). Note which flags are explicitly passed.
+Step 0.x — Per pipeline phase:
+  - If --no-prompt is set: skip gates, use defaults for missing flags.
+  - Else if all phase flags are passed: skip the gate.
+  - Else: present a batched gate prompting for the missing flags.
+Validate the resolved flag set (same validator as flag-only path).
+Proceed with execution.
+```
+
+Result:
+- Zero-flag designer invocations → all gates fire
+- Full-flag invocations → zero gates (no behavior change for automation)
+- Mixed invocations → gates fire only for missing flags
+- `--no-prompt` invocations → zero gates, defaults applied
+
+## The `--no-prompt` flag
+
+Single skill-wide suppressor. When present:
+- Skips every gate
+- Uses the documented default for every flag not explicitly passed
+- Available on every skill that adopts this convention
+
+**Why `--no-prompt` over `--yes`:** `--yes` semantically suggests "auto-accept all gate suggestions," which would imply running audit, generating extra states, etc. `--no-prompt` is conservative: it means "no prompts, defaults only." Different semantics, different blast radius.
+
+**Use cases:**
+- Companion routes that have already extracted full intent from prose
+- CI workflows (Sync from Figma, etc.)
+- Scripted Cowork sessions
+- Automated regression tests
+- Power users who already know their flag set
+
+## Gate batching (one prompt per pipeline phase)
+
+Gates are batched per **pipeline phase**, not per flag. Reasons:
+- Fewer interactive turns = faster designer flow
+- Designers see the full configuration surface at once
+- Easier to type one combined response than answer N sequential questions
+
+The proven precedent: `/component-brief` Step 1.5 batches card selection + research scope into one prompt with one combined parser. This convention generalizes that.
+
+**Per-skill batching:**
+- `/generate-flow`: 2 phases — pre-generation gate (4 flags), post-generation gate (2 flags). Special-case flags `--from` and `--branch` are NOT gated; they're detected by companion or absent by default.
+- `/design-audit`: 2 single-flag gates — scope at start, fix after findings reported.
+- `/convert-to-hifi`: 1 single-flag gate — ref at start.
+
+## Gate prompt shape
+
+Each gate prompt should:
+1. **State the question + default in plain prose** — no CLI jargon
+2. **Show all options inline** — designers learn the option set by reading the prompt
+3. **Provide examples** — at least 2 example responses
+4. **Document the keystroke for "default"** — typically just enter
+5. **Re-prompt on parse failure** — 3 retries, then abort with a message pointing at `--no-prompt` or the flag form
+
+Example shape (adapted from `/component-brief` Step 1.5):
+
+```
+Configure generation for [feature]:
+
+Output:        lo-fi (default) | hi-fi
+Variants:      1 (default) | 2 | 3
+References:    none (default) | <paste Figma URL(s) or image URL(s)>
+Breakpoints:   desktop (default) | + tablet | + mobile | all
+
+Reply: enter for all defaults, or specify any subset.
+Examples:
+  hifi 3
+  ref:https://figma.com/design/abc/foo?node-id=1-2
+  hifi tablet,mobile
+```
+
+## Companion's responsibility
+
+The companion skill (`skills/companion/SKILL.md`) routes designer prose to specific skills. When companion routes:
+
+- **Pass `--no-prompt`** when ALL flags relevant to the route's intent have been confidently extracted from prose. Example: companion row 3 ("ship-ready X") extracts `--hifi --audit`, so it routes `/generate-flow X --hifi --audit --no-prompt`.
+- **Don't pass `--no-prompt`** when intent is partial or vague. Let the downstream skill gate. Example: companion row 1 ("design me a settings page") extracts no flags; routes `/generate-flow "settings page"` (no `--no-prompt`), letting the skill gate on output mode, variants, refs, and breakpoints.
+
+The downstream skill gate is the canonical UX. Companion's job is intent classification and partial-flag pre-fill, not UX duplication.
+
+**Per-row decision matrix** (precise):
+
+| Companion row | Relevant flags | Pass `--no-prompt`? |
+|---|---|---|
+| 1 ("design me X") | none | No — let skill gate everything |
+| 3 ("ship-ready X") | `--hifi`, `--audit` | Yes — append `--hifi --audit --no-prompt` |
+| 4 ("variants of X") | `--variants` | Yes — append `--variants 3 --no-prompt` |
+| 9 ("match this style" + refs) | `--ref` | Conditional — only if no other intent missing |
+| 18 ("add empty + error states") | `--states` | Yes — append `--states empty,error --no-prompt` |
+| 20 ("responsive") | `--breakpoints` | Yes — append `--breakpoints tablet,mobile --no-prompt` |
+
+Other rows fall back to the gate.
+
+## Defaults table (canonical)
+
+This table is the source of truth for "what does the skill do when a flag is missing AND `--no-prompt` is set." Skills inherit these defaults; gates show them as the "press enter" choice.
+
+| Flag | Skill | Default if missing AND `--no-prompt` |
+|---|---|---|
+| `--hifi` | `/generate-flow` | false (lo-fi output) |
+| `--audit` | `/generate-flow` | false (skip post-gen audit) |
+| `--variants <N>` | `/generate-flow` | 1 |
+| `--ref <url>` | `/generate-flow`, `/convert-to-hifi` | none |
+| `--breakpoints <list>` | `/generate-flow` | desktop only |
+| `--from <url>` | `/generate-flow` | none |
+| `--branch <name>` | `/generate-flow` | none |
+| `--states <list>` | `/generate-flow` | none |
+| `--scope <list>` | `/design-audit` | all |
+| `--fix <N\|all>` | `/design-audit` | skip |
+
+These match silent-default behavior pre-v1.63.0. No behavior change for automation that already passes flags.
+
+## Validation parity
+
+Same validator runs whether input came from a flag or a gate response. Skills MUST resolve gate input to the equivalent flag before validation, so a single code path catches invalid values regardless of source.
+
+Example: `--variants 99` from a flag fails validation with "Variants must be 1-3." A gate input of "99" hits the same validator and produces the same error message, then re-prompts.
+
+## Migration notes
+
+When adopting this convention in a new skill:
+
+1. Add `var parseNoPrompt = require("../../scripts/lib/parse-no-prompt.js");` at the top of any script that needs the flag.
+2. Update the skill's `argument-hint` frontmatter field to include `[--no-prompt]`.
+3. Add Step 0 (parse) and Step 0.x (gate) sections to `SKILL.md`, following the prompt shape above.
+4. Document each gate's parser rules inline (valid tokens, retries, abort behavior).
+5. Update `references/context/companion-context.md` and `skills/companion/SKILL.md` if companion has a row that should route to your skill.
+
+## Out of scope for this convention
+
+- `/component-brief` Step 1.5 already batches its gates; it does NOT need `--no-prompt` until a future iteration adds it for parity.
+- `/sync-design-system`, `/compare-flows`, `/create-component` don't currently have gateable flags — adopt the convention if/when they grow them.
+- Gates inside refine flows (URL + prose) — refine intent is already explicit; no gate needed.

--- a/plugins/actian-design-system/references/ds-rules/interactive-gates.md
+++ b/plugins/actian-design-system/references/ds-rules/interactive-gates.md
@@ -54,7 +54,7 @@ Gates are batched per **pipeline phase**, not per flag. Reasons:
 The proven precedent: `/component-brief` Step 1.5 batches card selection + research scope into one prompt with one combined parser. This convention generalizes that.
 
 **Per-skill batching:**
-- `/generate-flow`: 2 phases — pre-generation gate (4 flags), post-generation gate (2 flags). Special-case flags `--from` and `--branch` are NOT gated; they're detected by companion or absent by default.
+- `/generate-flow`: 2 phases — pre-generation gate (5 flags: `--hifi`, `--variants`, `--ref`, `--breakpoints`, `--states`), post-push gate (1 flag: `--audit`). Special-case flags `--from` and `--branch` are NOT gated; they're detected by companion or absent by default.
 - `/design-audit`: 2 single-flag gates — scope at start, fix after findings reported.
 - `/convert-to-hifi`: 1 single-flag gate — ref at start.
 

--- a/plugins/actian-design-system/scripts/lib/parse-no-prompt.js
+++ b/plugins/actian-design-system/scripts/lib/parse-no-prompt.js
@@ -1,0 +1,31 @@
+"use strict";
+
+// Parses the --no-prompt flag from CLI args.
+//
+// Used by /generate-flow, /design-audit, /convert-to-hifi to decide whether
+// to run interactive gates or skip with documented defaults. The flag is the
+// single skill-wide suppressor for the gate convention defined in
+// references/ds-rules/interactive-gates.md.
+//
+// Returns { noPrompt: boolean, remainingArgs: string[] } — does NOT mutate
+// the input array. Strict equality match (no prefixed variants, no aliases).
+
+var FLAG = "--no-prompt";
+
+function parseNoPrompt(args) {
+  if (!Array.isArray(args)) {
+    return { noPrompt: false, remainingArgs: [] };
+  }
+  var noPrompt = false;
+  var remaining = [];
+  for (var i = 0; i < args.length; i++) {
+    if (args[i] === FLAG) {
+      noPrompt = true;
+    } else {
+      remaining.push(args[i]);
+    }
+  }
+  return { noPrompt: noPrompt, remainingArgs: remaining };
+}
+
+module.exports = parseNoPrompt;

--- a/plugins/actian-design-system/skills/companion/SKILL.md
+++ b/plugins/actian-design-system/skills/companion/SKILL.md
@@ -52,28 +52,37 @@ The companion is the API. Match the user's prose against this table; pick the mo
 |---|---------------|------|-----------|
 | 1 | "design me X" / "mock me X" / "create a screen for X" | no | `/generate-flow X` (single screen) |
 | 2 | "design a flow for X" / "create the X flow" / "wizard for X" | no | `/generate-flow X` (multi-screen) |
-| 3 | "build me X end-to-end" / "ship-ready X" / "production version of X" | no | `/generate-flow X --hifi --audit` |
-| 4 | "show me alternatives" / "different angles" / "variants of X" / "three ways to do X" | no | `/generate-flow X --variants 3` |
+| 3 | "build me X end-to-end" / "ship-ready X" / "production version of X" | no | `/generate-flow X --hifi --audit --no-prompt` |
+| 4 | "show me alternatives" / "different angles" / "variants of X" / "three ways to do X" | no | `/generate-flow X --variants 3 --no-prompt` |
 | 5 | "edit this" / "change X to Y" / "swap" / "move" / "rename" / "fix" | yes | `/generate-flow <url> "instruction"` (refine shape — surgical: only changed screen frames are recreated, untouched screens stay byte-identical via `flow-data.snapshot.json`; validator findings stay scoped via `--scope single-unit:<id>` or `multi-unit:[…]`; B-refine.1+B-refine.2, v1.55.0–v1.56.0+) |
 | 6 | "try a different angle on this" / "what else" / "another version" | yes | `/generate-flow --from <url>` (iterate, no instruction) |
 | 7 | "branch this for X variant" / "fork this as Y" | yes | `/generate-flow --from <url> --branch X` |
 | 8 | "make it hifi" / "convert to hifi" / "DS version" / "polish this up" | yes | `/convert-to-hifi <url>` |
-| 9 | "make it feel like X" / "match this style" / "match the density of this" + ref URLs | yes + refs | `/generate-flow X --ref <refs>` or `/convert-to-hifi <url> --ref <refs>` (v1.57.0+: vision-extracts a 4-field structural fingerprint per ref and biases recipe + density; cached on `meta.references[].fingerprint` for refine reuse) |
+| 9 | "make it feel like X" / "match this style" / "match the density of this" + ref URLs | yes + refs | `/generate-flow X --ref <refs>` (gates on remaining flags) or `/convert-to-hifi <url> --ref <refs> --no-prompt` (v1.57.0+: vision-extracts a 4-field structural fingerprint per ref and biases recipe + density; cached on `meta.references[].fingerprint` for refine reuse) |
 | 10 | "is this any good?" / "review this" / "audit this" | yes | `/design-audit <url>` |
-| 11 | "is the copy ok?" / "review the copy" / "content check" | yes | `/design-audit <url> --scope copy` |
-| 12 | "fix the copy" / "rewrite the text" | yes | `/design-audit <url> --scope copy --fix all` |
-| 13 | "UX-wise, how does this read?" / "heuristic check" / "usability review" | yes | `/design-audit <url> --scope heuristic` |
-| 14 | "fix #N" (in audit context) | yes | `/design-audit --fix N` |
+| 11 | "is the copy ok?" / "review the copy" / "content check" | yes | `/design-audit <url> --scope copy --no-prompt` |
+| 12 | "fix the copy" / "rewrite the text" | yes | `/design-audit <url> --scope copy --fix all --no-prompt` |
+| 13 | "UX-wise, how does this read?" / "heuristic check" / "usability review" | yes | `/design-audit <url> --scope heuristic --no-prompt` |
+| 14 | "fix #N" (in audit context) | yes | `/design-audit --fix N --no-prompt` |
 | 15 | "compare X and Y" / "diff these two" | 2 URLs | `/compare-flows <url1> <url2>` |
 | 16 | "find every empty state" / "where do we use FilterChip" / "show me all X in our library" | optional | answer inline (no skill invocation) |
 | 17 | Ticket URL (Jira / Confluence / Google doc) | yes (non-Figma) | `/generate-flow --from <url>` (URL-type detection → spec mode) |
-| 18 | "add empty + error states" / "state coverage for X" | yes | `/generate-flow <url> --states empty,error` |
+| 18 | "add empty + error states" / "state coverage for X" | yes | `/generate-flow <url> --states empty,error --no-prompt` |
 | 19 | "make this realistic" / "use real data" / "fill with proper content" | yes | `/generate-flow <url> "use realistic data drawn from app-context"` (refine) |
-| 20 | "responsive" / "for tablet" / "mobile version" | yes | `/generate-flow <url> --breakpoints tablet,mobile` |
+| 20 | "responsive" / "for tablet" / "mobile version" | yes | `/generate-flow <url> --breakpoints tablet,mobile --no-prompt` |
 | 21 | "document this component" / "brief for this" | yes (component) | `/component-brief <url>` |
 | 22 | "sync the design system" / "pull tokens from Figma" / "refresh registries" | optional | `/sync-design-system` |
 
 Invoke the chosen skill via the Skill tool with the user's message as argument. If no row fits, proceed to Step 4 (direct help).
+
+### 3.0 The `--no-prompt` rule (interactive gates)
+
+`/generate-flow`, `/design-audit`, `/convert-to-hifi` adopt the interactive-gate convention defined in `references/ds-rules/interactive-gates.md`. Each gates on missing flags by default.
+
+When companion routes:
+- **Append `--no-prompt`** when ALL flags relevant to the row's intent are extracted from prose. This suppresses the downstream gate and uses defaults for any unset flags (since intent is fully captured). See rows 3, 4, 9 (convert-to-hifi half), 11, 12, 13, 14, 18, 20 — they all carry `--no-prompt`.
+- **Don't append `--no-prompt`** when intent is vague or partial. Let the downstream skill gate the designer through the missing options. Rows 1, 2, 8, 9 (generate-flow half), 10, 17 fall back to gates — designers benefit from option discovery.
+- **Refine paths** (rows 5, 6, 7, 19) — already explicit (URL + prose); no gate fires regardless.
 
 ### 3.1 URL classification
 

--- a/plugins/actian-design-system/skills/convert-to-hifi/SKILL.md
+++ b/plugins/actian-design-system/skills/convert-to-hifi/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: convert-to-hifi
 description: Convert a Fat Marker wireframe screen or flow into high-fidelity using DS Kit components. Reads FM instances from a Figma frame, maps to DS equivalents, applies layout polish, and pushes a new hifi frame.
-argument-hint: "<figma-url> [--ref <figma-url>[,<figma-url>]]"
+argument-hint: "<figma-url> [--ref <figma-url>[,<figma-url>]] [--no-prompt]"
 ---
 
 # Convert to HiFi
@@ -13,6 +13,36 @@ Upgrade a Fat Marker wireframe to a high-fidelity DS Kit frame. Three-stage pipe
 | Flag | Type | Default | Behavior |
 |------|------|---------|----------|
 | `--ref <url[,url]>` | URL list | none | **v1: Figma URLs only.** Reference frames influence hifi-specific decisions: component variant selection (compact vs. comfortable density), hierarchy emphasis, toolbar/empty-state choices. Multi-URL = blended influence. For external references (Linear, Stripe, etc.), screenshot into a Figma frame first and pass that URL. Image-URL support targeted for v2 alongside the vision pipeline. Until the engine pipeline lands, `--ref` URLs are surfaced to the LLM as `get_screenshot` reference images during Stage 3 polish. |
+| `--no-prompt` | boolean | false | Skip the interactive ref gate (Step 0.5). Use defaults for any unset flags. See `references/ds-rules/interactive-gates.md`. |
+
+## Step 0 — Parse args
+
+Parse the args. Note whether `--ref` and `--no-prompt` were explicitly passed. The `--no-prompt` flag is parsed via `scripts/lib/parse-no-prompt.js`.
+
+## Step 0.5 — Ref gate (interactive)
+
+**Skipped if:** `--ref` is explicitly passed OR `--no-prompt` is set.
+
+Otherwise, present this prompt verbatim (do NOT proceed until the user replies):
+
+```
+Convert <source frame name> to hifi.
+
+Reference (optional): paste a Figma URL or image URL to bias density/style,
+or press enter to use registry defaults.
+
+Examples:
+  https://figma.com/design/abc/foo?node-id=1-2
+  https://figma.com/design/x/y?node-id=3-4 https://figma.com/design/x/z?node-id=5-6
+```
+
+Parser:
+- Empty / "enter" → no ref, proceed with defaults
+- One or more space-separated URLs → set `--ref <url1>,<url2>,…`
+- Anything else (non-URL token) → re-prompt with "I need URL(s) or enter for no ref. Got: <input>"
+- 3 retry attempts → abort with: "Aborting. Run again with `--no-prompt` to skip this gate, or `--ref <url>` to pass a ref directly."
+
+Once a value is resolved (from flag or gate), proceed to the pipeline.
 
 ## Pipeline
 

--- a/plugins/actian-design-system/skills/design-audit/SKILL.md
+++ b/plugins/actian-design-system/skills/design-audit/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: design-audit
 description: Audit a Figma design against DS rules — tokens, spacing, a11y, component usage, copy, heuristic UX. Finds inconsistencies and can fix specific findings.
-argument-hint: "[Figma URL] [--scope copy|tokens|a11y|heuristic|all] [--fix <id|all>]"
+argument-hint: "[Figma URL] [--scope copy|tokens|a11y|heuristic|all] [--fix <id|all>] [--no-prompt]"
 ---
 
 # Design System Audit
@@ -14,6 +14,40 @@ Audit a Figma file or section against the Actian Design System 2026 and/or Fat M
 |------|------|---------|----------|
 | `--scope <list>` | string list | `all` | Limits findings to a subset: `copy`, `tokens`, `a11y`, `heuristic`, `all`. Multi-value supported (`--scope copy,tokens`). `heuristic` is a new finding category covering UX principles, IA clarity, task efficiency — full implementation is engine work; for now, surfaces a placeholder section in the report. |
 | `--fix <id\|all>` | string | none | Auto-applies fixes. `id` = single finding number (e.g., `--fix 3`). `all` = all P0 + P1 findings where `autoFixable: true`. Without `--fix`, the audit reports without modifying the design (passive audit is the default). |
+| `--no-prompt` | boolean | false | Skip the interactive scope + fix gates (Step 0.5 + Step 5.5). Use defaults for any unset flags. See `references/ds-rules/interactive-gates.md`. |
+
+## Step 0 — Parse args
+
+Parse args. Note whether `--scope`, `--fix`, and `--no-prompt` were explicitly passed. The `--no-prompt` flag is parsed via `scripts/lib/parse-no-prompt.js`.
+
+## Step 0.5 — Scope gate (interactive)
+
+**Skipped if:** `--scope` is explicitly passed OR `--no-prompt` is set.
+
+Otherwise, present this prompt verbatim before running any audit checks:
+
+```
+Audit scope for <target>:
+
+  all (default) — copy + tokens + a11y + heuristic
+  copy          — content guidelines, banned terms, label patterns
+  tokens        — color/spacing/radius binding, hardcoded values
+  a11y          — WCAG 2.1 AA, contrast, ARIA, keyboard
+  heuristic     — UX patterns, layout, intent
+
+Reply: scope name, comma-separated list, or enter for all.
+Examples:
+  copy
+  copy,a11y
+  tokens
+```
+
+Parser:
+- Empty / "all" → `--scope all`
+- One token from {copy, tokens, a11y, heuristic} → `--scope <token>`
+- Comma-separated list of valid tokens → `--scope <list>`
+- Invalid token → re-prompt with the valid set
+- 3 retries → abort with: "Aborting. Run again with `--no-prompt` to use scope=all, or `--scope <list>` to set directly."
 
 ## Pipeline
 
@@ -22,7 +56,9 @@ Audit a Figma file or section against the Actian Design System 2026 and/or Fat M
 3. `get_screenshot` of resolved target → visual reference
 4. `get_design_context` on resolved target → inspect tokens, typography, spacing, components
 5. Check each dimension below → structured report with severity (P0/P1/P2)
-6. Present findings; user can request fixes ("fix #3", "fix all auto-fixable")
+6. Present findings to user
+7. **Step 5.5 — Fix gate** (see below) → resolve `--fix` value
+8. Apply fixes per resolved value
 
 ## What to check
 
@@ -53,9 +89,32 @@ When `--scope` is set, run only the listed dimensions; otherwise run all.
 | 1 | P0 | 0.95 | Button uses hardcoded #0550DC | Zero hardcoded hex | Bind theme-primary variable |
 ```
 
-## Fixing findings
+## Step 5.5 — Fix gate (interactive)
 
-After the audit report, the user can request fixes via flags or prose:
+**Skipped if:** `--fix` is explicitly passed OR `--no-prompt` is set OR no findings to fix.
+
+Otherwise, after presenting findings, present this prompt verbatim:
+
+```
+N findings (P0: A, P1: B, P2: C). Fix?
+
+  skip (default) — report only, no edits
+  N              — fix finding number N (e.g. "3")
+  all            — fix all auto-fixable findings (P0 + P1)
+
+Reply: skip / N / all
+```
+
+Parser:
+- Empty / "skip" → no fixes (exit cleanly with the report)
+- Integer matching a finding number → `--fix <N>`
+- "all" → `--fix all`
+- Invalid → re-prompt
+- 3 retries → abort with: "Aborting. Run again with `--no-prompt` to skip fixes, or `--fix N|all` to set directly."
+
+## Fixing findings (flag form)
+
+The user can also request fixes via prose or flags directly:
 - `--fix 3` or `"fix #3"` — fix a specific finding
 - `--fix all` or `"fix all auto-fixable"` — batch fix all `autoFixable: true` findings (P0 + P1)
 - Free-text: `"fix the hardcoded blue on the login button"`

--- a/plugins/actian-design-system/skills/generate-flow/SKILL.md
+++ b/plugins/actian-design-system/skills/generate-flow/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: generate-flow
 description: Generate one or more lo-fi screens — single screen or multi-screen flow — from a feature idea, user story, or single-screen prompt. Also handles refine (URL + instruction), iterate (URL only), branch (URL + new variant), prototype wiring, and hifi conversion. Pushes to Figma.
-argument-hint: "[feature description or Figma URL] [prose instruction] [--hifi --audit --variants N --ref <url> --breakpoints tablet,mobile --from <url> --branch <name> --states empty,error]"
+argument-hint: "[feature description or Figma URL] [prose instruction] [--hifi --audit --variants N --ref <url> --breakpoints tablet,mobile --from <url> --branch <name> --states empty,error --no-prompt]"
 ---
 
 # Generate Fat Marker Flow
@@ -32,6 +32,7 @@ Refine activates when ALL of: a Figma URL is provided, prose instruction is prov
 | `--from <url>` | URL | none | URL-type detected. **Figma URL** → iterate on existing flow (preserves data model, re-rolls recipes). **Jira/Confluence/Google doc URL** → spec input (extracts user story, acceptance criteria). **Image URL** → primary visual reference. |
 | `--branch <name>` | string | none | Requires `--from <url>`. Forks the flow into a sibling frame named `[original] — <name>`. Provenance in `.last-push.json` so `/compare-flows` works between branches. |
 | `--states <list>` | string list | none | State coverage: `empty`, `error`, `loading`, `no-permission`, `populated`, `partial-data`. Generates each as additional screens or variants. |
+| `--no-prompt` | boolean | false | Skip the interactive pre-gen gate (Step 0.5) AND post-push audit gate (Step 7.5). Use defaults for any unset flags. See `references/ds-rules/interactive-gates.md`. Refine path is unaffected (already explicit). |
 
 ### Flag interaction matrix
 
@@ -45,9 +46,62 @@ Refine activates when ALL of: a Figma URL is provided, prose instruction is prov
 | `--ref <url> --states empty,error` | Reference biases base layout; states inherit the same reference treatment. |
 | `--states X` without `--from` | Generates flow + states from prompt (greenfield). |
 
+## Step 0 — Parse args + classify input shape
+
+Parse args. Note which flags are explicitly passed:
+- `--no-prompt` — parsed via `scripts/lib/parse-no-prompt.js`. Suppresses Step 0.5 + Step 7.5.
+- `--hifi`, `--audit`, `--variants <N>`, `--ref <url>`, `--breakpoints <list>`, `--states <list>` — note presence; missing flags are subject to gates unless `--no-prompt` is set.
+- `--from <url>`, `--branch <name>` — special cases. Not gated. Detected by companion or absent by default.
+
+Classify input shape (Prompt / Refine / Iterate per the table above). **Refine and Iterate paths skip Step 0.5 entirely** — URL + prose (refine) or `--from <url>` (iterate) are already explicit intent.
+
+## Step 0.5 — Pre-gen gate (interactive, greenfield-only)
+
+**Skipped if:** input is Refine or Iterate shape, OR all of `--hifi`, `--variants`, `--ref`, `--breakpoints`, `--states` are explicitly passed, OR `--no-prompt` is set.
+
+**Pre-flight prose detection** (run before showing the gate; suppresses gate questions for any flag whose value can be confidently inferred from prose):
+- "ship-ready", "production", "make it real" → infer `--hifi`
+- "alternatives", "show me variants", "different angles" → infer `--variants 3`
+- Trailing Figma URLs after the feature prompt → infer `--ref <urls>`
+- "responsive", "tablet", "mobile" → infer `--breakpoints` accordingly
+- "with empty state", "add error state", "loading state" → infer `--states <list>`
+
+After pre-flight inference, if any of the 5 gateable flags are STILL missing, present this prompt verbatim:
+
+```
+Configure generation for <feature>:
+
+Output:        lo-fi (default) | hi-fi
+Variants:      1 (default) | 2 | 3
+References:    none (default) | <paste Figma URL(s) or image URL(s)>
+Breakpoints:   desktop (default) | + tablet | + mobile | all
+State coverage: none (default) | empty | error | loading | populated | all
+
+Reply: enter for all defaults, or specify any subset.
+Examples:
+  hifi 3
+  ref:https://figma.com/design/abc/foo?node-id=1-2
+  hifi tablet,mobile
+  3 ref:https://stripe.com/screen.png
+  empty,error
+  hifi 3 empty,error
+```
+
+Parser:
+- Empty / "enter" → all defaults
+- `hifi` token → `--hifi`
+- Bare integer 1-3 → `--variants <N>`
+- `ref:<url>` (repeatable, space-separated) → `--ref <url1>,<url2>,...`
+- One of `tablet`, `mobile`, `tablet,mobile`, `all` (without `ref:` prefix) → `--breakpoints <list>` (`all` = `tablet,mobile,desktop`)
+- One or more of `empty`, `error`, `loading`, `populated` (comma-separated, no `ref:` prefix) → `--states <list>`
+- Invalid token → re-prompt with: "Unknown token `foo`. Valid: hifi, 1-3, ref:<url>, tablet, mobile, all, empty, error, loading, populated."
+- 3 retries → abort with: "Aborting. Run again with `--no-prompt` to use defaults, or pass flags directly."
+
+Once resolved, proceed to the pipeline.
+
 ## Refine shape
 
-Refine is a shape the skill detects, not a flag. When detected (v1.56.0+), it runs a targeted edit through the engine in `scripts/lib/resolve-unit.js`, `scripts/lib/snapshot-store.js`, and `scripts/lib/derive-scope.js`, with the validator running scope-filtered (B-refine.1). It skips the standard 3-gate pipeline and pushes only the affected screen frames.
+Refine is a shape the skill detects, not a flag. When detected (v1.56.0+), it runs a targeted edit through the engine in `scripts/lib/resolve-unit.js`, `scripts/lib/snapshot-store.js`, and `scripts/lib/derive-scope.js`, with the validator running scope-filtered (B-refine.1). It skips the standard 3-gate pipeline AND the Step 0.5 pre-gen gate, and pushes only the affected screen frames.
 
 ### Detection (all must match)
 
@@ -243,6 +297,7 @@ For warning-level findings (`default-true-boolean-unset`, `unresolved-token`, `t
 **`intent-mismatch` recovery (hifi tier only):** When the validator flags `intent-mismatch` findings on hifi-converted data, either change the variant to match the expected variant for the effective intent (e.g., `Type=Critical primary` for `destructive-action` on a DS button), OR change the `intent` field at the responsible node to reflect the actual screen role. For sibling-rule warnings ("destructive-action container ambiguous" or "missing Critical primary"), restructure the button group: exactly one Critical primary action button, with Tertiary or Secondary cancel/dismiss siblings.
 
 7. Push to Figma (see Push section below)
+7.5. **Post-push gate** (interactive — see Step 7.5 below) — runs the audit if `--audit` is set OR designer opts in via gate.
 8. Preview (opt-in):
    ```bash
    source "${CLAUDE_PLUGIN_ROOT}/scripts/lib/resolve-node.sh"
@@ -250,6 +305,31 @@ For warning-level findings (`default-true-boolean-unset`, `unresolved-token`, `t
    BASE_URL=$(${CLAUDE_PLUGIN_ROOT}/scripts/renderers/ensure-server.sh "{project_working_directory}" 8765)
    ```
 9. Parity check (opt-in) → `references/figma/parity-check.md` + `references/ds-rules/quality-checklist.md`. Manifest includes `sourceHash` (of flow-data.json), `componentKeys` (from push), and `tokenHash` (of tokens file).
+
+---
+
+## Step 7.5 — Post-push audit gate (interactive)
+
+**Skipped if:** `--audit` is explicitly passed (audit runs automatically), OR `--no-prompt` is set, OR refine/iterate path (designer-driven, no extra prompts).
+
+After push completes successfully and the result is reported to the designer, present this prompt verbatim:
+
+```
+Flow pushed. Audit it now?
+
+  no (default) — finished, no further action
+  yes          — runs /design-audit on the pushed result; reports findings
+
+Reply: enter for no, or "yes".
+```
+
+Parser:
+- Empty / "no" / "skip" → done; exit cleanly
+- "yes" / "audit" → invoke `/design-audit <pushed-url>` per row 10 of companion intent table
+- Invalid → re-prompt
+- 3 retries → abort with: "Aborting. Run again with `--no-prompt` to skip, or pass `--audit` to auto-run."
+
+When `--audit` is set explicitly, skip this gate and run the audit pipeline immediately after push (existing behavior preserved).
 
 ---
 

--- a/plugins/actian-design-system/tests/lib/parse-no-prompt.test.js
+++ b/plugins/actian-design-system/tests/lib/parse-no-prompt.test.js
@@ -1,0 +1,85 @@
+#!/usr/bin/env node
+"use strict";
+
+// Verifies the --no-prompt flag parser used by skills with interactive gates
+// (/generate-flow, /design-audit, /convert-to-hifi). The parser strips the
+// flag and reports whether it was present, so callers can decide whether to
+// run the gate prose or skip with defaults.
+//
+// Covered cases:
+//   1. Flag absent → noPrompt=false, args unchanged
+//   2. Flag at end of args → noPrompt=true, flag removed
+//   3. Flag in middle of args → noPrompt=true, flag removed in place
+//   4. Flag at start → noPrompt=true, flag removed
+//   5. Multiple occurrences → noPrompt=true, all occurrences removed
+//   6. Empty args → noPrompt=false, empty args
+//   7. Only --no-prompt → noPrompt=true, empty args
+//   8. Flag adjacent to value-bearing flags doesn't disturb them
+
+var { describe, it } = require("node:test");
+var assert = require("node:assert");
+
+var parseNoPrompt = require("../../scripts/lib/parse-no-prompt.js");
+
+describe("parse-no-prompt", function () {
+  it("absent → noPrompt=false, args returned unchanged", function () {
+    var result = parseNoPrompt(["foo", "bar", "--variants", "3"]);
+    assert.strictEqual(result.noPrompt, false);
+    assert.deepStrictEqual(result.remainingArgs, ["foo", "bar", "--variants", "3"]);
+  });
+
+  it("at end → noPrompt=true, flag removed", function () {
+    var result = parseNoPrompt(["foo", "bar", "--no-prompt"]);
+    assert.strictEqual(result.noPrompt, true);
+    assert.deepStrictEqual(result.remainingArgs, ["foo", "bar"]);
+  });
+
+  it("in middle → noPrompt=true, flag removed in place", function () {
+    var result = parseNoPrompt(["foo", "--no-prompt", "bar"]);
+    assert.strictEqual(result.noPrompt, true);
+    assert.deepStrictEqual(result.remainingArgs, ["foo", "bar"]);
+  });
+
+  it("at start → noPrompt=true, flag removed", function () {
+    var result = parseNoPrompt(["--no-prompt", "foo", "bar"]);
+    assert.strictEqual(result.noPrompt, true);
+    assert.deepStrictEqual(result.remainingArgs, ["foo", "bar"]);
+  });
+
+  it("multiple occurrences → noPrompt=true, all removed", function () {
+    var result = parseNoPrompt(["--no-prompt", "foo", "--no-prompt", "bar", "--no-prompt"]);
+    assert.strictEqual(result.noPrompt, true);
+    assert.deepStrictEqual(result.remainingArgs, ["foo", "bar"]);
+  });
+
+  it("empty args → noPrompt=false, empty args", function () {
+    var result = parseNoPrompt([]);
+    assert.strictEqual(result.noPrompt, false);
+    assert.deepStrictEqual(result.remainingArgs, []);
+  });
+
+  it("only --no-prompt → noPrompt=true, empty args", function () {
+    var result = parseNoPrompt(["--no-prompt"]);
+    assert.strictEqual(result.noPrompt, true);
+    assert.deepStrictEqual(result.remainingArgs, []);
+  });
+
+  it("preserves value-bearing flags adjacent to --no-prompt", function () {
+    var result = parseNoPrompt(["--variants", "3", "--no-prompt", "--ref", "https://figma.com/x"]);
+    assert.strictEqual(result.noPrompt, true);
+    assert.deepStrictEqual(result.remainingArgs, ["--variants", "3", "--ref", "https://figma.com/x"]);
+  });
+
+  it("does not match partial / prefixed variants", function () {
+    var result = parseNoPrompt(["--no-prompts", "--noPrompt", "--no-prompt-extra"]);
+    assert.strictEqual(result.noPrompt, false);
+    assert.deepStrictEqual(result.remainingArgs, ["--no-prompts", "--noPrompt", "--no-prompt-extra"]);
+  });
+
+  it("does not mutate the input array", function () {
+    var input = ["foo", "--no-prompt", "bar"];
+    var snapshot = input.slice();
+    parseNoPrompt(input);
+    assert.deepStrictEqual(input, snapshot);
+  });
+});


### PR DESCRIPTION
## Summary

Surface all 11 flags on `/generate-flow`, `/design-audit`, and `/convert-to-hifi` as **interactive gates** by default. Power users + automation keep flags via the new skill-wide `--no-prompt` suppressor.

**Reframed from "UX polish" to "discovery mechanism"** — designers don't know most flags exist (variants, ref, breakpoints, states, audit, scope, fix). Gates expose hidden capability AND create the usage signal needed to inform Brief Refresh v2 wording and future ergonomics conversations.

## What changed

| Skill | Gate | Covers |
|---|---|---|
| `/generate-flow` | Pre-gen (Step 0.5) | hifi, variants, ref, breakpoints, states |
| `/generate-flow` | Post-push (Step 7.5) | audit |
| `/design-audit` | Scope (Step 0.5) | scope |
| `/design-audit` | Fix (Step 5.5) | fix |
| `/convert-to-hifi` | Ref (Step 0.5) | ref |

**Refine flows skip all gates** — URL + prose is already explicit intent.

## What didn't change

- All 11 flags work exactly as before when explicitly passed
- All defaults preserved
- Schema, recipes, validators, push patterns: unchanged

## New: `--no-prompt` flag

Single skill-wide suppressor on the 3 skills. Skips every gate, uses documented defaults. Used by:
- Companion routes that have already extracted full intent (e.g., row 3 ship-ready X → /generate-flow X --hifi --audit --no-prompt)
- Automation, CI, scripted Cowork sessions

Convention: references/ds-rules/interactive-gates.md (NEW).

## Companion changes

Intent table updated for 8 rows that should suppress downstream gates (3, 4, 9 convert-to-hifi half, 11, 12, 13, 14, 18, 20). New Section 3.0 documents the rule.

## Spec adjustment from PLAN

Moved \`--states\` from post-gen to pre-gen gate. Reason: it determines WHAT gets generated (additional state screens) so must resolve before screen-generator runs. Post-push gate is now \`--audit\` only.

## Files

**New:** parse-no-prompt.js + tests (10 unit), interactive-gates.md convention doc
**Modified:** 4 SKILL.mds + companion-context.md + plugin.json (1.62.4 → 1.63.0)

## Test plan
- [x] 39/39 test files green (added 10 new unit tests)
- [x] path-validation passes (no broken links in new doc)
- [ ] Manual smoke (post-merge, on Cowork Desktop): bare invocation gates / full-flag invocation skips / mixed invocation gates only on missing / companion routes correctly with --no-prompt

## Post-ship signal collection

1-2 week informal observation window per comms/PLAN-ux-flags-to-gates.md. Track which gate options designers actually pick. Findings → project_ux_flags_to_gates_signal.md. Trigger for v1.63.x patch if 3+ wording or option-set changes surface.

Generated with [Claude Code](https://claude.com/claude-code)