### PR TITLE
feat(briefs): motion authoring for 5 components + cwd fix on version-bump check (v1.65.2)

### DIFF
--- a/.github/workflows/scripts/check-version-bump.js
+++ b/.github/workflows/scripts/check-version-bump.js
@@ -32,6 +32,9 @@ var fs = require("fs");
 var path = require("path");
 var { execFileSync } = require("child_process");
 
+// Repo root, derived from __dirname so the script works from any cwd
+// (CI runs from $GITHUB_WORKSPACE; locally we may run from anywhere).
+var REPO_ROOT = path.resolve(__dirname, "..", "..", "..");
 var PLUGIN_PREFIX = "plugins/actian-design-system/";
 var MANIFEST_REL = ".claude-plugin/plugin.json";
 var MANIFEST_PATH = PLUGIN_PREFIX + MANIFEST_REL;
@@ -45,7 +48,7 @@ var IGNORED_PREFIXES = [
 
 function git() {
   var args = Array.prototype.slice.call(arguments);
-  return execFileSync("git", args, { encoding: "utf8" });
+  return execFileSync("git", args, { encoding: "utf8", cwd: REPO_ROOT });
 }
 
 function changedPlatformSourceFiles(baseSha, headSha) {
@@ -89,7 +92,7 @@ function readManifestVersion(sha) {
 }
 
 function readManifestVersionFromDisk() {
-  var p = path.resolve(MANIFEST_PATH);
+  var p = path.join(REPO_ROOT, MANIFEST_PATH);
   var raw = fs.readFileSync(p, "utf8");
   return JSON.parse(raw).version || null;
 }

--- a/plugins/actian-design-system/.claude-plugin/plugin.json
+++ b/plugins/actian-design-system/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "actian-design-system",
   "description": "Actian Design System toolkit — sync tokens from Figma, generate wireframe flows with prototype wiring, create component briefs, audit designs, compare flows, and build presentations. 9 skills (with tiered generation: recognized / adapted / improvised), 8 agents, 155 tokens (3 themes, 8 collections), WCAG 2.1 AA.",
-  "version": "1.65.1",
+  "version": "1.65.2",
   "author": {
     "name": "Actian UX Team"
   },

--- a/plugins/actian-design-system/docs/component-guidelines/_index.json
+++ b/plugins/actian-design-system/docs/component-guidelines/_index.json
@@ -520,7 +520,7 @@
       "has_design_guidelines": false,
       "has_examples": false,
       "has_screenshots": true,
-      "has_behavior": false,
+      "has_behavior": true,
       "frames_found": ["Components", "Screenshots of current use cases"],
       "frames_missing": [
         "Content guidelines",
@@ -657,7 +657,7 @@
       "has_design_guidelines": false,
       "has_examples": false,
       "has_screenshots": false,
-      "has_behavior": false,
+      "has_behavior": true,
       "frames_found": ["Behavior demo"],
       "frames_missing": [
         "Content guidelines",
@@ -804,7 +804,7 @@
       "has_design_guidelines": true,
       "has_examples": false,
       "has_screenshots": true,
-      "has_behavior": false,
+      "has_behavior": true,
       "frames_found": [
         "Design guidelines",
         "Components",
@@ -1222,7 +1222,7 @@
       "has_design_guidelines": false,
       "has_examples": false,
       "has_screenshots": false,
-      "has_behavior": false,
+      "has_behavior": true,
       "frames_found": [],
       "frames_missing": [
         "Design guidelines",
@@ -1348,7 +1348,7 @@
       "has_design_guidelines": false,
       "has_examples": false,
       "has_screenshots": false,
-      "has_behavior": false,
+      "has_behavior": true,
       "frames_found": [],
       "frames_missing": [
         "Design guidelines",

--- a/plugins/actian-design-system/docs/component-guidelines/drawer-side-panel.json
+++ b/plugins/actian-design-system/docs/component-guidelines/drawer-side-panel.json
@@ -17,14 +17,17 @@
   "design_guidelines": null,
   "variants": {
     "axes": {
-      "App": [
-        "Studio",
-        "Explorer"
-      ]
+      "App": ["Studio", "Explorer"]
     },
     "totalVariants": 2
   },
   "examples": null,
   "screenshots": null,
-  "behavior": null
+  "behavior": {
+    "motion": {
+      "pattern": "drawer",
+      "overrides": null,
+      "notes": "Same canonical drawer choreography as the Drawer component (open: duration-slow + ease-entrance, close: duration-base + ease-exit). Note: this guideline is a stub — the motion data is forward-compatible; brief output requires the stub to be curated first OR card_motion routing to be updated to bypass the stub short-circuit."
+    }
+  }
 }

--- a/plugins/actian-design-system/docs/component-guidelines/loading-skeleton.json
+++ b/plugins/actian-design-system/docs/component-guidelines/loading-skeleton.json
@@ -17,14 +17,17 @@
   "design_guidelines": null,
   "variants": {
     "axes": {
-      "Transition": [
-        "1",
-        "2"
-      ]
+      "Transition": ["1", "2"]
     },
     "totalVariants": 2
   },
   "examples": null,
   "screenshots": null,
-  "behavior": null
+  "behavior": {
+    "motion": {
+      "pattern": "skeleton-loading",
+      "overrides": null,
+      "notes": "Continuous 2000ms linear shimmer (looping); not tokenized — value is fixed. Provides visual confirmation the system is active and reduces perceived wait time for data-heavy views. Note: this guideline is a stub — motion data is forward-compatible."
+    }
+  }
 }

--- a/plugins/actian-design-system/docs/component-guidelines/popover.json
+++ b/plugins/actian-design-system/docs/component-guidelines/popover.json
@@ -17,6 +17,12 @@
   "variants": null,
   "examples": null,
   "screenshots": null,
-  "behavior": null,
+  "behavior": {
+    "motion": {
+      "pattern": "anchor-motion",
+      "overrides": null,
+      "notes": "Popover uses the anchor-motion pattern (same as tooltips and dropdowns). Open: duration-base + ease-entrance, fades in + scales up from trigger. Close: duration-fast + ease-standard."
+    }
+  },
   "_note": "Figma MCP tool call limit reached before metadata could be retrieved for this page. Re-run extraction when API quota resets."
 }

--- a/plugins/actian-design-system/docs/component-guidelines/side-nav.json
+++ b/plugins/actian-design-system/docs/component-guidelines/side-nav.json
@@ -2,9 +2,7 @@
   "component": "Side nav",
   "page_id": "13599:19122",
   "extracted_at": "2026-03-25T00:00:00Z",
-  "frames_found": [
-    "Behavior demo"
-  ],
+  "frames_found": ["Behavior demo"],
   "frames_missing": [
     "Content guidelines",
     "design guidelines",
@@ -17,5 +15,11 @@
   "variants": null,
   "examples": null,
   "screenshots": null,
-  "behavior": null
+  "behavior": {
+    "motion": {
+      "pattern": "drawer",
+      "overrides": null,
+      "notes": "Side nav uses the canonical drawer choreography. Open: duration-slow + ease-entrance; close: duration-base + ease-exit. Collapse-to-rail variant follows the same timing but animates width instead of x-translation."
+    }
+  }
 }

--- a/plugins/actian-design-system/docs/component-guidelines/tooltip.json
+++ b/plugins/actian-design-system/docs/component-guidelines/tooltip.json
@@ -2,9 +2,7 @@
   "component": "Tooltip",
   "page_id": "9253:37504",
   "extracted_at": "2026-03-26T00:00:00Z",
-  "frames_found": [
-    "Design guidelines"
-  ],
+  "frames_found": ["Design guidelines"],
   "frames_missing": [
     "Content guidelines",
     "Components",
@@ -21,27 +19,12 @@
         "heading": "Elements",
         "tables": [
           {
-            "headers": [
-              "Element name",
-              "Values"
-            ],
+            "headers": ["Element name", "Values"],
             "rows": [
-              [
-                "Title (optional)",
-                "Heading 2XS"
-              ],
-              [
-                "Body",
-                "Body SM"
-              ],
-              [
-                "Actions (optional)",
-                "TBD (small ghost buttons)"
-              ],
-              [
-                "Container",
-                "CoolGrey90, radius 4px"
-              ]
+              ["Title (optional)", "Heading 2XS"],
+              ["Body", "Body SM"],
+              ["Actions (optional)", "TBD (small ghost buttons)"],
+              ["Container", "CoolGrey90, radius 4px"]
             ]
           }
         ]
@@ -86,9 +69,7 @@
       },
       {
         "heading": "Clearance",
-        "items": [
-          "Keep 2px clearance between the target area and the tooltip."
-        ]
+        "items": ["Keep 2px clearance between the target area and the tooltip."]
       },
       {
         "heading": "Spacing",
@@ -102,9 +83,7 @@
       },
       {
         "heading": "Maximum width",
-        "items": [
-          "The maximum width of the tooltip is 200px."
-        ]
+        "items": ["The maximum width of the tooltip is 200px."]
       },
       {
         "heading": "Positioning",
@@ -119,5 +98,11 @@
   "variants": null,
   "examples": null,
   "screenshots": null,
-  "behavior": null
+  "behavior": {
+    "motion": {
+      "pattern": "anchor-motion",
+      "overrides": null,
+      "notes": "Tooltip is the canonical anchor-motion case. Open: duration-base + ease-entrance, fades in + scales up from trigger. Close: duration-fast + ease-standard. Apply delay-intent (300ms) for hover-triggered tooltips to prevent accidental triggers; keyboard focus (Tab) ignores the delay."
+    }
+  }
 }

--- a/plugins/actian-design-system/tests/integration/path-validation.test.js
+++ b/plugins/actian-design-system/tests/integration/path-validation.test.js
@@ -31,15 +31,18 @@ var SCAN_DIRS = [
 
 var SCAN_FILES = [path.join(PLUGIN_ROOT, "CLAUDE.md")];
 
-// Paths that only exist after running /sync-design-system.
-// These are expected outputs referenced in sync skill docs — skip them in assertions
-// but still log them so they stay visible.
+// Paths that only exist after running /sync-design-system, or are
+// gitignored secrets/local-only files. These are referenced in skill docs
+// — skip them in assertions but still log them so they stay visible.
 var KNOWN_SYNC_OUTPUTS = [
   "docs/generated/meta-kit/meta-kit-reference.md",
   "tokens/actian-ds.tokens.css",
   "docs/foundations/_index.json",
   // Sprint 1 Wave 1: REST orchestrator output, populated on first nightly run.
   "docs/generated/meta-kit/styles.json",
+  // Gitignored: contains the Figma PAT. Materialized from FIGMA_KEYS_JSON
+  // secret in the sync-from-figma workflow; never committed.
+  ".figma-keys.json",
 ];
 
 // Known root-relative prefixes (resolve from plugin root)


### PR DESCRIPTION
## Summary

**Motion authoring batch** — adds `behavior.motion.pattern` to 5 more component guidelines, lifting curated motion coverage from 3 → 8 components. Also exercises the brand-new Tier 1 PR check workflow end-to-end (this is the first plugin-touching PR since #18 merged).

| Component | Pattern | Notes |
|---|---|---|
| Side nav | `drawer` | Same canonical choreography; collapse-to-rail uses width animation but same tokens |
| Drawer / Side panel (stub) | `drawer` | Forward-compatible — output requires un-stubbing or routing tweak |
| Loading skeleton (stub) | `skeleton-loading` | Forward-compatible (same caveat) |
| Tooltip | `anchor-motion` | Canonical anchor-motion case with `delay-intent` for hover |
| Popover | `anchor-motion` | Same anchor pattern |

## Plus a small CI helper fix

While running `check-version-bump.js` locally from inside `plugins/actian-design-system/`, hit a path-doubling bug — `MANIFEST_PATH` was resolved against cwd. CI didn't trip on it (GH Actions defaults to `$GITHUB_WORKSPACE` = repo root), but the helper is now cwd-independent (resolves from `__dirname`).

## Test plan
- [x] 781/781 tests pass
- [x] `check-json-syntax.js` — 176 files clean
- [x] `check-version-bump.js` — correctly detects 6 source files changed + bump 1.65.1 → 1.65.2
- [ ] **End-to-end Tier 1 validation:** this is the first plugin PR since #18; expect to see `test`, `json-syntax`, and `plugin.json bumped` jobs run on this PR. If they don't show up, path filter is wrong. If any fail, that's the new-CI feedback we wanted.

## Notes for reviewers

- The 2 stubs (`drawer-side-panel`, `loading-skeleton`) get motion blocks that won't surface in briefs today because `brief-sourcing.js` short-circuits stubs to Phase B. Forward-compatible — when the stubs are curated OR if we extend `card_motion` routing to bypass the stub gate, the data is ready.
- Routing extension is a small follow-up if/when designers want stubs to surface motion. Tracked informally; not in scope here.
- `_index.json` `has_behavior` flipped for all 5.

🤖 Generated with [Claude Code](https://claude.com/claude-code)