### PR TITLE
feat: auto-bump plugin.json on data sync (v1.63.1)

### DIFF
--- a/.github/workflows/foundations-derive.yml
+++ b/.github/workflows/foundations-derive.yml
@@ -56,13 +56,20 @@ jobs:
             git diff --stat -- plugins/actian-design-system/docs/generated/foundations/
           fi
 
+      - name: Auto-bump plugin.json patch
+        if: steps.diff.outputs.changed == 'true'
+        working-directory: plugins/actian-design-system
+        run: |
+          node scripts/lib/bump-version.js .claude-plugin/plugin.json patch
+
       - name: Commit derived JSONs back to PR
         if: steps.diff.outputs.changed == 'true'
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git add plugins/actian-design-system/docs/generated/foundations/
-          git commit -m "chore(foundations): regenerate JSONs from foundations.md"
+          git add plugins/actian-design-system/docs/generated/foundations/ \
+                  plugins/actian-design-system/.claude-plugin/plugin.json
+          git commit -m "chore(foundations): regenerate JSONs from foundations.md + bump patch"
           git push
 
       - name: Post semantic-diff comment

--- a/.github/workflows/sync-from-figma.yml
+++ b/.github/workflows/sync-from-figma.yml
@@ -95,6 +95,7 @@ jobs:
           delete-branch: true
           add-paths: |
             plugins/actian-design-system/docs/**
+            plugins/actian-design-system/.claude-plugin/plugin.json
 
       - name: Enable auto-merge for additive PRs
         if: steps.verdict.outputs.category == 'additive' && steps.cpr.outputs.pull-request-number

--- a/plugins/actian-design-system/.claude-plugin/plugin.json
+++ b/plugins/actian-design-system/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "actian-design-system",
   "description": "Actian Design System toolkit — sync tokens from Figma, generate wireframe flows with prototype wiring, create component briefs, audit designs, compare flows, and build presentations. 9 skills (with tiered generation: recognized / adapted / improvised), 8 agents, 155 tokens (3 themes, 8 collections), WCAG 2.1 AA.",
-  "version": "1.63.0",
+  "version": "1.63.1",
   "author": {
     "name": "Actian UX Team"
   },

--- a/plugins/actian-design-system/scripts/lib/bump-version.js
+++ b/plugins/actian-design-system/scripts/lib/bump-version.js
@@ -1,0 +1,53 @@
+"use strict";
+
+// Pure semver bump utility used by the auto-sync GitHub Action workflow and
+// foundations-derive workflow to PATCH-bump plugin.json when generated data
+// (registries, styles, foundations JSONs) changes.
+//
+// Returns the bumped version string. Throws on invalid semver or unknown
+// level. No I/O — caller reads/writes plugin.json.
+
+var SEMVER_RE = /^(\d+)\.(\d+)\.(\d+)$/;
+var LEVELS = ["major", "minor", "patch"];
+
+function bumpVersion(version, level) {
+  if (LEVELS.indexOf(level) === -1) {
+    throw new Error(
+      "Invalid level: " + level + " (expected one of: " + LEVELS.join(", ") + ")",
+    );
+  }
+  var match = SEMVER_RE.exec(version);
+  if (!match) {
+    throw new Error(
+      "Invalid semver: " + version + " (expected x.y.z with non-negative integers)",
+    );
+  }
+  var major = parseInt(match[1], 10);
+  var minor = parseInt(match[2], 10);
+  var patch = parseInt(match[3], 10);
+
+  if (level === "major") return major + 1 + ".0.0";
+  if (level === "minor") return major + "." + (minor + 1) + ".0";
+  return major + "." + minor + "." + (patch + 1);
+}
+
+module.exports = bumpVersion;
+
+// CLI: node bump-version.js <plugin.json path> <level>
+// Reads, bumps, writes back. Used by GitHub workflows.
+if (require.main === module) {
+  var fs = require("fs");
+  var args = process.argv.slice(2);
+  if (args.length !== 2) {
+    process.stderr.write("Usage: bump-version.js <plugin.json path> <patch|minor|major>\n");
+    process.exit(1);
+  }
+  var pluginJsonPath = args[0];
+  var level = args[1];
+  var plugin = JSON.parse(fs.readFileSync(pluginJsonPath, "utf8"));
+  var oldVersion = plugin.version;
+  var newVersion = bumpVersion(oldVersion, level);
+  plugin.version = newVersion;
+  fs.writeFileSync(pluginJsonPath, JSON.stringify(plugin, null, 2) + "\n", "utf8");
+  process.stdout.write(oldVersion + " -> " + newVersion + "\n");
+}

--- a/plugins/actian-design-system/scripts/sync/sync-from-figma.js
+++ b/plugins/actian-design-system/scripts/sync/sync-from-figma.js
@@ -327,6 +327,34 @@ async function run(opts) {
     "utf8",
   );
 
+  // Auto-bump plugin.json patch when generated data actually changed.
+  // Cowork (cloud) re-pulls plugin per session and reads from the bumped
+  // version; without this, designers see stale registries/styles until the
+  // next manual ship. Skip on `unchanged` (no diff) and `error` (failed run).
+  //
+  // Only fires when opts.pluginJsonPath is set explicitly (CLI passes it;
+  // tests omit it). This keeps test fixtures from polluting the real
+  // plugin.json when their mock REST data produces additive/breaking diffs.
+  var bumpedFrom = null;
+  var bumpedTo = null;
+  var pluginJsonPath = opts.pluginJsonPath || null;
+  if (
+    pluginJsonPath &&
+    (category === "additive" || category === "breaking") &&
+    fs.existsSync(pluginJsonPath)
+  ) {
+    var bumpVersion = require("../lib/bump-version.js");
+    var plugin = JSON.parse(fs.readFileSync(pluginJsonPath, "utf8"));
+    bumpedFrom = plugin.version;
+    bumpedTo = bumpVersion(bumpedFrom, "patch");
+    plugin.version = bumpedTo;
+    fs.writeFileSync(
+      pluginJsonPath,
+      JSON.stringify(plugin, null, 2) + "\n",
+      "utf8",
+    );
+  }
+
   return {
     category: category,
     exitCode: exitCode,
@@ -334,6 +362,8 @@ async function run(opts) {
     errors: errors,
     releasePath: releasePath,
     changelog: changelog,
+    bumpedFrom: bumpedFrom,
+    bumpedTo: bumpedTo,
   };
 }
 
@@ -352,12 +382,27 @@ function parseArgs(argv) {
     else if (a === "--keys-file") out.keysFile = next();
     else if (a === "--artifacts-dir") out.artifactsDir = next();
     else if (a === "--plugin-dir") out.pluginDir = next();
+    else if (a === "--plugin-json-path") out.pluginJsonPath = next();
   }
   return out;
 }
 
 if (require.main === module) {
   var cliOpts = parseArgs(process.argv.slice(2));
+  // CLI mode (e.g., GitHub Action) defaults pluginJsonPath to plugin.json
+  // under the resolved pluginDir, so auto-bump fires without explicit
+  // wiring. Programmatic callers (tests, scripts) must opt in by passing
+  // pluginJsonPath explicitly — keeps test fixtures from polluting the
+  // real plugin.json on additive/breaking verdicts from mock data.
+  if (!cliOpts.pluginJsonPath) {
+    var resolvedPluginDir =
+      cliOpts.pluginDir || path.resolve(__dirname, "../..");
+    cliOpts.pluginJsonPath = path.join(
+      resolvedPluginDir,
+      ".claude-plugin",
+      "plugin.json",
+    );
+  }
   run(cliOpts).then(
     function (r) {
       console.log("[sync] verdict=" + r.category + " exit=" + r.exitCode);

--- a/plugins/actian-design-system/skills/sync-design-system/SKILL.md
+++ b/plugins/actian-design-system/skills/sync-design-system/SKILL.md
@@ -55,6 +55,17 @@ Read `sync-phases.md` for the implementation details of the phase you are execut
 
 **Phase dependencies:** Phase 4 requires Phase 2 data. All other phases are independent.
 
+## After sync — bump plugin.json
+
+When this skill writes any generated file (Phase 1, 3, 4 outputs), Cowork's plugin cache won't pick up the change until `plugin.json` version bumps. **Bump `plugin.json` patch (e.g., `1.63.1` → `1.63.2`) before committing** — otherwise designers running on Cowork keep reading stale cached registries/tokens until the next manual ship. The auto-sync GitHub workflow handles this for nightly REST runs (Phases 1 + 3); for manual `/sync-design-system` runs, the bump is your responsibility per `feedback_version_bump.md`.
+
+```bash
+node "${CLAUDE_PLUGIN_ROOT}/scripts/lib/bump-version.js" \
+  "${CLAUDE_PLUGIN_ROOT}/.claude-plugin/plugin.json" patch
+```
+
+Skip the bump only if the sync was a verification noop (no files actually changed).
+
 ## Extraction constraints
 
 - 20KB response limit per `use_figma` — split large extractions

--- a/plugins/actian-design-system/tests/lib/bump-version.test.js
+++ b/plugins/actian-design-system/tests/lib/bump-version.test.js
@@ -1,0 +1,83 @@
+#!/usr/bin/env node
+"use strict";
+
+// Verifies the semver bump utility used by the auto-sync GitHub Action and
+// foundations-derive workflow to PATCH-bump plugin.json when generated data
+// changes (registries, styles, foundations JSONs). Pure semver math; no I/O.
+//
+// Covered cases:
+//   1. Patch bump from x.y.z → x.y.(z+1)
+//   2. Minor bump from x.y.z → x.(y+1).0  (z resets)
+//   3. Major bump from x.y.z → (x+1).0.0  (y, z reset)
+//   4. Multi-digit components (1.99.99 → 1.99.100)
+//   5. Invalid semver throws
+//   6. Invalid level throws
+
+var { describe, it } = require("node:test");
+var assert = require("node:assert");
+
+var bumpVersion = require("../../scripts/lib/bump-version.js");
+
+describe("bump-version", function () {
+  describe("patch bumps", function () {
+    it("1.0.0 → 1.0.1", function () {
+      assert.strictEqual(bumpVersion("1.0.0", "patch"), "1.0.1");
+    });
+
+    it("1.62.4 → 1.62.5", function () {
+      assert.strictEqual(bumpVersion("1.62.4", "patch"), "1.62.5");
+    });
+
+    it("multi-digit: 1.99.99 → 1.99.100", function () {
+      assert.strictEqual(bumpVersion("1.99.99", "patch"), "1.99.100");
+    });
+  });
+
+  describe("minor bumps", function () {
+    it("1.62.4 → 1.63.0 (resets patch)", function () {
+      assert.strictEqual(bumpVersion("1.62.4", "minor"), "1.63.0");
+    });
+
+    it("1.0.0 → 1.1.0", function () {
+      assert.strictEqual(bumpVersion("1.0.0", "minor"), "1.1.0");
+    });
+  });
+
+  describe("major bumps", function () {
+    it("1.62.4 → 2.0.0 (resets minor + patch)", function () {
+      assert.strictEqual(bumpVersion("1.62.4", "major"), "2.0.0");
+    });
+  });
+
+  describe("invalid input", function () {
+    it("throws on non-semver string", function () {
+      assert.throws(function () {
+        bumpVersion("not-a-version", "patch");
+      }, /Invalid semver/);
+    });
+
+    it("throws on partial semver", function () {
+      assert.throws(function () {
+        bumpVersion("1.0", "patch");
+      }, /Invalid semver/);
+    });
+
+    it("throws on extra components", function () {
+      assert.throws(function () {
+        bumpVersion("1.0.0.0", "patch");
+      }, /Invalid semver/);
+    });
+
+    it("throws on unknown level", function () {
+      assert.throws(function () {
+        bumpVersion("1.0.0", "huge");
+      }, /Invalid level/);
+    });
+
+    it("throws on non-numeric component", function () {
+      assert.throws(function () {
+        bumpVersion("1.x.0", "patch");
+      }, /Invalid semver/);
+    });
+  });
+});

--- a/plugins/actian-design-system/tests/sync/sync-from-figma.test.js
+++ b/plugins/actian-design-system/tests/sync/sync-from-figma.test.js
@@ -453,5 +453,124 @@ describe("sync-from-figma", function () {
     it("defaults phase to 'all'", function () {
       assert.strictEqual(sync.parseArgs([]).phase, "all");
     });
+
+    it("parses --plugin-json-path", function () {
+      var p = sync.parseArgs([
+        "--plugin-json-path",
+        "/foo/.claude-plugin/plugin.json",
+      ]);
+      assert.strictEqual(p.pluginJsonPath, "/foo/.claude-plugin/plugin.json");
+    });
+  });
+
+  // Auto-bump regression guards. The orchestrator's bump branch must:
+  //   - fire only when opts.pluginJsonPath is explicitly provided AND
+  //     verdict is additive or breaking
+  //   - never touch the real plugin.json from test fixtures (the bug that
+  //     made me catch this whole thing — fixtures bumped real plugin.json
+  //     9 times during a single full-suite run)
+  describe("auto-bump on data sync", function () {
+    function makePluginJson(dirs, version) {
+      var pluginJsonDir = path.join(dirs.root, ".claude-plugin");
+      fs.mkdirSync(pluginJsonDir, { recursive: true });
+      var pluginJsonPath = path.join(pluginJsonDir, "plugin.json");
+      fs.writeFileSync(
+        pluginJsonPath,
+        JSON.stringify({ name: "test", version: version }, null, 2) + "\n",
+      );
+      return pluginJsonPath;
+    }
+
+    function readVersion(pluginJsonPath) {
+      return JSON.parse(fs.readFileSync(pluginJsonPath, "utf8")).version;
+    }
+
+    it("bumps plugin.json patch when verdict is additive AND pluginJsonPath set", async function () {
+      var dirs = freshDirs();
+      var pluginJsonPath = makePluginJson(dirs, "1.0.0");
+      var rest = buildMockRest(buildBasicData());
+      // Initial sync writes registries (verdict=additive vs empty before)
+      var r = await sync.run(
+        baseOpts(dirs, { rest: rest, pluginJsonPath: pluginJsonPath }),
+      );
+      assert.strictEqual(r.category, "additive");
+      assert.strictEqual(r.bumpedFrom, "1.0.0");
+      assert.strictEqual(r.bumpedTo, "1.0.1");
+      assert.strictEqual(readVersion(pluginJsonPath), "1.0.1");
+    });
+
+    it("bumps plugin.json patch when verdict is breaking AND pluginJsonPath set", async function () {
+      var dirs = freshDirs();
+      var pluginJsonPath = makePluginJson(dirs, "2.5.7");
+      // Seed: do an initial run so before-files exist
+      await sync.run(baseOpts(dirs, { rest: buildMockRest(buildBasicData()) }));
+      // Now run with data that removes Button → verdict=breaking
+      var dataWithoutButton = buildBasicData();
+      delete dataWithoutButton.componentSets.dsk[0]; // mutate carefully
+      dataWithoutButton.componentSets.dsk =
+        dataWithoutButton.componentSets.dsk.filter(Boolean);
+      var r = await sync.run(
+        baseOpts(dirs, {
+          rest: buildMockRest(dataWithoutButton),
+          pluginJsonPath: pluginJsonPath,
+        }),
+      );
+      assert.strictEqual(r.category, "breaking");
+      assert.strictEqual(r.bumpedFrom, "2.5.7");
+      assert.strictEqual(r.bumpedTo, "2.5.8");
+      assert.strictEqual(readVersion(pluginJsonPath), "2.5.8");
+    });
+
+    it("does NOT bump on unchanged verdict, even when pluginJsonPath set", async function () {
+      var dirs = freshDirs();
+      var pluginJsonPath = makePluginJson(dirs, "1.0.0");
+      // Seed
+      await sync.run(baseOpts(dirs, { rest: buildMockRest(buildBasicData()) }));
+      // Same data again → verdict=unchanged
+      var r = await sync.run(
+        baseOpts(dirs, {
+          rest: buildMockRest(buildBasicData()),
+          pluginJsonPath: pluginJsonPath,
+        }),
+      );
+      assert.strictEqual(r.category, "unchanged");
+      assert.strictEqual(r.bumpedFrom, null);
+      assert.strictEqual(r.bumpedTo, null);
+      assert.strictEqual(readVersion(pluginJsonPath), "1.0.0");
+    });
+
+    it("REGRESSION GUARD — does NOT bump when pluginJsonPath is omitted, even on additive verdict", async function () {
+      // This is the exact scenario that polluted the real plugin.json 9
+      // times during a full suite run. Tests omit pluginJsonPath; bump
+      // must be silently skipped, not fall back to a default path.
+      var dirs = freshDirs();
+      var rest = buildMockRest(buildBasicData());
+      var r = await sync.run(baseOpts(dirs, { rest: rest })); // no pluginJsonPath
+      assert.strictEqual(r.category, "additive");
+      assert.strictEqual(
+        r.bumpedFrom,
+        null,
+        "must not bump without explicit pluginJsonPath",
+      );
+      assert.strictEqual(
+        r.bumpedTo,
+        null,
+        "must not bump without explicit pluginJsonPath",
+      );
+    });
+
+    it("does NOT bump when pluginJsonPath points to a missing file (graceful skip)", async function () {
+      var dirs = freshDirs();
+      var missingPath = path.join(dirs.root, "nonexistent", "plugin.json");
+      var r = await sync.run(
+        baseOpts(dirs, {
+          rest: buildMockRest(buildBasicData()),
+          pluginJsonPath: missingPath,
+        }),
+      );
+      assert.strictEqual(r.category, "additive");
+      assert.strictEqual(r.bumpedFrom, null);
+      assert.strictEqual(r.bumpedTo, null);
+    });
   });
 });


### PR DESCRIPTION
## Summary

GitHub Actions workflows now PATCH-bump `plugin.json` automatically when generated data changes.

- **Sync from Figma** (cron, daily 07:00 UTC) — bumps when verdict in {additive, breaking}. Skipped on unchanged + error.
- **Derive foundations JSON** (PR-triggered) — bumps when foundations.md edit produces JSON deltas.

## Why

Cowork's plugin distribution serves the version pinned in plugin.json. Without a bump, designers running on Cowork keep reading stale registries / styles / tokens / foundations until the next manual ship. Auto-bump closes that gap so daily auto-sync changes propagate to designers immediately.

Local Claude Code users still need manual cache refresh (separate Anthropic bug); this only fixes the Cowork audience — which is the active POC cohort.

## Files

**New:** scripts/lib/bump-version.js + 11 unit tests, release-notes/v1.63.1.md

**Modified:** sync-from-figma.js orchestrator (gated bump opt), sync-from-figma.yml (add-paths includes plugin.json), foundations-derive.yml (new bump step), sync-design-system SKILL.md (manual-run bump reminder), plugin.json (1.63.0 -> 1.63.1).

## Implementation note: caught a bug mid-sprint

First iteration of the orchestrator change always bumped on additive/breaking verdicts using auto-resolved pluginDir. tests/sync/sync-from-figma.test.js bumped the real plugin.json 9 times in a single full-suite run because fixtures don't pass pluginDir.

Fixed by gating the bump on explicit opts.pluginJsonPath. Default is set ONLY in the CLI entry point. Programmatic callers (tests) must opt in.

Added 5 regression tests including a REGRESSION GUARD for the exact pollution scenario.

## What /sync-design-system does NOT do

The skill does NOT auto-bump (interactive, user controls commit cadence per feedback_version_bump.md). Reminder section + CLI snippet added to SKILL.md instead.

## Test plan
- [x] 40/40 test files green (added bump-version.test.js + 5 auto-bump regression tests)
- [x] Pollution fix verified: full suite run no longer touches real plugin.json
- [ ] Manual smoke deferred to first post-merge cron run (within 24h)

Generated with [Claude Code](https://claude.com/claude-code)