### PR TITLE
feat(brief): card_motion + pattern-indexed motion JSON (v1.65.0)

### DIFF
--- a/plugins/actian-design-system/.claude-plugin/plugin.json
+++ b/plugins/actian-design-system/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "actian-design-system",
   "description": "Actian Design System toolkit — sync tokens from Figma, generate wireframe flows with prototype wiring, create component briefs, audit designs, compare flows, and build presentations. 9 skills (with tiered generation: recognized / adapted / improvised), 8 agents, 155 tokens (3 themes, 8 collections), WCAG 2.1 AA.",
-  "version": "1.65.0",
+  "version": "1.65.1",
   "author": {
     "name": "Actian UX Team"
   },

--- a/plugins/actian-design-system/.claude-plugin/plugin.json
+++ b/plugins/actian-design-system/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "actian-design-system",
   "description": "Actian Design System toolkit — sync tokens from Figma, generate wireframe flows with prototype wiring, create component briefs, audit designs, compare flows, and build presentations. 9 skills (with tiered generation: recognized / adapted / improvised), 8 agents, 155 tokens (3 themes, 8 collections), WCAG 2.1 AA.",
-  "version": "1.64.1",
+  "version": "1.65.0",
   "author": {
     "name": "Actian UX Team"
   },

--- a/plugins/actian-design-system/docs/component-guidelines/_index.json
+++ b/plugins/actian-design-system/docs/component-guidelines/_index.json
@@ -12,10 +12,7 @@
       "has_examples": false,
       "has_screenshots": false,
       "has_behavior": false,
-      "frames_found": [
-        "Design guidelines",
-        "Components"
-      ],
+      "frames_found": ["Design guidelines", "Components"],
       "frames_missing": [
         "Content guidelines",
         "ready made examples",
@@ -39,10 +36,7 @@
         "Components",
         "Screenshots of use cases"
       ],
-      "frames_missing": [
-        "ready made examples",
-        "Behavior demo"
-      ]
+      "frames_missing": ["ready made examples", "Behavior demo"]
     },
     {
       "slug": "badge",
@@ -60,10 +54,7 @@
         "Components",
         "Ready made examples"
       ],
-      "frames_missing": [
-        "Screenshots of use cases",
-        "Behavior demo"
-      ]
+      "frames_missing": ["Screenshots of use cases", "Behavior demo"]
     },
     {
       "slug": "breadcrumbs",
@@ -75,9 +66,7 @@
       "has_examples": false,
       "has_screenshots": true,
       "has_behavior": false,
-      "frames_found": [
-        "Screenshots of use cases"
-      ],
+      "frames_found": ["Screenshots of use cases"],
       "frames_missing": [
         "Content guidelines",
         "design guidelines",
@@ -117,10 +106,7 @@
       "has_examples": false,
       "has_screenshots": false,
       "has_behavior": false,
-      "frames_found": [
-        "Content guidelines",
-        "Components"
-      ],
+      "frames_found": ["Content guidelines", "Components"],
       "frames_missing": [
         "design guidelines",
         "ready made examples",
@@ -165,10 +151,7 @@
         "Components",
         "Screenshots of current use cases"
       ],
-      "frames_missing": [
-        "ready made examples",
-        "Behavior demo"
-      ]
+      "frames_missing": ["ready made examples", "Behavior demo"]
     },
     {
       "slug": "collapse-accordion",
@@ -180,11 +163,7 @@
       "has_examples": false,
       "has_screenshots": false,
       "has_behavior": false,
-      "frames_found": [
-        "Design guidelines",
-        "Content guidelines",
-        "Components"
-      ],
+      "frames_found": ["Design guidelines", "Content guidelines", "Components"],
       "frames_missing": [
         "ready made examples",
         "Screenshots of use cases",
@@ -201,9 +180,7 @@
       "has_examples": false,
       "has_screenshots": true,
       "has_behavior": false,
-      "frames_found": [
-        "Screenshots of use cases"
-      ],
+      "frames_found": ["Screenshots of use cases"],
       "frames_missing": [
         "Content guidelines",
         "design guidelines",
@@ -222,10 +199,7 @@
       "has_examples": false,
       "has_screenshots": true,
       "has_behavior": false,
-      "frames_found": [
-        "Components",
-        "Screenshots of use cases"
-      ],
+      "frames_found": ["Components", "Screenshots of use cases"],
       "frames_missing": [
         "Content guidelines",
         "design guidelines",
@@ -243,10 +217,7 @@
       "has_examples": false,
       "has_screenshots": true,
       "has_behavior": false,
-      "frames_found": [
-        "Components",
-        "Screenshots of use cases"
-      ],
+      "frames_found": ["Components", "Screenshots of use cases"],
       "frames_missing": [
         "Content guidelines",
         "design guidelines",
@@ -285,10 +256,7 @@
       "has_examples": false,
       "has_screenshots": true,
       "has_behavior": false,
-      "frames_found": [
-        "Components",
-        "Screenshots of use cases"
-      ],
+      "frames_found": ["Components", "Screenshots of use cases"],
       "frames_missing": [
         "Content guidelines",
         "design guidelines",
@@ -306,10 +274,7 @@
       "has_examples": false,
       "has_screenshots": true,
       "has_behavior": false,
-      "frames_found": [
-        "Components",
-        "Screenshots of use cases"
-      ],
+      "frames_found": ["Components", "Screenshots of use cases"],
       "frames_missing": [
         "Content guidelines",
         "design guidelines",
@@ -327,10 +292,7 @@
       "has_examples": false,
       "has_screenshots": true,
       "has_behavior": false,
-      "frames_found": [
-        "Components",
-        "Screenshots of current use cases"
-      ],
+      "frames_found": ["Components", "Screenshots of current use cases"],
       "frames_missing": [
         "Content guidelines",
         "design guidelines",
@@ -347,11 +309,8 @@
       "has_design_guidelines": false,
       "has_examples": false,
       "has_screenshots": true,
-      "has_behavior": false,
-      "frames_found": [
-        "Components",
-        "Screenshots of current use cases"
-      ],
+      "has_behavior": true,
+      "frames_found": ["Components", "Screenshots of current use cases"],
       "frames_missing": [
         "Content guidelines",
         "design guidelines",
@@ -390,11 +349,7 @@
       "has_examples": false,
       "has_screenshots": false,
       "has_behavior": false,
-      "frames_found": [
-        "Design guidelines",
-        "Content guidelines",
-        "Components"
-      ],
+      "frames_found": ["Design guidelines", "Content guidelines", "Components"],
       "frames_missing": [
         "ready made examples",
         "Screenshots of use cases",
@@ -453,11 +408,7 @@
       "has_examples": false,
       "has_screenshots": false,
       "has_behavior": false,
-      "frames_found": [
-        "Design guidelines",
-        "Content guidelines",
-        "Components"
-      ],
+      "frames_found": ["Design guidelines", "Content guidelines", "Components"],
       "frames_missing": [
         "ready made examples",
         "Screenshots of use cases",
@@ -495,10 +446,7 @@
       "has_examples": false,
       "has_screenshots": true,
       "has_behavior": false,
-      "frames_found": [
-        "Components",
-        "Screenshots of use cases"
-      ],
+      "frames_found": ["Components", "Screenshots of use cases"],
       "frames_missing": [
         "Content guidelines",
         "design guidelines",
@@ -515,7 +463,7 @@
       "has_design_guidelines": false,
       "has_examples": false,
       "has_screenshots": true,
-      "has_behavior": false,
+      "has_behavior": true,
       "frames_found": [
         "Content guidelines",
         "Components",
@@ -536,11 +484,8 @@
       "has_design_guidelines": false,
       "has_examples": false,
       "has_screenshots": true,
-      "has_behavior": false,
-      "frames_found": [
-        "Components",
-        "Screenshots of use cases"
-      ],
+      "has_behavior": true,
+      "frames_found": ["Components", "Screenshots of use cases"],
       "frames_missing": [
         "Content guidelines",
         "design guidelines",
@@ -558,10 +503,7 @@
       "has_examples": false,
       "has_screenshots": true,
       "has_behavior": false,
-      "frames_found": [
-        "Components",
-        "Screenshots of current use cases"
-      ],
+      "frames_found": ["Components", "Screenshots of current use cases"],
       "frames_missing": [
         "Content guidelines",
         "design guidelines",
@@ -579,10 +521,7 @@
       "has_examples": false,
       "has_screenshots": true,
       "has_behavior": false,
-      "frames_found": [
-        "Components",
-        "Screenshots of current use cases"
-      ],
+      "frames_found": ["Components", "Screenshots of current use cases"],
       "frames_missing": [
         "Content guidelines",
         "design guidelines",
@@ -621,10 +560,7 @@
       "has_examples": false,
       "has_screenshots": true,
       "has_behavior": false,
-      "frames_found": [
-        "Components",
-        "Screenshots of use cases"
-      ],
+      "frames_found": ["Components", "Screenshots of use cases"],
       "frames_missing": [
         "Content guidelines",
         "design guidelines",
@@ -704,10 +640,7 @@
       "has_examples": false,
       "has_screenshots": true,
       "has_behavior": false,
-      "frames_found": [
-        "Components",
-        "Screenshots of use cases"
-      ],
+      "frames_found": ["Components", "Screenshots of use cases"],
       "frames_missing": [
         "Content guidelines",
         "design guidelines",
@@ -725,9 +658,7 @@
       "has_examples": false,
       "has_screenshots": false,
       "has_behavior": false,
-      "frames_found": [
-        "Behavior demo"
-      ],
+      "frames_found": ["Behavior demo"],
       "frames_missing": [
         "Content guidelines",
         "design guidelines",
@@ -746,10 +677,7 @@
       "has_examples": false,
       "has_screenshots": true,
       "has_behavior": false,
-      "frames_found": [
-        "Components",
-        "Screenshots of current use cases"
-      ],
+      "frames_found": ["Components", "Screenshots of current use cases"],
       "frames_missing": [
         "Content guidelines",
         "design guidelines",
@@ -767,10 +695,7 @@
       "has_examples": false,
       "has_screenshots": true,
       "has_behavior": false,
-      "frames_found": [
-        "Content guidelines",
-        "Screenshots of use cases"
-      ],
+      "frames_found": ["Content guidelines", "Screenshots of use cases"],
       "frames_missing": [
         "design guidelines",
         "Components",
@@ -788,10 +713,7 @@
       "has_examples": false,
       "has_screenshots": true,
       "has_behavior": false,
-      "frames_found": [
-        "Components",
-        "Screenshots of current use cases"
-      ],
+      "frames_found": ["Components", "Screenshots of current use cases"],
       "frames_missing": [
         "Content guidelines",
         "design guidelines",
@@ -809,10 +731,7 @@
       "has_examples": false,
       "has_screenshots": true,
       "has_behavior": false,
-      "frames_found": [
-        "Components",
-        "Screenshots of current use cases"
-      ],
+      "frames_found": ["Components", "Screenshots of current use cases"],
       "frames_missing": [
         "Content guidelines",
         "design guidelines",
@@ -836,10 +755,7 @@
         "Content guidelines",
         "Screenshots of current use cases"
       ],
-      "frames_missing": [
-        "ready made examples",
-        "Behavior demo"
-      ]
+      "frames_missing": ["ready made examples", "Behavior demo"]
     },
     {
       "slug": "text-input",
@@ -872,11 +788,7 @@
       "has_examples": false,
       "has_screenshots": false,
       "has_behavior": false,
-      "frames_found": [
-        "Design guidelines",
-        "Content guidelines",
-        "Components"
-      ],
+      "frames_found": ["Design guidelines", "Content guidelines", "Components"],
       "frames_missing": [
         "ready made examples",
         "Screenshots of use cases",
@@ -914,10 +826,7 @@
       "has_examples": false,
       "has_screenshots": true,
       "has_behavior": false,
-      "frames_found": [
-        "Components",
-        "Screenshots of current use cases"
-      ],
+      "frames_found": ["Components", "Screenshots of current use cases"],
       "frames_missing": [
         "Content guidelines",
         "design guidelines",

--- a/plugins/actian-design-system/docs/component-guidelines/drawer.json
+++ b/plugins/actian-design-system/docs/component-guidelines/drawer.json
@@ -2,10 +2,7 @@
   "component": "Drawer / Side panel",
   "page_id": "12054:49858",
   "extracted_at": "2026-03-25T00:00:00Z",
-  "frames_found": [
-    "Components",
-    "Screenshots of current use cases"
-  ],
+  "frames_found": ["Components", "Screenshots of current use cases"],
   "frames_missing": [
     "Content guidelines",
     "Design guidelines",
@@ -17,10 +14,7 @@
   "design_guidelines": null,
   "variants": {
     "axes": {
-      "App": [
-        "Studio",
-        "Explorer"
-      ]
+      "App": ["Studio", "Explorer"]
     }
   },
   "examples": null,
@@ -31,5 +25,11 @@
       "Frame 2: 9 screenshots showing Explorer drawer use cases (2026-03-12)"
     ]
   },
-  "behavior": null
+  "behavior": {
+    "motion": {
+      "pattern": "drawer",
+      "overrides": null,
+      "notes": "Canonical drawer choreography. Open uses duration-slow + ease-entrance (responsive feel that settles); close uses duration-base + ease-exit (clears out faster)."
+    }
+  }
 }

--- a/plugins/actian-design-system/docs/component-guidelines/modal.json
+++ b/plugins/actian-design-system/docs/component-guidelines/modal.json
@@ -134,5 +134,11 @@
       "Grouped by size: 1200px, 900px, 700px, 500px, 450px, 400px with multiple real use case screenshots each"
     ]
   },
-  "behavior": null
+  "behavior": {
+    "motion": {
+      "pattern": "layered-overlays",
+      "overrides": null,
+      "notes": "Modal uses Layered Overlays pattern. Open: scales 95→100% + scrim fades in over duration-slow with ease-entrance. Close: scales 100→95% + fades + scrim fades, all duration-fast with ease-exit. The slow open communicates entering a new context; the quick close stays out of the user's way."
+    }
+  }
 }

--- a/plugins/actian-design-system/docs/component-guidelines/notification-toast.json
+++ b/plugins/actian-design-system/docs/component-guidelines/notification-toast.json
@@ -2,10 +2,7 @@
   "component": "Notification / Toast",
   "page_id": "13868:11578",
   "extracted_at": "2026-03-25T00:00:00Z",
-  "frames_found": [
-    "Components",
-    "Screenshots of use cases"
-  ],
+  "frames_found": ["Components", "Screenshots of use cases"],
   "frames_missing": [
     "Content guidelines",
     "Design guidelines",
@@ -17,10 +14,7 @@
   "design_guidelines": null,
   "variants": {
     "axes": {
-      "Type": [
-        "Default",
-        "Critical"
-      ]
+      "Type": ["Default", "Critical"]
     }
   },
   "examples": null,
@@ -33,5 +27,11 @@
       "Screenshot 2026-02-19 at 4.18.36 PM"
     ]
   },
-  "behavior": null
+  "behavior": {
+    "motion": {
+      "pattern": "success-toast",
+      "overrides": null,
+      "notes": "Three-phase toast choreography: Entry (slide in from bottom, duration-base + ease-entrance) → Hold (delay-long settle, ~4000ms total at the product level) → Exit (fade out, duration-fast + ease-exit). Hold duration is product-level, not a motion token — delay-long is the unit, full hold is configured per call site."
+    }
+  }
 }

--- a/plugins/actian-design-system/docs/generated/foundations/interaction-motion.json
+++ b/plugins/actian-design-system/docs/generated/foundations/interaction-motion.json
@@ -4,182 +4,240 @@
     "source": "docs/foundations.md",
     "do_not_edit": "Edit the source MD; CI regenerates this file."
   },
-  "rows": [
-    {
-      "Token": "--zen-motion-duration-instant",
-      "Value": "100ms",
-      "Usage": "Micro-feedback: button hovers, checkbox toggles, radio buttons, focus rings",
-      "status_note": "🟡 Proposed"
+  "description": "Motion tokens cover three dimensions: duration (how long), easing (how it accelerates), and delay (when it starts). All three must be specified together for any animated component.",
+  "tokens": {
+    "duration": {
+      "description": "Duration controls the speed of a transition. Smaller, simpler components move faster; larger, complex surfaces take slightly more time to respect their physical weight.",
+      "rows": [
+        {
+          "Token": "--zen-motion-duration-instant",
+          "Value": "100ms",
+          "Usage": "Micro-feedback: button hovers, checkbox toggles, radio buttons, focus rings",
+          "status_note": "🟡 Proposed"
+        },
+        {
+          "Token": "--zen-motion-duration-fast",
+          "Value": "200ms",
+          "Usage": "Small scale: tooltip fade-ins, dropdown/select expansions, tag dismissals",
+          "status_note": "🟡 Proposed"
+        },
+        {
+          "Token": "--zen-motion-duration-base",
+          "Value": "300ms",
+          "Usage": "Structural changes: collapse/accordion expanding, toast notifications sliding in",
+          "status_note": "🟡 Proposed"
+        },
+        {
+          "Token": "--zen-motion-duration-slow",
+          "Value": "400ms",
+          "Usage": "Large surfaces: modal scaling in, drawer (side panel) sliding in",
+          "status_note": "🟡 Proposed"
+        }
+      ]
     },
-    {
-      "Token": "--zen-motion-duration-fast",
-      "Value": "200ms",
-      "Usage": "Small scale: tooltip fade-ins, dropdown/select expansions, tag dismissals",
-      "status_note": "🟡 Proposed"
+    "easing": {
+      "description": "Easing curves give motion a natural, physical feel.",
+      "rows": [
+        {
+          "Token": "--zen-motion-ease-entrance",
+          "Value": "ease-out",
+          "Usage": "Fast start, slow finish. Objects entering the screen (e.g. modals, drawers). Feels responsive but settles smoothly.",
+          "status_note": "🟡 Proposed"
+        },
+        {
+          "Token": "--zen-motion-ease-exit",
+          "Value": "ease-in",
+          "Usage": "Slow start, fast finish. Objects leaving the screen (e.g. closing a side nav, dismissing a toast). Gets out of the user's way quickly.",
+          "status_note": "🟡 Proposed"
+        },
+        {
+          "Token": "--zen-motion-ease-standard",
+          "Value": "ease-in-out",
+          "Usage": "Smooth start and finish. Elements moving from point A to B, or expanding internally (e.g. accordions opening, progress bars filling).",
+          "status_note": "🟡 Proposed"
+        }
+      ]
     },
-    {
-      "Token": "--zen-motion-duration-base",
-      "Value": "300ms",
-      "Usage": "Structural changes: collapse/accordion expanding, toast notifications sliding in",
-      "status_note": "🟡 Proposed"
-    },
-    {
-      "Token": "--zen-motion-duration-slow",
-      "Value": "400ms",
-      "Usage": "Large surfaces: modal scaling in, drawer (side panel) sliding in",
-      "status_note": "🟡 Proposed"
-    },
-    {
-      "Token": "--zen-motion-ease-entrance",
-      "Value": "ease-out",
-      "Usage": "Fast start, slow finish. Objects entering the screen (e.g. modals, drawers). Feels responsive but settles smoothly.",
-      "status_note": "🟡 Proposed"
-    },
-    {
-      "Token": "--zen-motion-ease-exit",
-      "Value": "ease-in",
-      "Usage": "Slow start, fast finish. Objects leaving the screen (e.g. closing a side nav, dismissing a toast). Gets out of the user's way quickly.",
-      "status_note": "🟡 Proposed"
-    },
-    {
-      "Token": "--zen-motion-ease-standard",
-      "Value": "ease-in-out",
-      "Usage": "Smooth start and finish. Elements moving from point A to B, or expanding internally (e.g. accordions opening, progress bars filling).",
-      "status_note": "🟡 Proposed"
-    },
-    {
-      "Token": "--zen-motion-delay-stagger",
-      "Value": "20ms",
-      "Usage": "Choreography: applied incrementally to list items, table rows, or search result cards as they enter the screen",
-      "status_note": "🟡 Proposed"
-    },
-    {
-      "Token": "--zen-motion-delay-intent",
-      "Value": "300ms",
-      "Usage": "Hover protection: standard wait time before revealing a tooltip or complex glossary popover. Prevents accidental visual noise.",
-      "status_note": "🟡 Proposed"
-    },
-    {
-      "Token": "--zen-motion-delay-long",
-      "Value": "500ms",
-      "Usage": "Feedback holding: used for temporary success states before they auto-dismiss (e.g. a toast lingering before sliding out)",
-      "status_note": "🟡 Proposed"
-    },
-    {
-      "Phase": "Open",
-      "Duration": "duration-slow",
-      "Easing": "ease-entrance",
-      "Behavior": "Slides in from the right"
-    },
-    {
-      "Phase": "Close",
-      "Duration": "duration-base",
-      "Easing": "ease-exit",
-      "Behavior": "Slides out to the right"
-    },
-    {
-      "Phase": "Expand",
-      "Duration": "duration-base",
-      "Easing": "ease-standard",
-      "Behavior": "Height animates open; content fades in (0→100% opacity) during final 150ms"
-    },
-    {
-      "Phase": "Collapse",
-      "Duration": "duration-base",
-      "Easing": "ease-standard",
-      "Behavior": "Height animates closed; content fades out (100→0% opacity) during initial 100ms"
-    },
-    {
-      "Phase": "Entry",
-      "Duration": "duration-base",
-      "Easing": "ease-entrance",
-      "Behavior": "Slides in from the bottom"
-    },
-    {
-      "Phase": "Hold",
-      "Duration": "`delay-long` (500ms as token; 4000ms total hold)",
-      "Easing": "—",
-      "Behavior": "Settle time after entry completes before auto-dismiss timer begins"
-    },
-    {
-      "Phase": "Exit",
-      "Duration": "duration-fast",
-      "Easing": "ease-exit",
-      "Behavior": "Fades out quickly"
-    },
-    {
-      "Phase": "Open",
-      "Duration": "duration-base",
-      "Easing": "ease-entrance",
-      "Behavior": "Fades in (0→100% opacity) over full duration; element scales up from its trigger point while fading in"
-    },
-    {
-      "Phase": "Close",
-      "Duration": "duration-fast",
-      "Easing": "ease-standard",
-      "Behavior": "Fades out (100→0% opacity) over full duration; element scales down and retracts back to its trigger point"
-    },
-    {
-      "Phase": "Open",
-      "Duration": "duration-slow",
-      "Easing": "ease-entrance",
-      "Behavior": "Modal scales 95%→100% while background scrim fades in. The slow duration communicates that the user has entered a new, temporary top-level context."
-    },
-    {
-      "Phase": "Close",
-      "Duration": "duration-fast",
-      "Easing": "ease-exit",
-      "Behavior": "Modal scales 100%→95% and fades 100%→0%. Scrim fades 100%→0%, synchronized. Slower on open to help users track context; dismisses quickly once the decision is made."
-    },
-    {
-      "Duration": "`2000ms` (looping)",
-      "Easing": "linear",
-      "Behavior": "A continuous, subtle gradient shimmer moving left-to-right. Not tokenized — value is fixed. Provides visual confirmation the system is active and reduces perceived wait time for data-heavy views."
-    },
-    {
-      "Per-item duration": "duration-fast",
-      "Easing": "ease-entrance",
-      "Delay per item": "`delay-stagger` × item index (item 1: 0ms, item 2: 20ms, item 3: 40ms…)"
-    },
-    {
-      "State": "Hover",
-      "Duration": "duration-instant",
-      "Easing": "ease-standard",
-      "Behavior": "Subtle background color shift via brightness filter"
-    },
-    {
-      "State": "Focus",
-      "Duration": "—",
-      "Easing": "—",
-      "Behavior": "No motion tokens — instant high-contrast ring/border for accessibility and speed"
-    },
-    {
-      "State": "Pressed",
-      "Duration": "duration-instant",
-      "Easing": "ease-exit",
-      "Behavior": "Subtle scale or brightness darkening"
-    },
-    {
-      "State": "→ Selected",
-      "Duration": "duration-fast",
-      "Easing": "ease-standard",
-      "Behavior": "Subtle background color shift and side stroke draw-in"
-    },
-    {
-      "State": "→ Unselected",
-      "Duration": "duration-instant",
-      "Easing": "ease-exit",
-      "Behavior": "Rapid fade and stroke collapse"
+    "delay": {
+      "description": "Delay dictates the pause before the motion duration begins.",
+      "rows": [
+        {
+          "Token": "--zen-motion-delay-stagger",
+          "Value": "20ms",
+          "Usage": "Choreography: applied incrementally to list items, table rows, or search result cards as they enter the screen",
+          "status_note": "🟡 Proposed"
+        },
+        {
+          "Token": "--zen-motion-delay-intent",
+          "Value": "300ms",
+          "Usage": "Hover protection: standard wait time before revealing a tooltip or complex glossary popover. Prevents accidental visual noise.",
+          "status_note": "🟡 Proposed"
+        },
+        {
+          "Token": "--zen-motion-delay-long",
+          "Value": "500ms",
+          "Usage": "Feedback holding: used for temporary success states before they auto-dismiss (e.g. a toast lingering before sliding out)",
+          "status_note": "🟡 Proposed"
+        }
+      ]
     }
-  ],
-  "lists": [
-    [
-      "Intentionality: Apply --zen-motion-delay-intent (300ms) for Tooltip opening on hover to prevent accidental triggers",
-      "Immediate Focus: Keyboard focus (Tab) ignores delays and triggers the open motion immediately",
-      "Reduced Motion: When prefers-reduced-motion: reduce is detected, fade transitions are disabled and elements toggle visibility instantly"
-    ]
-  ],
-  "description": "Motion tokens cover three dimensions: duration (how long), easing (how it accelerates), and delay (when it starts). All three must be specified together for any animated component.\n\nDuration controls the speed of a transition. Smaller, simpler components move faster; larger, complex surfaces take slightly more time to respect their physical weight.\n\nEasing curves give motion a natural, physical feel.\n\nDelay dictates the pause before the motion duration begins.\n\nReference patterns for how motion tokens combine in common components. These define the expected behavior — engineering should implement these exactly.\n\nDrawer (open/close)\n\nAccordion (expand/collapse)\n\nSuccess Toast\n\nThe &quot;Anchor&quot; Motion — Dropdowns, Popovers, and Tooltips\n\nLogic &amp; Accessibility\n\nLayered Overlays — Modals\n\nSkeleton Loading\n\nStaggered Entrance — Lists, Table Rows, Search Cards\n\nThe cascading effect guides the eye naturally downward and prevents the screen feeling &quot;flashed&quot; with too much at once.\n\nState Transitions",
+  },
+  "patterns": {
+    "drawer": {
+      "name": "Drawer (open/close)",
+      "phases": [
+        {
+          "Phase": "Open",
+          "Duration": "duration-slow",
+          "Easing": "ease-entrance",
+          "Behavior": "Slides in from the right"
+        },
+        {
+          "Phase": "Close",
+          "Duration": "duration-base",
+          "Easing": "ease-exit",
+          "Behavior": "Slides out to the right"
+        }
+      ]
+    },
+    "accordion": {
+      "name": "Accordion (expand/collapse)",
+      "phases": [
+        {
+          "Phase": "Expand",
+          "Duration": "duration-base",
+          "Easing": "ease-standard",
+          "Behavior": "Height animates open; content fades in (0→100% opacity) during final 150ms"
+        },
+        {
+          "Phase": "Collapse",
+          "Duration": "duration-base",
+          "Easing": "ease-standard",
+          "Behavior": "Height animates closed; content fades out (100→0% opacity) during initial 100ms"
+        }
+      ]
+    },
+    "success-toast": {
+      "name": "Success Toast",
+      "phases": [
+        {
+          "Phase": "Entry",
+          "Duration": "duration-base",
+          "Easing": "ease-entrance",
+          "Behavior": "Slides in from the bottom"
+        },
+        {
+          "Phase": "Hold",
+          "Duration": "`delay-long` (500ms as token; 4000ms total hold)",
+          "Easing": "—",
+          "Behavior": "Settle time after entry completes before auto-dismiss timer begins"
+        },
+        {
+          "Phase": "Exit",
+          "Duration": "duration-fast",
+          "Easing": "ease-exit",
+          "Behavior": "Fades out quickly"
+        }
+      ]
+    },
+    "anchor-motion": {
+      "name": "The \"Anchor\" Motion — Dropdowns, Popovers, and Tooltips",
+      "phases": [
+        {
+          "Phase": "Open",
+          "Duration": "duration-base",
+          "Easing": "ease-entrance",
+          "Behavior": "Fades in (0→100% opacity) over full duration; element scales up from its trigger point while fading in"
+        },
+        {
+          "Phase": "Close",
+          "Duration": "duration-fast",
+          "Easing": "ease-standard",
+          "Behavior": "Fades out (100→0% opacity) over full duration; element scales down and retracts back to its trigger point"
+        }
+      ],
+      "logic_and_accessibility": [
+        "Intentionality: Apply --zen-motion-delay-intent (300ms) for Tooltip opening on hover to prevent accidental triggers",
+        "Immediate Focus: Keyboard focus (Tab) ignores delays and triggers the open motion immediately",
+        "Reduced Motion: When prefers-reduced-motion: reduce is detected, fade transitions are disabled and elements toggle visibility instantly"
+      ]
+    },
+    "layered-overlays": {
+      "name": "Layered Overlays — Modals",
+      "phases": [
+        {
+          "Phase": "Open",
+          "Duration": "duration-slow",
+          "Easing": "ease-entrance",
+          "Behavior": "Modal scales 95%→100% while background scrim fades in. The slow duration communicates that the user has entered a new, temporary top-level context."
+        },
+        {
+          "Phase": "Close",
+          "Duration": "duration-fast",
+          "Easing": "ease-exit",
+          "Behavior": "Modal scales 100%→95% and fades 100%→0%. Scrim fades 100%→0%, synchronized. Slower on open to help users track context; dismisses quickly once the decision is made."
+        }
+      ]
+    },
+    "skeleton-loading": {
+      "name": "Skeleton Loading",
+      "phases": [
+        {
+          "Duration": "`2000ms` (looping)",
+          "Easing": "linear",
+          "Behavior": "A continuous, subtle gradient shimmer moving left-to-right. Not tokenized — value is fixed. Provides visual confirmation the system is active and reduces perceived wait time for data-heavy views."
+        }
+      ]
+    },
+    "staggered-entrance": {
+      "name": "Staggered Entrance — Lists, Table Rows, Search Cards",
+      "phases": [
+        {
+          "Per-item duration": "duration-fast",
+          "Easing": "ease-entrance",
+          "Delay per item": "`delay-stagger` × item index (item 1: 0ms, item 2: 20ms, item 3: 40ms…)"
+        }
+      ],
+      "notes": [
+        "The cascading effect guides the eye naturally downward and prevents the screen feeling \"flashed\" with too much at once."
+      ]
+    },
+    "state-transitions": {
+      "name": "State Transitions",
+      "phases": [
+        {
+          "State": "Hover",
+          "Duration": "duration-instant",
+          "Easing": "ease-standard",
+          "Behavior": "Subtle background color shift via brightness filter"
+        },
+        {
+          "State": "Focus",
+          "Duration": "—",
+          "Easing": "—",
+          "Behavior": "No motion tokens — instant high-contrast ring/border for accessibility and speed"
+        },
+        {
+          "State": "Pressed",
+          "Duration": "duration-instant",
+          "Easing": "ease-exit",
+          "Behavior": "Subtle scale or brightness darkening"
+        },
+        {
+          "State": "→ Selected",
+          "Duration": "duration-fast",
+          "Easing": "ease-standard",
+          "Behavior": "Subtle background color shift and side stroke draw-in"
+        },
+        {
+          "State": "→ Unselected",
+          "Duration": "duration-instant",
+          "Easing": "ease-exit",
+          "Behavior": "Rapid fade and stroke collapse"
+        }
+      ]
+    }
+  },
   "brightness_filter": {
     "rows": [
       {

--- a/plugins/actian-design-system/recipes/brief/_index.json
+++ b/plugins/actian-design-system/recipes/brief/_index.json
@@ -3,6 +3,7 @@
   { "file": "card-component.json", "card": "card_component" },
   { "file": "card-anatomy.json", "card": "card_anatomy" },
   { "file": "card-tokens.json", "card": "card_tokens" },
+  { "file": "card-motion.json", "card": "card_motion" },
   { "file": "card-usage.json", "card": "card_usage" },
   { "file": "card-content.json", "card": "card_content" },
   { "file": "card-accessibility.json", "card": "card_accessibility" }

--- a/plugins/actian-design-system/recipes/brief/card-motion.json
+++ b/plugins/actian-design-system/recipes/brief/card-motion.json
@@ -1,0 +1,36 @@
+{
+  "card": "card_motion",
+  "title": "Behavior & motion",
+  "description": "Conditional card. Renders only when the component has behavior.motion.pattern set in its component-guidelines JSON. Pulls phase rows from docs/generated/foundations/interaction-motion.json#patterns.<slug>.",
+  "phase": "transcribe",
+  "source": {
+    "primary": {
+      "type": "motion-pattern-lookup",
+      "registry": "docs/component-guidelines/<slug>.json",
+      "field": "behavior.motion.pattern",
+      "patternRegistry": "docs/generated/foundations/interaction-motion.json",
+      "patternKey": "patterns.<pattern>"
+    },
+    "fallback": "skip-card",
+    "grounding": ["docs/foundations.md"]
+  },
+  "research": {
+    "applicable": false
+  },
+  "sections": {
+    "patternSlug": "Slug of the motion pattern referenced from foundations.md (e.g. 'drawer', 'layered-overlays', 'success-toast'). Must exist in interaction-motion.json#patterns.",
+    "patternName": "Human-readable pattern name copied from interaction-motion.json (e.g. 'Drawer (open/close)'). Used as a card subtitle.",
+    "phases": "Array of phase rows pulled verbatim from interaction-motion.json#patterns.<slug>.phases. Columns vary by pattern (Phase / Duration / Easing / Behavior, or pattern-specific shapes).",
+    "logic_and_accessibility": "Optional — array of strings copied from interaction-motion.json#patterns.<slug>.logic_and_accessibility. Per-pattern accessibility/intent notes (e.g. 'Reduced motion: disable fades').",
+    "notes": "Optional — array of strings copied from interaction-motion.json#patterns.<slug>.notes. Pattern-level notes (cascading effects, hold timing, etc).",
+    "overrides": "Optional free-text. Component-specific deviations from the canonical pattern, copied from <slug>.json behavior.motion.overrides."
+  },
+  "qualityRules": [
+    "Phases must come verbatim from interaction-motion.json — never invent durations or easings",
+    "When the component has no behavior.motion.pattern, suppress the card entirely (do not emit empty card_motion)",
+    "patternSlug must match a key in interaction-motion.json#patterns; fail loudly if not"
+  ],
+  "minimums": {
+    "phases": 1
+  }
+}

--- a/plugins/actian-design-system/schemas/brief-data.schema.json
+++ b/plugins/actian-design-system/schemas/brief-data.schema.json
@@ -430,6 +430,41 @@
         }
       }
     },
+    "card_motion": {
+      "type": "object",
+      "description": "Behavior & motion card (DS mode) — conditional. Only present when the component has a curated motion pattern (component-guidelines/<slug>.json behavior.motion.pattern is set). Pattern data is sourced from docs/generated/foundations/interaction-motion.json.",
+      "properties": {
+        "_source": {
+          "type": "string",
+          "enum": ["figma", "generated", "scaffold"]
+        },
+        "patternSlug": {
+          "type": "string",
+          "description": "Slug into foundations interaction-motion.json#patterns, e.g. 'drawer', 'modal', 'success-toast'"
+        },
+        "patternName": {
+          "type": "string",
+          "description": "Human-readable name (e.g. 'Drawer (open/close)')"
+        },
+        "phases": {
+          "type": "array",
+          "description": "Phase rows from the canonical motion pattern (Phase / Duration / Easing / Behavior, or pattern-specific columns)",
+          "items": { "type": "object" }
+        },
+        "logic_and_accessibility": {
+          "type": "array",
+          "items": { "type": "string" }
+        },
+        "notes": {
+          "type": "array",
+          "items": { "type": "string" }
+        },
+        "overrides": {
+          "type": "string",
+          "description": "Optional component-specific deviations from the canonical pattern (free-text)"
+        }
+      }
+    },
     "card9_code": {
       "type": "object",
       "description": "Code specification card (DS mode — retired)",

--- a/plugins/actian-design-system/scripts/foundations/derive-foundations.js
+++ b/plugins/actian-design-system/scripts/foundations/derive-foundations.js
@@ -223,6 +223,14 @@ function buildMotionPayload(contentTokens, logger) {
   if (!payload.description) delete payload.description;
   if (Object.keys(payload.tokens).length === 0) delete payload.tokens;
   if (Object.keys(payload.patterns).length === 0) delete payload.patterns;
+
+  // Defensive: strip any leftover _pendingSubsection markers that didn't get
+  // resolved (e.g., if a sub-section label is followed by no list).
+  Object.keys(payload.patterns || {}).forEach(function (slug) {
+    if (payload.patterns[slug] && payload.patterns[slug]._pendingSubsection) {
+      delete payload.patterns[slug]._pendingSubsection;
+    }
+  });
   return payload;
 }
 

--- a/plugins/actian-design-system/scripts/foundations/derive-foundations.js
+++ b/plugins/actian-design-system/scripts/foundations/derive-foundations.js
@@ -57,6 +57,175 @@ function applyStatusToRows(rows, sectionNumber, logger) {
   });
 }
 
+// Section 2.9 (Motion) needs a structured payload — tokens grouped by category
+// (duration / easing / delay) and named patterns indexed by slug — so the
+// brief renderer can look up `patterns.drawer` etc. The generic
+// rows/lists/code/description shape collapses this structure.
+function isBoldOnlyParagraph(token) {
+  if (!token || token.type !== "paragraph" || !Array.isArray(token.tokens))
+    return false;
+  var significant = token.tokens.filter(function (t) {
+    if (t.type === "text") return String(t.text || "").trim().length > 0;
+    return true;
+  });
+  return significant.length === 1 && significant[0].type === "strong";
+}
+
+// marked emits HTML-encoded entities in inline text (e.g. `&quot;`, `&amp;`).
+// We need decoded strings for slug + display.
+function decodeHtmlEntities(s) {
+  return String(s || "")
+    .replace(/&quot;/g, '"')
+    .replace(/&#39;/g, "'")
+    .replace(/&amp;/g, "&")
+    .replace(/&lt;/g, "<")
+    .replace(/&gt;/g, ">");
+}
+
+function slugifyPatternName(name) {
+  // Decode HTML entities first so "&quot;" doesn't leak into the slug.
+  // Trim quotes and "The " prefix; drop content in parens and after em-dash.
+  var s = decodeHtmlEntities(name)
+    .replace(/^The\s+/i, "")
+    .replace(/["“”]/g, "")
+    .replace(/\(.*?\)/g, "")
+    .replace(/—.*$/, "")
+    .trim()
+    .toLowerCase();
+  s = s.replace(/[^a-z0-9]+/g, "-").replace(/^-|-$/g, "");
+  return s;
+}
+
+// Bold-paragraph labels that look like patterns but are actually sub-sections
+// of the *previous* pattern. Currently only "Logic & Accessibility" qualifies
+// (it's nested under the Anchor Motion pattern in foundations.md). Add new
+// names here if more sub-section conventions emerge.
+function isPatternSubsectionLabel(decodedName) {
+  return /^\s*logic\s*&\s*accessibility\s*$/i.test(decodedName);
+}
+
+function buildMotionPayload(contentTokens, logger) {
+  var payload = { description: null, tokens: {}, patterns: {} };
+  var introLines = [];
+  var mode = "intro"; // intro | duration | easing | delay | guide
+  var currentPatternSlug = null;
+
+  function ensureTokenBucket(key) {
+    if (!payload.tokens[key]) payload.tokens[key] = {};
+    return payload.tokens[key];
+  }
+
+  for (var i = 0; i < contentTokens.length; i++) {
+    var tok = contentTokens[i];
+
+    if (tok.type === "heading" && tok.depth === 4) {
+      var h = String(tok.text || "")
+        .toLowerCase()
+        .trim();
+      if (h === "duration") mode = "duration";
+      else if (h === "easing") mode = "easing";
+      else if (h === "delay") mode = "delay";
+      else if (h === "component motion guide") {
+        mode = "guide";
+        currentPatternSlug = null;
+      } else {
+        // Unknown h4 — stay in current mode but reset pattern context
+        currentPatternSlug = null;
+      }
+      continue;
+    }
+
+    if (mode === "intro" && tok.type === "paragraph") {
+      var prose = extractors.extractProse(tok);
+      if (prose) introLines.push(prose);
+      continue;
+    }
+
+    if (mode === "duration" || mode === "easing" || mode === "delay") {
+      var bucket = ensureTokenBucket(mode);
+      if (tok.type === "table") {
+        var rows = extractors.extractTable(tok);
+        bucket.rows = applyStatusToRows(rows, "2.9", logger);
+      } else if (tok.type === "paragraph") {
+        var p = extractors.extractProse(tok);
+        if (p)
+          bucket.description = bucket.description
+            ? bucket.description + "\n\n" + p
+            : p;
+      }
+      continue;
+    }
+
+    if (mode === "guide") {
+      if (tok.type === "paragraph") {
+        if (isBoldOnlyParagraph(tok)) {
+          var rawName = extractors.extractProse(tok).trim();
+          var name = decodeHtmlEntities(rawName);
+          // "Logic & Accessibility" and similar are sub-section labels of the
+          // current pattern, not new patterns. Mark a pending key so the next
+          // list/table attaches under the right field.
+          if (isPatternSubsectionLabel(name) && currentPatternSlug) {
+            payload.patterns[currentPatternSlug]._pendingSubsection =
+              "logic_and_accessibility";
+            continue;
+          }
+          var slug = slugifyPatternName(rawName);
+          if (!slug) {
+            logger.warn(
+              "Section '2.9' pattern paragraph '" +
+                name +
+                "' produced empty slug; skipping",
+            );
+            currentPatternSlug = null;
+            continue;
+          }
+          if (payload.patterns[slug]) {
+            logger.warn(
+              "Section '2.9' duplicate pattern slug '" +
+                slug +
+                "' — keeping first",
+            );
+            currentPatternSlug = null;
+            continue;
+          }
+          payload.patterns[slug] = { name: name, phases: [] };
+          currentPatternSlug = slug;
+          continue;
+        }
+        // Non-bold paragraph inside guide — note for current pattern, or guide intro
+        var notesText = decodeHtmlEntities(extractors.extractProse(tok));
+        if (notesText && currentPatternSlug) {
+          var pat = payload.patterns[currentPatternSlug];
+          if (!pat.notes) pat.notes = [];
+          pat.notes.push(notesText);
+        }
+        continue;
+      }
+      if (tok.type === "table" && currentPatternSlug) {
+        payload.patterns[currentPatternSlug].phases =
+          extractors.extractTable(tok);
+        continue;
+      }
+      if (tok.type === "list" && currentPatternSlug) {
+        var listItems = extractors.extractList(tok).map(decodeHtmlEntities);
+        var pendingKey =
+          payload.patterns[currentPatternSlug]._pendingSubsection ||
+          "logic_and_accessibility";
+        payload.patterns[currentPatternSlug][pendingKey] = listItems;
+        delete payload.patterns[currentPatternSlug]._pendingSubsection;
+        continue;
+      }
+      // hr, blockquote, etc. — ignore inside guide
+    }
+  }
+
+  if (introLines.length) payload.description = introLines.join("\n\n");
+  if (!payload.description) delete payload.description;
+  if (Object.keys(payload.tokens).length === 0) delete payload.tokens;
+  if (Object.keys(payload.patterns).length === 0) delete payload.patterns;
+  return payload;
+}
+
 function buildSectionPayload(contentTokens, sectionNumber, logger) {
   var payload = { rows: [], lists: [], code: [], description: null };
   var descLines = [];
@@ -110,7 +279,10 @@ function deriveFromMarkdown(mdSource, parserMap, opts) {
       continue;
     }
     var content = astWalk.sliceSectionContent(tokens, heading);
-    var payload = buildSectionPayload(content, heading.number, logger);
+    var payload =
+      heading.number === "2.9"
+        ? buildMotionPayload(content, logger)
+        : buildSectionPayload(content, heading.number, logger);
 
     if (!output[target.file]) output[target.file] = {};
     if (target.key) {
@@ -253,6 +425,8 @@ if (require.main === module) {
 module.exports = {
   deriveFromMarkdown,
   buildSectionPayload,
+  buildMotionPayload,
+  slugifyPatternName,
   applyStatusToRows,
   addMetaHeader,
   writeOutputs,

--- a/plugins/actian-design-system/scripts/renderers/html-renderers/brief-renderer.css
+++ b/plugins/actian-design-system/scripts/renderers/html-renderers/brief-renderer.css
@@ -247,6 +247,18 @@ td code {
   font-size: 16px;
   color: #101828;
 }
+
+/* Inline pattern slug pill on the Behavior & motion card */
+.pattern-slug {
+  display: inline-block;
+  padding: 2px 8px;
+  background: #f4f6fb;
+  color: #475467;
+  border-radius: 4px;
+  font-size: 12px;
+  font-family:
+    "JetBrains Mono", ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+}
 .card-divider {
   height: 1px;
   background: #e2e7f0;

--- a/plugins/actian-design-system/scripts/renderers/html-renderers/brief-renderer.js
+++ b/plugins/actian-design-system/scripts/renderers/html-renderers/brief-renderer.js
@@ -529,6 +529,113 @@
     );
   }
 
+  // Card 5 (numbered) — Behavior & motion. Conditional: returns "" when the
+  // component has no curated motion pattern. Source data comes from
+  // foundations/interaction-motion.json#patterns.<slug>; component-guideline
+  // declares the slug + optional overrides.
+  function renderCardMotion(motion) {
+    if (!motion) return "";
+    var phases = Array.isArray(motion.phases) ? motion.phases : [];
+    if (phases.length === 0 && !motion.overrides) return "";
+    var parts = [];
+
+    // Pattern reference line
+    if (motion.patternName || motion.patternSlug) {
+      parts.push(
+        '<div class="section" data-name="Pattern">' +
+          sectionTitle("Pattern reference") +
+          '<div class="section-body"><p>' +
+          esc(motion.patternName || motion.patternSlug) +
+          (motion.patternSlug
+            ? ' &nbsp;<code class="pattern-slug">' +
+              esc(motion.patternSlug) +
+              "</code>"
+            : "") +
+          "</p></div></div>",
+      );
+    }
+
+    // Phase rows — table headers derived from row keys (patterns have varying
+    // shapes: Phase/Duration/Easing/Behavior is most common, but skeleton +
+    // staggered-entrance use different columns)
+    if (phases.length) {
+      var headers = Object.keys(phases[0]);
+      var rows = phases.map(function (p) {
+        return headers.map(function (h) {
+          var v = p[h];
+          if (typeof v === "string" && /^[a-z][\w-]*$/.test(v)) {
+            // Looks like a token slug — render in code style
+            return "<code>" + esc(v) + "</code>";
+          }
+          return esc(typeof v === "string" ? v : "");
+        });
+      });
+      parts.push(
+        cardDivider() +
+          '<div class="section" data-name="Phases">' +
+          sectionTitle("Phases") +
+          specTable(headers, rows) +
+          "</div>",
+      );
+    }
+
+    // Optional notes
+    if (Array.isArray(motion.notes) && motion.notes.length) {
+      parts.push(
+        cardDivider() +
+          '<div class="section" data-name="Notes">' +
+          sectionTitle("Notes") +
+          '<div class="section-body"><ul>' +
+          motion.notes
+            .map(function (n) {
+              return "<li>" + esc(n) + "</li>";
+            })
+            .join("") +
+          "</ul></div></div>",
+      );
+    }
+
+    // Optional logic & accessibility
+    if (
+      Array.isArray(motion.logic_and_accessibility) &&
+      motion.logic_and_accessibility.length
+    ) {
+      parts.push(
+        cardDivider() +
+          '<div class="section" data-name="Logic and accessibility">' +
+          sectionTitle("Logic & accessibility") +
+          '<div class="section-body"><ul>' +
+          motion.logic_and_accessibility
+            .map(function (n) {
+              return "<li>" + esc(n) + "</li>";
+            })
+            .join("") +
+          "</ul></div></div>",
+      );
+    }
+
+    // Optional component-specific overrides
+    if (typeof motion.overrides === "string" && motion.overrides.length) {
+      parts.push(
+        cardDivider() +
+          '<div class="section" data-name="Overrides">' +
+          sectionTitle("Component-specific overrides") +
+          '<div class="section-body"><p>' +
+          esc(motion.overrides) +
+          "</p></div></div>",
+      );
+    }
+
+    return cardShell(
+      (motion && motion.cardTitle) || "Behavior & motion",
+      (motion && motion.cardSubtitle) ||
+        "Phases, durations, easings, and accessibility behavior",
+      parts.join(""),
+      null,
+      motion,
+    );
+  }
+
   function renderCard6(usage) {
     if (!usage) return "";
     var parts = [];
@@ -882,6 +989,7 @@
       component: data.card_component || data.card2_component,
       anatomy: data.card_anatomy || data.card3_anatomy,
       tokens: data.card_tokens || data.card4_tokens,
+      motion: data.card_motion,
       usage: data.card_usage || data.card6_usage,
       content: data.card_content || data.card7_content,
       accessibility: data.card_accessibility || data.card8_accessibility,
@@ -907,6 +1015,7 @@
         renderCard2(d.component, componentHtml),
         renderCard3(d.anatomy, componentHtml),
         renderCard4(d.tokens),
+        renderCardMotion(d.motion),
         renderCard6(d.usage),
         renderCard7(d.content),
         renderCard8(d.accessibility),

--- a/plugins/actian-design-system/scripts/renderers/html-renderers/brief-renderer.js
+++ b/plugins/actian-design-system/scripts/renderers/html-renderers/brief-renderer.js
@@ -563,8 +563,10 @@
       var rows = phases.map(function (p) {
         return headers.map(function (h) {
           var v = p[h];
-          if (typeof v === "string" && /^[a-z][\w-]*$/.test(v)) {
-            // Looks like a token slug — render in code style
+          // Token slugs follow `category-name` shape (duration-slow,
+          // ease-entrance, delay-stagger). Require at least one hyphen so
+          // bare CSS keywords like `linear` aren't wrapped in <code>.
+          if (typeof v === "string" && /^[a-z][\w-]*-[\w-]+$/.test(v)) {
             return "<code>" + esc(v) + "</code>";
           }
           return esc(typeof v === "string" ? v : "");

--- a/plugins/actian-design-system/scripts/transformers/brief-sourcing.js
+++ b/plugins/actian-design-system/scripts/transformers/brief-sourcing.js
@@ -36,6 +36,42 @@ function transcribeContentGuidelines(guidelinesJson) {
   return { source: "figma", content: { sections: sections } };
 }
 
+// Motion is a registry-derived card (pattern data lives in
+// docs/generated/foundations/interaction-motion.json under #patterns.<slug>).
+// The component-guideline only declares which pattern + optional overrides;
+// the canonical phase data comes from foundations. Caller passes
+// ctx.motionPatterns (the patterns object from interaction-motion.json).
+function transcribeMotionPattern(guidelinesJson, motionPatterns) {
+  if (!guidelinesJson || !guidelinesJson.behavior) return null;
+  var motion = guidelinesJson.behavior.motion;
+  if (!motion || typeof motion.pattern !== "string" || !motion.pattern) {
+    return null;
+  }
+  var slug = motion.pattern;
+  var pattern =
+    motionPatterns && Object.prototype.hasOwnProperty.call(motionPatterns, slug)
+      ? motionPatterns[slug]
+      : null;
+  if (!pattern) {
+    return {
+      source: null,
+      missingPattern: true,
+      slug: slug,
+    };
+  }
+  return {
+    source: "figma",
+    content: {
+      patternSlug: slug,
+      patternName: pattern.name || slug,
+      phases: Array.isArray(pattern.phases) ? pattern.phases : [],
+      logic_and_accessibility: pattern.logic_and_accessibility || null,
+      notes: pattern.notes || null,
+      overrides: typeof motion.overrides === "string" ? motion.overrides : null,
+    },
+  };
+}
+
 // ---------------------------------------------------------------------------
 // Dispatcher
 // ---------------------------------------------------------------------------
@@ -76,6 +112,29 @@ function resolveSection(cardKey, ctx, recipe) {
     primary = transcribeContentGuidelines(ctx && ctx.guidelinesJson);
     fallbackReason =
       "content_guidelines empty in component-guidelines JSON — Jeff to author Content frame in Figma + re-sync";
+  } else if (cardKey === "card_motion") {
+    var motionResult = transcribeMotionPattern(
+      ctx && ctx.guidelinesJson,
+      ctx && ctx.motionPatterns,
+    );
+    if (motionResult && motionResult.source === "figma") {
+      return { phase: "A", source: "figma", content: motionResult.content };
+    }
+    if (motionResult && motionResult.missingPattern) {
+      // Loud fallback: the component declares a pattern slug that doesn't
+      // exist in foundations. Surface it so the brief generator can decide.
+      return {
+        phase: "A",
+        source: null,
+        fallback: true,
+        fallbackReason:
+          "behavior.motion.pattern '" +
+          motionResult.slug +
+          "' not found in foundations interaction-motion.json#patterns — fix the slug or author the pattern",
+      };
+    }
+    // Component has no motion — suppress the card. Caller skips emitting it.
+    return { phase: "A", source: null, skipCard: true };
   } else {
     throw new Error(
       "resolveSection: no transcription rule for cardKey '" + cardKey + "'",
@@ -124,12 +183,28 @@ function formatForBrief(cardKey, sourceResult, ctx) {
       _source: sourceResult.source || "generated",
     };
   }
+  if (cardKey === "card_motion") {
+    var m = sourceResult.content || {};
+    var card = {
+      patternSlug: m.patternSlug || "",
+      patternName: m.patternName || "",
+      phases: Array.isArray(m.phases) ? m.phases : [],
+      _source: sourceResult.source || "generated",
+    };
+    if (Array.isArray(m.logic_and_accessibility))
+      card.logic_and_accessibility = m.logic_and_accessibility;
+    if (Array.isArray(m.notes)) card.notes = m.notes;
+    if (typeof m.overrides === "string" && m.overrides.length > 0)
+      card.overrides = m.overrides;
+    return card;
+  }
   throw new Error("formatForBrief: unknown cardKey '" + cardKey + "'");
 }
 
 module.exports = {
   transcribeFigmaDescription: transcribeFigmaDescription,
   transcribeContentGuidelines: transcribeContentGuidelines,
+  transcribeMotionPattern: transcribeMotionPattern,
   resolveSection: resolveSection,
   formatForBrief: formatForBrief,
 };

--- a/plugins/actian-design-system/scripts/validation/validate-schema.js
+++ b/plugins/actian-design-system/scripts/validation/validate-schema.js
@@ -266,6 +266,19 @@ function validateBriefData(data) {
           message: "card_content claims figma source but rules array is empty",
         });
       }
+      if (
+        k === "card_motion" &&
+        (!Array.isArray(card.phases) || card.phases.length === 0) &&
+        (typeof card.overrides !== "string" || card.overrides.length === 0)
+      ) {
+        findings.push({
+          kind: "empty-figma-source",
+          severity: "error",
+          card: k,
+          message:
+            "card_motion claims figma source but phases array is empty and no overrides set",
+        });
+      }
     }
   }
   return { findings: findings };

--- a/plugins/actian-design-system/scripts/validation/validate-schema.js
+++ b/plugins/actian-design-system/scripts/validation/validate-schema.js
@@ -279,6 +279,18 @@ function validateBriefData(data) {
             "card_motion claims figma source but phases array is empty and no overrides set",
         });
       }
+      if (
+        k === "card_motion" &&
+        (typeof card.patternSlug !== "string" || card.patternSlug.trim() === "")
+      ) {
+        findings.push({
+          kind: "empty-figma-source",
+          severity: "error",
+          card: k,
+          message:
+            "card_motion claims figma source but patternSlug is missing or empty (recipe contract: patternSlug must match a key in interaction-motion.json#patterns)",
+        });
+      }
     }
   }
   return { findings: findings };

--- a/plugins/actian-design-system/tests/fixtures/foundations-parser/golden/expected/interaction-motion.json
+++ b/plugins/actian-design-system/tests/fixtures/foundations-parser/golden/expected/interaction-motion.json
@@ -4,182 +4,240 @@
     "source": "docs/foundations.md",
     "do_not_edit": "Edit the source MD; CI regenerates this file."
   },
-  "rows": [
-    {
-      "Token": "--zen-motion-duration-instant",
-      "Value": "100ms",
-      "Usage": "Micro-feedback: button hovers, checkbox toggles, radio buttons, focus rings",
-      "status_note": "🟡 Proposed"
+  "description": "Motion tokens cover three dimensions: duration (how long), easing (how it accelerates), and delay (when it starts). All three must be specified together for any animated component.",
+  "tokens": {
+    "duration": {
+      "description": "Duration controls the speed of a transition. Smaller, simpler components move faster; larger, complex surfaces take slightly more time to respect their physical weight.",
+      "rows": [
+        {
+          "Token": "--zen-motion-duration-instant",
+          "Value": "100ms",
+          "Usage": "Micro-feedback: button hovers, checkbox toggles, radio buttons, focus rings",
+          "status_note": "🟡 Proposed"
+        },
+        {
+          "Token": "--zen-motion-duration-fast",
+          "Value": "200ms",
+          "Usage": "Small scale: tooltip fade-ins, dropdown/select expansions, tag dismissals",
+          "status_note": "🟡 Proposed"
+        },
+        {
+          "Token": "--zen-motion-duration-base",
+          "Value": "300ms",
+          "Usage": "Structural changes: collapse/accordion expanding, toast notifications sliding in",
+          "status_note": "🟡 Proposed"
+        },
+        {
+          "Token": "--zen-motion-duration-slow",
+          "Value": "400ms",
+          "Usage": "Large surfaces: modal scaling in, drawer (side panel) sliding in",
+          "status_note": "🟡 Proposed"
+        }
+      ]
     },
-    {
-      "Token": "--zen-motion-duration-fast",
-      "Value": "200ms",
-      "Usage": "Small scale: tooltip fade-ins, dropdown/select expansions, tag dismissals",
-      "status_note": "🟡 Proposed"
+    "easing": {
+      "description": "Easing curves give motion a natural, physical feel.",
+      "rows": [
+        {
+          "Token": "--zen-motion-ease-entrance",
+          "Value": "ease-out",
+          "Usage": "Fast start, slow finish. Objects entering the screen (e.g. modals, drawers). Feels responsive but settles smoothly.",
+          "status_note": "🟡 Proposed"
+        },
+        {
+          "Token": "--zen-motion-ease-exit",
+          "Value": "ease-in",
+          "Usage": "Slow start, fast finish. Objects leaving the screen (e.g. closing a side nav, dismissing a toast). Gets out of the user's way quickly.",
+          "status_note": "🟡 Proposed"
+        },
+        {
+          "Token": "--zen-motion-ease-standard",
+          "Value": "ease-in-out",
+          "Usage": "Smooth start and finish. Elements moving from point A to B, or expanding internally (e.g. accordions opening, progress bars filling).",
+          "status_note": "🟡 Proposed"
+        }
+      ]
     },
-    {
-      "Token": "--zen-motion-duration-base",
-      "Value": "300ms",
-      "Usage": "Structural changes: collapse/accordion expanding, toast notifications sliding in",
-      "status_note": "🟡 Proposed"
-    },
-    {
-      "Token": "--zen-motion-duration-slow",
-      "Value": "400ms",
-      "Usage": "Large surfaces: modal scaling in, drawer (side panel) sliding in",
-      "status_note": "🟡 Proposed"
-    },
-    {
-      "Token": "--zen-motion-ease-entrance",
-      "Value": "ease-out",
-      "Usage": "Fast start, slow finish. Objects entering the screen (e.g. modals, drawers). Feels responsive but settles smoothly.",
-      "status_note": "🟡 Proposed"
-    },
-    {
-      "Token": "--zen-motion-ease-exit",
-      "Value": "ease-in",
-      "Usage": "Slow start, fast finish. Objects leaving the screen (e.g. closing a side nav, dismissing a toast). Gets out of the user's way quickly.",
-      "status_note": "🟡 Proposed"
-    },
-    {
-      "Token": "--zen-motion-ease-standard",
-      "Value": "ease-in-out",
-      "Usage": "Smooth start and finish. Elements moving from point A to B, or expanding internally (e.g. accordions opening, progress bars filling).",
-      "status_note": "🟡 Proposed"
-    },
-    {
-      "Token": "--zen-motion-delay-stagger",
-      "Value": "20ms",
-      "Usage": "Choreography: applied incrementally to list items, table rows, or search result cards as they enter the screen",
-      "status_note": "🟡 Proposed"
-    },
-    {
-      "Token": "--zen-motion-delay-intent",
-      "Value": "300ms",
-      "Usage": "Hover protection: standard wait time before revealing a tooltip or complex glossary popover. Prevents accidental visual noise.",
-      "status_note": "🟡 Proposed"
-    },
-    {
-      "Token": "--zen-motion-delay-long",
-      "Value": "500ms",
-      "Usage": "Feedback holding: used for temporary success states before they auto-dismiss (e.g. a toast lingering before sliding out)",
-      "status_note": "🟡 Proposed"
-    },
-    {
-      "Phase": "Open",
-      "Duration": "duration-slow",
-      "Easing": "ease-entrance",
-      "Behavior": "Slides in from the right"
-    },
-    {
-      "Phase": "Close",
-      "Duration": "duration-base",
-      "Easing": "ease-exit",
-      "Behavior": "Slides out to the right"
-    },
-    {
-      "Phase": "Expand",
-      "Duration": "duration-base",
-      "Easing": "ease-standard",
-      "Behavior": "Height animates open; content fades in (0→100% opacity) during final 150ms"
-    },
-    {
-      "Phase": "Collapse",
-      "Duration": "duration-base",
-      "Easing": "ease-standard",
-      "Behavior": "Height animates closed; content fades out (100→0% opacity) during initial 100ms"
-    },
-    {
-      "Phase": "Entry",
-      "Duration": "duration-base",
-      "Easing": "ease-entrance",
-      "Behavior": "Slides in from the bottom"
-    },
-    {
-      "Phase": "Hold",
-      "Duration": "`delay-long` (500ms as token; 4000ms total hold)",
-      "Easing": "—",
-      "Behavior": "Settle time after entry completes before auto-dismiss timer begins"
-    },
-    {
-      "Phase": "Exit",
-      "Duration": "duration-fast",
-      "Easing": "ease-exit",
-      "Behavior": "Fades out quickly"
-    },
-    {
-      "Phase": "Open",
-      "Duration": "duration-base",
-      "Easing": "ease-entrance",
-      "Behavior": "Fades in (0→100% opacity) over full duration; element scales up from its trigger point while fading in"
-    },
-    {
-      "Phase": "Close",
-      "Duration": "duration-fast",
-      "Easing": "ease-standard",
-      "Behavior": "Fades out (100→0% opacity) over full duration; element scales down and retracts back to its trigger point"
-    },
-    {
-      "Phase": "Open",
-      "Duration": "duration-slow",
-      "Easing": "ease-entrance",
-      "Behavior": "Modal scales 95%→100% while background scrim fades in. The slow duration communicates that the user has entered a new, temporary top-level context."
-    },
-    {
-      "Phase": "Close",
-      "Duration": "duration-fast",
-      "Easing": "ease-exit",
-      "Behavior": "Modal scales 100%→95% and fades 100%→0%. Scrim fades 100%→0%, synchronized. Slower on open to help users track context; dismisses quickly once the decision is made."
-    },
-    {
-      "Duration": "`2000ms` (looping)",
-      "Easing": "linear",
-      "Behavior": "A continuous, subtle gradient shimmer moving left-to-right. Not tokenized — value is fixed. Provides visual confirmation the system is active and reduces perceived wait time for data-heavy views."
-    },
-    {
-      "Per-item duration": "duration-fast",
-      "Easing": "ease-entrance",
-      "Delay per item": "`delay-stagger` × item index (item 1: 0ms, item 2: 20ms, item 3: 40ms…)"
-    },
-    {
-      "State": "Hover",
-      "Duration": "duration-instant",
-      "Easing": "ease-standard",
-      "Behavior": "Subtle background color shift via brightness filter"
-    },
-    {
-      "State": "Focus",
-      "Duration": "—",
-      "Easing": "—",
-      "Behavior": "No motion tokens — instant high-contrast ring/border for accessibility and speed"
-    },
-    {
-      "State": "Pressed",
-      "Duration": "duration-instant",
-      "Easing": "ease-exit",
-      "Behavior": "Subtle scale or brightness darkening"
-    },
-    {
-      "State": "→ Selected",
-      "Duration": "duration-fast",
-      "Easing": "ease-standard",
-      "Behavior": "Subtle background color shift and side stroke draw-in"
-    },
-    {
-      "State": "→ Unselected",
-      "Duration": "duration-instant",
-      "Easing": "ease-exit",
-      "Behavior": "Rapid fade and stroke collapse"
+    "delay": {
+      "description": "Delay dictates the pause before the motion duration begins.",
+      "rows": [
+        {
+          "Token": "--zen-motion-delay-stagger",
+          "Value": "20ms",
+          "Usage": "Choreography: applied incrementally to list items, table rows, or search result cards as they enter the screen",
+          "status_note": "🟡 Proposed"
+        },
+        {
+          "Token": "--zen-motion-delay-intent",
+          "Value": "300ms",
+          "Usage": "Hover protection: standard wait time before revealing a tooltip or complex glossary popover. Prevents accidental visual noise.",
+          "status_note": "🟡 Proposed"
+        },
+        {
+          "Token": "--zen-motion-delay-long",
+          "Value": "500ms",
+          "Usage": "Feedback holding: used for temporary success states before they auto-dismiss (e.g. a toast lingering before sliding out)",
+          "status_note": "🟡 Proposed"
+        }
+      ]
     }
-  ],
-  "lists": [
-    [
-      "Intentionality: Apply --zen-motion-delay-intent (300ms) for Tooltip opening on hover to prevent accidental triggers",
-      "Immediate Focus: Keyboard focus (Tab) ignores delays and triggers the open motion immediately",
-      "Reduced Motion: When prefers-reduced-motion: reduce is detected, fade transitions are disabled and elements toggle visibility instantly"
-    ]
-  ],
-  "description": "Motion tokens cover three dimensions: duration (how long), easing (how it accelerates), and delay (when it starts). All three must be specified together for any animated component.\n\nDuration controls the speed of a transition. Smaller, simpler components move faster; larger, complex surfaces take slightly more time to respect their physical weight.\n\nEasing curves give motion a natural, physical feel.\n\nDelay dictates the pause before the motion duration begins.\n\nReference patterns for how motion tokens combine in common components. These define the expected behavior — engineering should implement these exactly.\n\nDrawer (open/close)\n\nAccordion (expand/collapse)\n\nSuccess Toast\n\nThe &quot;Anchor&quot; Motion — Dropdowns, Popovers, and Tooltips\n\nLogic &amp; Accessibility\n\nLayered Overlays — Modals\n\nSkeleton Loading\n\nStaggered Entrance — Lists, Table Rows, Search Cards\n\nThe cascading effect guides the eye naturally downward and prevents the screen feeling &quot;flashed&quot; with too much at once.\n\nState Transitions",
+  },
+  "patterns": {
+    "drawer": {
+      "name": "Drawer (open/close)",
+      "phases": [
+        {
+          "Phase": "Open",
+          "Duration": "duration-slow",
+          "Easing": "ease-entrance",
+          "Behavior": "Slides in from the right"
+        },
+        {
+          "Phase": "Close",
+          "Duration": "duration-base",
+          "Easing": "ease-exit",
+          "Behavior": "Slides out to the right"
+        }
+      ]
+    },
+    "accordion": {
+      "name": "Accordion (expand/collapse)",
+      "phases": [
+        {
+          "Phase": "Expand",
+          "Duration": "duration-base",
+          "Easing": "ease-standard",
+          "Behavior": "Height animates open; content fades in (0→100% opacity) during final 150ms"
+        },
+        {
+          "Phase": "Collapse",
+          "Duration": "duration-base",
+          "Easing": "ease-standard",
+          "Behavior": "Height animates closed; content fades out (100→0% opacity) during initial 100ms"
+        }
+      ]
+    },
+    "success-toast": {
+      "name": "Success Toast",
+      "phases": [
+        {
+          "Phase": "Entry",
+          "Duration": "duration-base",
+          "Easing": "ease-entrance",
+          "Behavior": "Slides in from the bottom"
+        },
+        {
+          "Phase": "Hold",
+          "Duration": "`delay-long` (500ms as token; 4000ms total hold)",
+          "Easing": "—",
+          "Behavior": "Settle time after entry completes before auto-dismiss timer begins"
+        },
+        {
+          "Phase": "Exit",
+          "Duration": "duration-fast",
+          "Easing": "ease-exit",
+          "Behavior": "Fades out quickly"
+        }
+      ]
+    },
+    "anchor-motion": {
+      "name": "The \"Anchor\" Motion — Dropdowns, Popovers, and Tooltips",
+      "phases": [
+        {
+          "Phase": "Open",
+          "Duration": "duration-base",
+          "Easing": "ease-entrance",
+          "Behavior": "Fades in (0→100% opacity) over full duration; element scales up from its trigger point while fading in"
+        },
+        {
+          "Phase": "Close",
+          "Duration": "duration-fast",
+          "Easing": "ease-standard",
+          "Behavior": "Fades out (100→0% opacity) over full duration; element scales down and retracts back to its trigger point"
+        }
+      ],
+      "logic_and_accessibility": [
+        "Intentionality: Apply --zen-motion-delay-intent (300ms) for Tooltip opening on hover to prevent accidental triggers",
+        "Immediate Focus: Keyboard focus (Tab) ignores delays and triggers the open motion immediately",
+        "Reduced Motion: When prefers-reduced-motion: reduce is detected, fade transitions are disabled and elements toggle visibility instantly"
+      ]
+    },
+    "layered-overlays": {
+      "name": "Layered Overlays — Modals",
+      "phases": [
+        {
+          "Phase": "Open",
+          "Duration": "duration-slow",
+          "Easing": "ease-entrance",
+          "Behavior": "Modal scales 95%→100% while background scrim fades in. The slow duration communicates that the user has entered a new, temporary top-level context."
+        },
+        {
+          "Phase": "Close",
+          "Duration": "duration-fast",
+          "Easing": "ease-exit",
+          "Behavior": "Modal scales 100%→95% and fades 100%→0%. Scrim fades 100%→0%, synchronized. Slower on open to help users track context; dismisses quickly once the decision is made."
+        }
+      ]
+    },
+    "skeleton-loading": {
+      "name": "Skeleton Loading",
+      "phases": [
+        {
+          "Duration": "`2000ms` (looping)",
+          "Easing": "linear",
+          "Behavior": "A continuous, subtle gradient shimmer moving left-to-right. Not tokenized — value is fixed. Provides visual confirmation the system is active and reduces perceived wait time for data-heavy views."
+        }
+      ]
+    },
+    "staggered-entrance": {
+      "name": "Staggered Entrance — Lists, Table Rows, Search Cards",
+      "phases": [
+        {
+          "Per-item duration": "duration-fast",
+          "Easing": "ease-entrance",
+          "Delay per item": "`delay-stagger` × item index (item 1: 0ms, item 2: 20ms, item 3: 40ms…)"
+        }
+      ],
+      "notes": [
+        "The cascading effect guides the eye naturally downward and prevents the screen feeling \"flashed\" with too much at once."
+      ]
+    },
+    "state-transitions": {
+      "name": "State Transitions",
+      "phases": [
+        {
+          "State": "Hover",
+          "Duration": "duration-instant",
+          "Easing": "ease-standard",
+          "Behavior": "Subtle background color shift via brightness filter"
+        },
+        {
+          "State": "Focus",
+          "Duration": "—",
+          "Easing": "—",
+          "Behavior": "No motion tokens — instant high-contrast ring/border for accessibility and speed"
+        },
+        {
+          "State": "Pressed",
+          "Duration": "duration-instant",
+          "Easing": "ease-exit",
+          "Behavior": "Subtle scale or brightness darkening"
+        },
+        {
+          "State": "→ Selected",
+          "Duration": "duration-fast",
+          "Easing": "ease-standard",
+          "Behavior": "Subtle background color shift and side stroke draw-in"
+        },
+        {
+          "State": "→ Unselected",
+          "Duration": "duration-instant",
+          "Easing": "ease-exit",
+          "Behavior": "Rapid fade and stroke collapse"
+        }
+      ]
+    }
+  },
   "brightness_filter": {
     "rows": [
       {

--- a/plugins/actian-design-system/tests/foundations/derive-foundations.test.js
+++ b/plugins/actian-design-system/tests/foundations/derive-foundations.test.js
@@ -863,3 +863,40 @@ describe("derive-foundations: buildMotionPayload", function () {
     ]);
   });
 });
+
+describe("derive-foundations: defensive cleanup", function () {
+  it("strips _pendingSubsection from output even if no list followed the sub-label", function () {
+    var md = [
+      "### 2.9 Motion",
+      "",
+      "#### Component Motion Guide",
+      "",
+      "**Anchor Motion**",
+      "",
+      "| Phase | Duration |",
+      "|-------|----------|",
+      "| Open | `duration-base` |",
+      "",
+      "**Logic & Accessibility**",
+      "",
+      // Section ends here — no list follows the sub-label.
+    ].join("\n");
+    var tokens = parseMarkdown(md);
+    var headings = findNumberedHeadings(tokens);
+    var motion = headings.find(function (h) {
+      return h.number === "2.9";
+    });
+    var content = [];
+    for (var i = motion.tokenIndex + 1; i < tokens.length; i++) {
+      content.push(tokens[i]);
+    }
+    var p = buildMotionPayload(content, { warn: function () {} });
+    assert.ok(
+      !Object.prototype.hasOwnProperty.call(
+        p.patterns["anchor-motion"],
+        "_pendingSubsection",
+      ),
+      "_pendingSubsection should not leak into output",
+    );
+  });
+});

--- a/plugins/actian-design-system/tests/foundations/derive-foundations.test.js
+++ b/plugins/actian-design-system/tests/foundations/derive-foundations.test.js
@@ -672,3 +672,194 @@ describe("ast-walk: findNumberedHeadings — heading regex tightening (issue #7)
     assert.strictEqual(headings[1].number, "1.99");
   });
 });
+
+var {
+  buildMotionPayload,
+  slugifyPatternName,
+} = require("../../scripts/foundations/derive-foundations.js");
+
+describe("derive-foundations: slugifyPatternName", function () {
+  it("kebab-cases simple names", function () {
+    assert.strictEqual(slugifyPatternName("Drawer"), "drawer");
+    assert.strictEqual(slugifyPatternName("Success Toast"), "success-toast");
+  });
+
+  it("drops content in parentheses", function () {
+    assert.strictEqual(
+      slugifyPatternName("Drawer (open/close)"),
+      "drawer",
+    );
+    assert.strictEqual(
+      slugifyPatternName("Accordion (expand/collapse)"),
+      "accordion",
+    );
+  });
+
+  it("drops content after em-dash", function () {
+    assert.strictEqual(
+      slugifyPatternName("Layered Overlays — Modals"),
+      "layered-overlays",
+    );
+    assert.strictEqual(
+      slugifyPatternName("Staggered Entrance — Lists, Table Rows, Search Cards"),
+      "staggered-entrance",
+    );
+  });
+
+  it("strips quotes and 'The ' prefix", function () {
+    assert.strictEqual(
+      slugifyPatternName('The "Anchor" Motion — Dropdowns'),
+      "anchor-motion",
+    );
+  });
+
+  it("decodes HTML entities before slugging", function () {
+    assert.strictEqual(
+      slugifyPatternName("The &quot;Anchor&quot; Motion — Dropdowns"),
+      "anchor-motion",
+    );
+  });
+});
+
+describe("derive-foundations: buildMotionPayload", function () {
+  function payloadFromMd(md) {
+    var tokens = parseMarkdown(md);
+    // Slice from the 2.9 heading through end (or next ###/##).
+    var headings = findNumberedHeadings(tokens);
+    var motion = headings.find(function (h) {
+      return h.number === "2.9";
+    });
+    var content = [];
+    for (var i = motion.tokenIndex + 1; i < tokens.length; i++) {
+      var t = tokens[i];
+      if (t.type === "heading" && t.depth <= motion.depth) break;
+      content.push(t);
+    }
+    return buildMotionPayload(content, { warn: function () {} });
+  }
+
+  it("groups duration/easing/delay token tables under tokens.<key>", function () {
+    var md = [
+      "### 2.9 Motion",
+      "",
+      "Intro paragraph.",
+      "",
+      "#### Duration",
+      "",
+      "| Token | Value |",
+      "|-------|-------|",
+      "| `--zen-motion-duration-instant` | `100ms` |",
+      "",
+      "#### Easing",
+      "",
+      "| Token | Value |",
+      "|-------|-------|",
+      "| `--zen-motion-ease-entrance` | `ease-out` |",
+      "",
+      "#### Delay",
+      "",
+      "| Token | Value |",
+      "|-------|-------|",
+      "| `--zen-motion-delay-stagger` | `20ms` |",
+      "",
+    ].join("\n");
+    var p = payloadFromMd(md);
+    assert.strictEqual(p.description, "Intro paragraph.");
+    assert.ok(p.tokens.duration.rows[0].Token === "--zen-motion-duration-instant");
+    assert.ok(p.tokens.easing.rows[0].Token === "--zen-motion-ease-entrance");
+    assert.ok(p.tokens.delay.rows[0].Token === "--zen-motion-delay-stagger");
+  });
+
+  it("indexes named patterns by slug under patterns.<slug>", function () {
+    var md = [
+      "### 2.9 Motion",
+      "",
+      "#### Component Motion Guide",
+      "",
+      "**Drawer (open/close)**",
+      "",
+      "| Phase | Duration |",
+      "|-------|----------|",
+      "| Open | `duration-slow` |",
+      "",
+      "**Success Toast**",
+      "",
+      "| Phase | Duration |",
+      "|-------|----------|",
+      "| Entry | `duration-base` |",
+      "",
+    ].join("\n");
+    var p = payloadFromMd(md);
+    assert.deepStrictEqual(Object.keys(p.patterns), ["drawer", "success-toast"]);
+    assert.strictEqual(p.patterns.drawer.name, "Drawer (open/close)");
+    assert.strictEqual(p.patterns.drawer.phases[0].Phase, "Open");
+    assert.strictEqual(p.patterns["success-toast"].name, "Success Toast");
+  });
+
+  it("attaches Logic & Accessibility list to current pattern, not as new pattern", function () {
+    var md = [
+      "### 2.9 Motion",
+      "",
+      "#### Component Motion Guide",
+      "",
+      "**Anchor Motion**",
+      "",
+      "| Phase | Duration |",
+      "|-------|----------|",
+      "| Open | `duration-base` |",
+      "",
+      "**Logic & Accessibility**",
+      "",
+      "- Intentionality: apply delay-intent",
+      "- Reduced motion: disable fades",
+      "",
+    ].join("\n");
+    var p = payloadFromMd(md);
+    assert.deepStrictEqual(Object.keys(p.patterns), ["anchor-motion"]);
+    assert.strictEqual(
+      p.patterns["anchor-motion"].logic_and_accessibility.length,
+      2,
+    );
+  });
+
+  it("decodes HTML entities in pattern names", function () {
+    var md = [
+      "### 2.9 Motion",
+      "",
+      "#### Component Motion Guide",
+      "",
+      '**The "Anchor" Motion — Dropdowns**',
+      "",
+      "| Phase | Duration |",
+      "|-------|----------|",
+      "| Open | `duration-base` |",
+      "",
+    ].join("\n");
+    var p = payloadFromMd(md);
+    assert.strictEqual(
+      p.patterns["anchor-motion"].name,
+      'The "Anchor" Motion — Dropdowns',
+    );
+  });
+
+  it("attaches non-bold paragraphs as notes on the current pattern", function () {
+    var md = [
+      "### 2.9 Motion",
+      "",
+      "#### Component Motion Guide",
+      "",
+      "**Staggered Entrance**",
+      "",
+      "| Item | Delay |",
+      "|------|-------|",
+      "| 1 | 0ms |",
+      "",
+      "Cascading effect guides the eye downward.",
+      "",
+    ].join("\n");
+    var p = payloadFromMd(md);
+    assert.deepStrictEqual(p.patterns["staggered-entrance"].notes, [
+      "Cascading effect guides the eye downward.",
+    ]);
+  });
+});

--- a/plugins/actian-design-system/tests/integration/brief-recipes.test.js
+++ b/plugins/actian-design-system/tests/integration/brief-recipes.test.js
@@ -10,25 +10,43 @@ var INDEX_PATH = path.join(RECIPE_DIR, "_index.json");
 test("brief recipes — _index.json exists and references existing files", function () {
   assert.ok(fs.existsSync(INDEX_PATH), "_index.json must exist");
   var idx = JSON.parse(fs.readFileSync(INDEX_PATH, "utf8"));
-  assert.equal(idx.length, 7, "expected exactly 7 cards (Header, Component, Anatomy, Tokens, Usage, Content, Accessibility)");
+  assert.equal(
+    idx.length,
+    8,
+    "expected exactly 8 cards (Header, Component, Anatomy, Tokens, Motion, Usage, Content, Accessibility)",
+  );
   for (var i = 0; i < idx.length; i++) {
     var entry = idx[i];
     assert.ok(entry.file, "entry " + i + " must have file");
     assert.ok(entry.card, "entry " + i + " must have card");
     var filePath = path.join(RECIPE_DIR, entry.file);
-    assert.ok(fs.existsSync(filePath), "recipe file " + entry.file + " must exist");
-    assert.ok(!/^card\d+-/.test(entry.file), "recipe filename " + entry.file + " must not start with card<number>-");
-    assert.ok(!/^card\d+_/.test(entry.card), "recipe card key " + entry.card + " must not start with card<number>_");
+    assert.ok(
+      fs.existsSync(filePath),
+      "recipe file " + entry.file + " must exist",
+    );
+    assert.ok(
+      !/^card\d+-/.test(entry.file),
+      "recipe filename " + entry.file + " must not start with card<number>-",
+    );
+    assert.ok(
+      !/^card\d+_/.test(entry.card),
+      "recipe card key " + entry.card + " must not start with card<number>_",
+    );
   }
 });
 
 test("brief recipes — every recipe declares phase", function () {
   var idx = JSON.parse(fs.readFileSync(INDEX_PATH, "utf8"));
   for (var i = 0; i < idx.length; i++) {
-    var recipe = JSON.parse(fs.readFileSync(path.join(RECIPE_DIR, idx[i].file), "utf8"));
+    var recipe = JSON.parse(
+      fs.readFileSync(path.join(RECIPE_DIR, idx[i].file), "utf8"),
+    );
     assert.ok(
       recipe.phase === "transcribe" || recipe.phase === "generate",
-      "recipe " + idx[i].file + " phase must be 'transcribe' or 'generate', got: " + recipe.phase
+      "recipe " +
+        idx[i].file +
+        " phase must be 'transcribe' or 'generate', got: " +
+        recipe.phase,
     );
   }
 });
@@ -36,9 +54,14 @@ test("brief recipes — every recipe declares phase", function () {
 test("brief recipes — transcribe recipes have source block with primary + fallback", function () {
   var idx = JSON.parse(fs.readFileSync(INDEX_PATH, "utf8"));
   for (var i = 0; i < idx.length; i++) {
-    var recipe = JSON.parse(fs.readFileSync(path.join(RECIPE_DIR, idx[i].file), "utf8"));
+    var recipe = JSON.parse(
+      fs.readFileSync(path.join(RECIPE_DIR, idx[i].file), "utf8"),
+    );
     if (recipe.phase !== "transcribe") continue;
-    assert.ok(recipe.source, "transcribe recipe " + idx[i].file + " must have source block");
+    assert.ok(
+      recipe.source,
+      "transcribe recipe " + idx[i].file + " must have source block",
+    );
     assert.ok(recipe.source.primary, "source.primary required");
     assert.ok(recipe.source.fallback, "source.fallback required");
   }
@@ -47,9 +70,14 @@ test("brief recipes — transcribe recipes have source block with primary + fall
 test("brief recipes — generate recipes have grounding array", function () {
   var idx = JSON.parse(fs.readFileSync(INDEX_PATH, "utf8"));
   for (var i = 0; i < idx.length; i++) {
-    var recipe = JSON.parse(fs.readFileSync(path.join(RECIPE_DIR, idx[i].file), "utf8"));
+    var recipe = JSON.parse(
+      fs.readFileSync(path.join(RECIPE_DIR, idx[i].file), "utf8"),
+    );
     if (recipe.phase !== "generate") continue;
-    assert.ok(Array.isArray(recipe.grounding), "generate recipe " + idx[i].file + " must have grounding array");
+    assert.ok(
+      Array.isArray(recipe.grounding),
+      "generate recipe " + idx[i].file + " must have grounding array",
+    );
   }
 });
 
@@ -58,21 +86,57 @@ test("brief recipes — usage / content / accessibility have research applicable
   var researchCards = ["card_usage", "card_content", "card_accessibility"];
   for (var i = 0; i < idx.length; i++) {
     if (researchCards.indexOf(idx[i].card) === -1) continue;
-    var recipe = JSON.parse(fs.readFileSync(path.join(RECIPE_DIR, idx[i].file), "utf8"));
-    assert.ok(recipe.research, "recipe " + idx[i].file + " must have research block (research-applicable card)");
-    assert.equal(recipe.research.applicable, true, "research.applicable must be true");
-    assert.ok(Array.isArray(recipe.research.focus) && recipe.research.focus.length > 0, "research.focus must be non-empty array");
+    var recipe = JSON.parse(
+      fs.readFileSync(path.join(RECIPE_DIR, idx[i].file), "utf8"),
+    );
+    assert.ok(
+      recipe.research,
+      "recipe " +
+        idx[i].file +
+        " must have research block (research-applicable card)",
+    );
+    assert.equal(
+      recipe.research.applicable,
+      true,
+      "research.applicable must be true",
+    );
+    assert.ok(
+      Array.isArray(recipe.research.focus) && recipe.research.focus.length > 0,
+      "research.focus must be non-empty array",
+    );
   }
 });
 
 test("brief recipes — card5_api and card9_code are gone", function () {
-  assert.ok(!fs.existsSync(path.join(RECIPE_DIR, "card5-api.json")), "card5-api.json must be deleted");
-  assert.ok(!fs.existsSync(path.join(RECIPE_DIR, "card9-code.json")), "card9-code.json must be deleted");
+  assert.ok(
+    !fs.existsSync(path.join(RECIPE_DIR, "card5-api.json")),
+    "card5-api.json must be deleted",
+  );
+  assert.ok(
+    !fs.existsSync(path.join(RECIPE_DIR, "card9-code.json")),
+    "card9-code.json must be deleted",
+  );
   var idx = JSON.parse(fs.readFileSync(INDEX_PATH, "utf8"));
   for (var i = 0; i < idx.length; i++) {
-    assert.notEqual(idx[i].card, "card5_api", "card5_api must not appear in _index.json");
-    assert.notEqual(idx[i].card, "card9_code", "card9_code must not appear in _index.json");
-    assert.notEqual(idx[i].card, "card_api", "card_api must not appear in _index.json");
-    assert.notEqual(idx[i].card, "card_code", "card_code must not appear in _index.json");
+    assert.notEqual(
+      idx[i].card,
+      "card5_api",
+      "card5_api must not appear in _index.json",
+    );
+    assert.notEqual(
+      idx[i].card,
+      "card9_code",
+      "card9_code must not appear in _index.json",
+    );
+    assert.notEqual(
+      idx[i].card,
+      "card_api",
+      "card_api must not appear in _index.json",
+    );
+    assert.notEqual(
+      idx[i].card,
+      "card_code",
+      "card_code must not appear in _index.json",
+    );
   }
 });

--- a/plugins/actian-design-system/tests/transformers/brief-sourcing.test.js
+++ b/plugins/actian-design-system/tests/transformers/brief-sourcing.test.js
@@ -258,3 +258,92 @@ test("formatForBrief — content card shapes content_guidelines.sections into ru
   assert.ok(result.rules.length > 0);
   assert.equal(result._source, "figma");
 });
+
+// ---------------------------------------------------------------------------
+// card_motion — Decision 4 / Brief Refresh v2 / v1.65.0
+// ---------------------------------------------------------------------------
+
+var DRAWER_PATTERN = {
+  name: "Drawer (open/close)",
+  phases: [
+    {
+      Phase: "Open",
+      Duration: "duration-slow",
+      Easing: "ease-entrance",
+      Behavior: "Slides in from the right",
+    },
+    {
+      Phase: "Close",
+      Duration: "duration-base",
+      Easing: "ease-exit",
+      Behavior: "Slides out to the right",
+    },
+  ],
+};
+
+test("card_motion — resolveSection returns figma source when guideline declares a known pattern", function () {
+  var ctx = {
+    component: "Drawer",
+    guidelinesJson: { behavior: { motion: { pattern: "drawer" } } },
+    motionPatterns: { drawer: DRAWER_PATTERN },
+  };
+  var result = sourcing.resolveSection("card_motion", ctx, {
+    phase: "transcribe",
+    grounding: ["docs/foundations.md"],
+  });
+  assert.equal(result.phase, "A");
+  assert.equal(result.source, "figma");
+  assert.equal(result.content.patternSlug, "drawer");
+  assert.equal(result.content.phases.length, 2);
+});
+
+test("card_motion — skipCard when guideline has no behavior.motion", function () {
+  var ctx = {
+    guidelinesJson: { behavior: null },
+    motionPatterns: { drawer: DRAWER_PATTERN },
+  };
+  var result = sourcing.resolveSection("card_motion", ctx, {
+    phase: "transcribe",
+    grounding: ["docs/foundations.md"],
+  });
+  assert.equal(result.phase, "A");
+  assert.equal(result.source, null);
+  assert.equal(result.skipCard, true);
+});
+
+test("card_motion — fallback when slug references unknown pattern", function () {
+  var ctx = {
+    guidelinesJson: {
+      behavior: { motion: { pattern: "nonexistent-pattern" } },
+    },
+    motionPatterns: { drawer: DRAWER_PATTERN },
+  };
+  var result = sourcing.resolveSection("card_motion", ctx, {
+    phase: "transcribe",
+    grounding: ["docs/foundations.md"],
+  });
+  assert.equal(result.phase, "A");
+  assert.equal(result.fallback, true);
+  assert.match(result.fallbackReason, /not found in foundations/);
+});
+
+test("card_motion — formatForBrief preserves phase rows + adds optional fields", function () {
+  var motionResult = {
+    source: "figma",
+    content: {
+      patternSlug: "drawer",
+      patternName: "Drawer (open/close)",
+      phases: DRAWER_PATTERN.phases,
+      logic_and_accessibility: ["Reduced motion: disable fades"],
+      notes: ["Note A"],
+      overrides: "Side nav variant uses faster close",
+    },
+  };
+  var formatted = sourcing.formatForBrief("card_motion", motionResult, {});
+  assert.equal(formatted.patternSlug, "drawer");
+  assert.equal(formatted.phases.length, 2);
+  assert.equal(formatted.logic_and_accessibility.length, 1);
+  assert.equal(formatted.notes.length, 1);
+  assert.equal(formatted.overrides, "Side nav variant uses faster close");
+  assert.equal(formatted._source, "figma");
+});

--- a/plugins/actian-design-system/tests/validation/schema.test.js
+++ b/plugins/actian-design-system/tests/validation/schema.test.js
@@ -711,6 +711,50 @@ test("brief schema — _fallback: true with no _fallbackReason → finding", fun
   );
 });
 
+test("brief schema — card_motion with figma source but missing patternSlug → finding (v1.65.0)", function () {
+  var schema = require("../../scripts/validation/validate-schema.js");
+  var data = {
+    meta: {},
+    card_header: { _source: "figma", description: "x" },
+    card_motion: {
+      _source: "figma",
+      // patternSlug intentionally missing
+      phases: [{ Phase: "Open", Duration: "duration-slow" }],
+    },
+  };
+  var result = schema.validateBriefData(data);
+  assert_ok(
+    result.findings.some(function (f) {
+      return (
+        f.kind === "empty-figma-source" &&
+        f.card === "card_motion" &&
+        /patternSlug is missing/.test(f.message)
+      );
+    }),
+    "expected empty-figma-source finding citing patternSlug for card_motion",
+  );
+});
+
+test("brief schema — card_motion with valid patternSlug + phases → no finding (v1.65.0)", function () {
+  var schema = require("../../scripts/validation/validate-schema.js");
+  var data = {
+    meta: {},
+    card_header: { _source: "figma", description: "x" },
+    card_motion: {
+      _source: "figma",
+      patternSlug: "drawer",
+      phases: [{ Phase: "Open", Duration: "duration-slow" }],
+    },
+  };
+  var result = schema.validateBriefData(data);
+  assert_ok(
+    !result.findings.some(function (f) {
+      return f.card === "card_motion";
+    }),
+    "expected no findings for valid card_motion",
+  );
+});
+
 // ---------------------------------------------------------------------------
 // Summary
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Ships **Brief Refresh v2 Decision 4** — per-component Behavior & motion card, opt-in via `behavior.motion.pattern` in component-guideline JSON.

Cross-DS research found per-component motion docs are rare even in motion-heavy systems (Material 3 keeps motion global; Polaris/Atlassian/Carbon have no per-component motion sections). Inclusion bar = idiosyncratic motion only — components that augment or deviate from a canonical pattern.

The work shipped in one session because **the data was already authored** in `foundations.md` Section 2.9 (10 tokens + 8 named patterns). The remaining gap was structure, not content.

## What's in this PR

**Foundation derive (pattern-indexed JSON):**
- `derive-foundations.js` emits `{ tokens: { duration, easing, delay }, patterns: { drawer, accordion, success-toast, anchor-motion, layered-overlays, skeleton-loading, staggered-entrance, state-transitions } }` instead of flat `rows[]` for section 2.9.
- HTML entities decoded; "Logic & Accessibility" sub-label correctly attached to its parent pattern.

**Brief layer:**
- New `card-motion` recipe (transcribe phase, conditional).
- `brief-sourcing`: `transcribeMotionPattern` + routing that returns `skipCard` when no motion, loud fallback when slug references missing foundations pattern.
- `brief-renderer`: `renderCardMotion` between cards 4 and 6 — pattern reference, phases table, notes, logic & accessibility, overrides.
- Schema, validator, CSS updates.

**Seed authoring (3 components):**
- Drawer → `drawer` pattern
- Modal → `layered-overlays` pattern
- Notification toast → `success-toast` pattern

## Test plan
- [x] 780/780 tests pass (+14 new)
  - 9 unit tests for `buildMotionPayload`, `slugifyPatternName`, HTML-entity decoding, sub-section label handling, notes attachment
  - 4 unit tests for `transcribeMotionPattern` + `formatForBrief` motion shapes
  - 1 updated count assertion in `brief-recipes.test.js` (7 → 8)
- [ ] Render a sample brief on Drawer / Modal / Toast in Cowork after marketplace auto-update; verify the motion card appears with phase rows
- [ ] Verify a non-motion component (e.g., Button) renders 7 cards as before — motion card suppressed
- [ ] Verify a component declaring an unknown pattern slug surfaces the loud fallback message

## Notes for reviewers

- `_index.json` diff is large (157 lines) but only 3 substantive changes (the `has_behavior` flips). The rest is Prettier reformatting from the format-on-save hook collapsing multiline arrays.
- `interaction-motion.json` 390-line diff is the structural shape change (flat → tokens/patterns).
- `card_motion` is the **first new card** added to the brief since sub-project B retired `card_api`/`card_code`. Total card count: 7 → 8 (Header, Component, Anatomy, Tokens, **Motion**, Usage, Content, Accessibility).
- Authoring path for new motion blocks is small (~3 lines per component); Kristina can add motion data to remaining candidates (Side nav, Skeleton, Drawer-side-panel) opportunistically.
- C-slots and other Brief Refresh v2 phases are unaffected by this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)