### PR TITLE
ci: Tier 1 PR checks — test suite + JSON syntax + version bump

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -1,0 +1,60 @@
+name: PR checks
+
+# Tier 1 PR gates for the Actian Design System plugin.
+# Three parallel jobs:
+#   1. test            — runs the plugin's full test suite
+#   2. json-syntax     — validates that all checked-in JSON files parse
+#   3. version-bump    — ensures plugin.json is bumped when source changes
+#
+# Path-filtered to plugins/actian-design-system/** so unrelated PRs (docs/,
+# comms/, .github/ on its own) don't waste CI minutes.
+#
+# Tiered plan + rationale: see memory/project_ci_pr_checks.md.
+
+on:
+  pull_request:
+    paths:
+      - 'plugins/actian-design-system/**'
+
+jobs:
+  test:
+    name: Test suite
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - uses: actions/setup-node@v5
+        with:
+          node-version: '22'
+      - name: Install plugin deps
+        working-directory: plugins/actian-design-system
+        run: npm install --no-audit --no-fund
+      - name: Run test suite
+        working-directory: plugins/actian-design-system
+        run: |
+          set -euo pipefail
+          find tests -name '*.test.js' -type f -print0 \
+            | xargs -0 node --test
+
+  json-syntax:
+    name: JSON syntax
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - uses: actions/setup-node@v5
+        with:
+          node-version: '22'
+      - name: Validate JSON files parse
+        run: node .github/workflows/scripts/check-json-syntax.js
+
+  version-bump:
+    name: plugin.json bumped
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+      - name: Verify plugin.json version bump
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: node .github/workflows/scripts/check-version-bump.js

--- a/.github/workflows/scripts/check-json-syntax.js
+++ b/.github/workflows/scripts/check-json-syntax.js
@@ -1,0 +1,116 @@
+#!/usr/bin/env node
+"use strict";
+
+/**
+ * check-json-syntax.js — PR gate that walks the plugin's checked-in JSON
+ * files and fails fast on any file that doesn't parse. Catches malformed
+ * JSON from manual edits or merge conflicts before merge.
+ *
+ * Scope: every .json file under plugins/actian-design-system/ except those
+ * that live inside ignore prefixes (node_modules, .git). Includes registries,
+ * recipes, schemas, fixtures, the plugin manifest, and the foundations
+ * generated outputs.
+ *
+ * Output: one line per failing file with the parser message + position.
+ * Exit 0 on success, 1 if any file fails.
+ */
+
+var fs = require("fs");
+var path = require("path");
+
+var PLUGIN_ROOT = path.resolve(
+  __dirname,
+  "..",
+  "..",
+  "..",
+  "plugins",
+  "actian-design-system",
+);
+
+// Directories whose contents we never want to walk (huge, third-party, or
+// not version-controlled). Path comparisons are name-based at any depth.
+var IGNORED_DIRS = new Set([
+  "node_modules",
+  ".git",
+  ".DS_Store",
+]);
+
+function walk(dir, out) {
+  var entries;
+  try {
+    entries = fs.readdirSync(dir, { withFileTypes: true });
+  } catch (err) {
+    // Plugin layout may shift; surface but don't crash on missing dirs.
+    if (err.code === "ENOENT") return;
+    throw err;
+  }
+  for (var i = 0; i < entries.length; i++) {
+    var entry = entries[i];
+    var full = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      if (IGNORED_DIRS.has(entry.name)) continue;
+      walk(full, out);
+      continue;
+    }
+    if (entry.isFile() && entry.name.endsWith(".json")) {
+      out.push(full);
+    }
+  }
+}
+
+function relPath(p) {
+  return path.relative(PLUGIN_ROOT, p);
+}
+
+function main() {
+  if (!fs.existsSync(PLUGIN_ROOT)) {
+    process.stderr.write(
+      "[check-json-syntax] plugin root not found: " + PLUGIN_ROOT + "\n",
+    );
+    process.exit(2);
+  }
+  var files = [];
+  walk(PLUGIN_ROOT, files);
+
+  var failures = [];
+  for (var i = 0; i < files.length; i++) {
+    var f = files[i];
+    var src;
+    try {
+      src = fs.readFileSync(f, "utf8");
+    } catch (err) {
+      failures.push({ file: f, message: "read error: " + err.message });
+      continue;
+    }
+    try {
+      JSON.parse(src);
+    } catch (err) {
+      failures.push({ file: f, message: err.message });
+    }
+  }
+
+  process.stdout.write(
+    "[check-json-syntax] checked " + files.length + " JSON files\n",
+  );
+
+  if (failures.length === 0) {
+    process.stdout.write("[check-json-syntax] all files parse cleanly\n");
+    return 0;
+  }
+
+  process.stderr.write(
+    "[check-json-syntax] " + failures.length + " file(s) failed to parse:\n",
+  );
+  for (var j = 0; j < failures.length; j++) {
+    process.stderr.write(
+      "  " + relPath(failures[j].file) + " — " + failures[j].message + "\n",
+    );
+  }
+  return 1;
+}
+
+if (require.main === module) {
+  process.exit(main());
+}
+
+module.exports = { walk, main };

--- a/.github/workflows/scripts/check-version-bump.js
+++ b/.github/workflows/scripts/check-version-bump.js
@@ -1,0 +1,158 @@
+#!/usr/bin/env node
+"use strict";
+
+/**
+ * check-version-bump.js — PR gate that requires plugin.json#version to be
+ * bumped whenever PR-modified files under plugins/actian-design-system/
+ * include any "source" file (anything except generated outputs and the
+ * plugin manifest itself).
+ *
+ * Per CLAUDE.md: "Bump as part of the feature/fix commit, not separately."
+ * Per memory feedback_version_bump.md: "Always bump plugin version in
+ * plugin.json before pushing."
+ *
+ * Inputs (env vars set by GitHub Actions):
+ *   BASE_SHA — SHA the PR is targeting
+ *   HEAD_SHA — SHA at the tip of the PR branch
+ *
+ * Behaviour:
+ *   - Lists files changed between BASE_SHA and HEAD_SHA
+ *   - Filters to plugins/actian-design-system/** that aren't auto-generated
+ *     (docs/generated/**) or the manifest itself
+ *   - If no source files changed: pass (nothing to enforce)
+ *   - If source files changed and version is unchanged from base: fail
+ *   - If source files changed and version is bumped: pass
+ *
+ * The auto-bump-on-data-sync workflow (sync-from-figma.yml, derive-foundations
+ * via shared bump-version.js) covers automated bumps; this gate covers
+ * human-authored PRs.
+ */
+
+var fs = require("fs");
+var path = require("path");
+var { execFileSync } = require("child_process");
+
+var PLUGIN_PREFIX = "plugins/actian-design-system/";
+var MANIFEST_REL = ".claude-plugin/plugin.json";
+var MANIFEST_PATH = PLUGIN_PREFIX + MANIFEST_REL;
+// Paths inside the plugin that don't count as "source" for the bump rule:
+// generated artifacts (CI rewrites them) and the manifest itself (a bump
+// touches plugin.json so this would otherwise self-trigger).
+var IGNORED_PREFIXES = [
+  PLUGIN_PREFIX + "docs/generated/",
+  MANIFEST_PATH,
+];
+
+function git() {
+  var args = Array.prototype.slice.call(arguments);
+  return execFileSync("git", args, { encoding: "utf8" });
+}
+
+function changedPlatformSourceFiles(baseSha, headSha) {
+  var raw = git("diff", "--name-only", baseSha + ".." + headSha);
+  var lines = raw
+    .split("\n")
+    .map(function (s) {
+      return s.trim();
+    })
+    .filter(Boolean);
+  var sourceFiles = [];
+  for (var i = 0; i < lines.length; i++) {
+    var f = lines[i];
+    if (f.indexOf(PLUGIN_PREFIX) !== 0) continue;
+    var ignored = false;
+    for (var j = 0; j < IGNORED_PREFIXES.length; j++) {
+      if (f === IGNORED_PREFIXES[j]) {
+        ignored = true;
+        break;
+      }
+      if (f.indexOf(IGNORED_PREFIXES[j]) === 0) {
+        ignored = true;
+        break;
+      }
+    }
+    if (!ignored) sourceFiles.push(f);
+  }
+  return sourceFiles;
+}
+
+function readManifestVersion(sha) {
+  // `git show <sha>:path` returns the file contents at that revision.
+  try {
+    var raw = git("show", sha + ":" + MANIFEST_PATH);
+    var parsed = JSON.parse(raw);
+    return parsed.version || null;
+  } catch (err) {
+    // Manifest may not have existed at base (rare). Treat as null.
+    return null;
+  }
+}
+
+function readManifestVersionFromDisk() {
+  var p = path.resolve(MANIFEST_PATH);
+  var raw = fs.readFileSync(p, "utf8");
+  return JSON.parse(raw).version || null;
+}
+
+function main() {
+  var baseSha = process.env.BASE_SHA;
+  var headSha = process.env.HEAD_SHA;
+  if (!baseSha || !headSha) {
+    process.stderr.write(
+      "[check-version-bump] BASE_SHA and HEAD_SHA must be set\n",
+    );
+    return 2;
+  }
+
+  var sourceFiles = changedPlatformSourceFiles(baseSha, headSha);
+  if (sourceFiles.length === 0) {
+    process.stdout.write(
+      "[check-version-bump] no plugin source files changed; nothing to enforce\n",
+    );
+    return 0;
+  }
+
+  var baseVersion = readManifestVersion(baseSha);
+  var headVersion = readManifestVersionFromDisk();
+  process.stdout.write(
+    "[check-version-bump] base " +
+      (baseVersion || "<unknown>") +
+      " → head " +
+      headVersion +
+      "\n",
+  );
+  process.stdout.write(
+    "[check-version-bump] " +
+      sourceFiles.length +
+      " source file(s) changed:\n",
+  );
+  for (var i = 0; i < sourceFiles.length; i++) {
+    process.stdout.write("  " + sourceFiles[i] + "\n");
+  }
+
+  if (baseVersion && headVersion && baseVersion === headVersion) {
+    process.stderr.write(
+      "[check-version-bump] FAIL: plugin.json version unchanged (" +
+        headVersion +
+        ") despite source file changes.\n",
+    );
+    process.stderr.write(
+      "  Bump plugins/actian-design-system/.claude-plugin/plugin.json " +
+        "version (PATCH for fixes, MINOR for features, MAJOR for breaking).\n",
+    );
+    return 1;
+  }
+
+  process.stdout.write("[check-version-bump] OK\n");
+  return 0;
+}
+
+if (require.main === module) {
+  process.exit(main());
+}
+
+module.exports = {
+  changedPlatformSourceFiles: changedPlatformSourceFiles,
+  readManifestVersion: readManifestVersion,
+  main: main,
+};


### PR DESCRIPTION
## Summary

Three parallel PR-gate jobs, path-filtered to `plugins/actian-design-system/**`:

| Job | What | Catches |
|---|---|---|
| **test** | `find tests -name '*.test.js' \| xargs node --test` | Any regression covered by 781 existing tests |
| **json-syntax** | walks every `.json` under the plugin and `JSON.parse`s it (~170 files) | Malformed JSON from manual edits / merge conflicts |
| **version-bump** | diffs `base..head`, filters to source files, fails if source changed without bumping `plugin.json#version` | Forgotten version bumps (per `CLAUDE.md` rule) |

## Why now

Post-PR-#17 finding: the test suite **never ran on PR**. The only existing PR check was `foundations-derive` (path-filtered to `foundations.md`). v1.65.0 motion card merged with 781 tests passing locally but never exercised by CI.

## Test plan
- [x] `node .github/workflows/scripts/check-json-syntax.js` — checks 176 files, all parse cleanly
- [x] `BASE_SHA=… HEAD_SHA=… node .github/workflows/scripts/check-version-bump.js` — correctly reports "no plugin source files changed; nothing to enforce" for this PR
- [ ] **Self-test caveat:** this PR only touches `.github/`, so its own workflow won't fire (path filter excludes). The next `plugins/**` PR will exercise all three jobs end-to-end.
- [ ] After merge, monitor the first plugin PR to validate test/json-syntax/version-bump all run and surface clearly in the PR UI.

## What's deferred to Tier 2-4

Prettier check, schema-vs-fixture validation, linkrot, conventional commits, tokens-only rule, visual regression — full plan in `memory/project_ci_pr_checks.md`. Triggers documented for each.

## Notes for reviewers

- Helpers live under `.github/workflows/scripts/` alongside the existing `foundations-pr-comment.js`.
- The `version-bump` ignore list explicitly excludes `docs/generated/**` (auto-regenerated) and `plugin.json` itself (a bump is the manifest change).
- If a future PR touches only generated/manifest paths, the bump check passes with "nothing to enforce" — appropriate.
- The `test` job uses `npm install` (matches existing `foundations-derive` pattern) — if `package-lock.json` lands later we can switch to `npm ci`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)