### PR TITLE
docs: refresh README + plugin CLAUDE.md through v1.66.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Iterate inside the loop with **refine** (paste a screen-frame URL + edit instruc
 
 The guidelines hold throughout — tokens, spacing, content rules, accessibility — but the output stays creative within them.
 
-**v1.64.0** · 9 skills (tiered generation: recognized / adapted / improvised) · 9 agents · 23 recipes · 155 design tokens across 8 collections · 3 themes · WCAG 2.1 AA · surgical refine engine · vision-grounded references · interactive gates · MD-as-SoT foundations
+**v1.66.0** · 9 skills (tiered generation: recognized / adapted / improvised) · 9 agents · 23 recipes · 155 design tokens across 8 collections · 3 themes · WCAG 2.1 AA · surgical refine engine · vision-grounded references · interactive gates · MD-as-SoT foundations · 6-section component briefs (anatomy + tokens / usages / content / motion / accessibility / real examples)
 
 ---
 
@@ -169,7 +169,7 @@ Every capability is also available as a direct command. Use these when you know 
 
 | Command | What it does |
 |---------|-------------|
-| `/component-brief` | 7-card component spec — header, component, anatomy, tokens, usage, content, accessibility. Two-pass (v1.62.0+): Phase A transcribes synced guidelines into the data model with provenance badges; Phase B fills gaps and (opt-in) attaches cross-DS research insights. Stub-aware: components with auto-generated stub guidelines route through Phase B fallback and surface a stub footer cue. |
+| `/component-brief` | Component spec organized into 6 sections (v1.66.0+): Header → §1 Anatomy / variation / tokens / specs → §2 Usages → §3 Content guidelines & examples → §4 Motion (conditional, only when applicable) → §5 Accessibility → §6 Real platform examples. Two-pass (v1.62.0+): Phase A transcribes synced guidelines into the data model with provenance badges; Phase B fills gaps and (opt-in) attaches cross-DS research insights. Stub-aware: components with auto-generated stub guidelines route through Phase B fallback and surface a stub footer cue. |
 | `/create-component` | Build Figma components with variants and correct token binding, with a build plan review before push |
 | `/compare-flows` | Side-by-side analysis of two Figma flows — v1 vs v2, competing approaches, branches, variants |
 | `/generate-presentation` | Slide deck with Actian templates, token-bound backgrounds, and chart support |
@@ -212,7 +212,7 @@ The companion has always-loaded knowledge of:
 - **Content rules** — sentence case, action verbs, error message patterns, empty state CTAs
 - **App context** — Studio (integration/catalog), Explorer (discovery), Administration (settings/users) — structured as queryable JSON with entities, terminology rules, and UI patterns
 - **Component inventory** — 322 DS Kit + 287 FM Kit + 28 Meta Kit components (82 / 33 / 11 sets) — dynamically derived from synced registries
-- **Component guidelines** — 85 per-component guideline JSONs (45 fully covered, 40 auto-stubs for set components awaiting authoring)
+- **Component guidelines** — 85 per-component guideline JSONs (44 fully curated, 41 auto-stubs for set components awaiting authoring)
 
 It loads detailed references on demand: per-component guidelines, accessibility standards, UX patterns, foundation docs.
 

--- a/plugins/actian-design-system/.claude-plugin/plugin.json
+++ b/plugins/actian-design-system/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "actian-design-system",
   "description": "Actian Design System toolkit — sync tokens from Figma, generate wireframe flows with prototype wiring, create component briefs, audit designs, compare flows, and build presentations. 9 skills (with tiered generation: recognized / adapted / improvised), 8 agents, 155 tokens (3 themes, 8 collections), WCAG 2.1 AA.",
-  "version": "1.66.0",
+  "version": "1.66.1",
   "author": {
     "name": "Actian UX Team"
   },

--- a/plugins/actian-design-system/CLAUDE.md
+++ b/plugins/actian-design-system/CLAUDE.md
@@ -49,7 +49,7 @@ This applies to freelance diagnostics too — if you're tempted to `node -e` som
 Data flows: `Figma -> /sync-design-system (MCP) -> docs/ + tokens/`. JSON is source of truth; Markdown is for human review.
 
 **Key data files** — JSON registries are SoT; `*-components.md` are auto-regenerated mirrors via `/sync-design-system` Phase 1:
-- `docs/component-guidelines/*.json` — 44 component guidelines
+- `docs/component-guidelines/*.json` — 85 component guidelines (44 fully curated + 41 auto-stubs awaiting authoring; stubs carry `_stub: true`)
 - `docs/generated/fmkit.json` / `docs/generated/dskit.json` / `docs/generated/metakit.json` — component registries (keys, variants, properties, defaults)
 - `docs/generated/fm-components.md` / `docs/generated/dskit-components.md` / `docs/generated/meta-kit/components.md` — human-readable mirrors with required-override callouts
 - `docs/generated/app-context.json` — structured app context (apps, entities, terminology, patterns)


### PR DESCRIPTION
## Summary

Doc-only refresh after v1.66.0 ships. No code changes.

- **README.md**
  - Version line: `v1.64.0` → `v1.66.0`; added 6-section brief structure to the always-loaded knowledge tagline.
  - `/component-brief` row rewritten to describe the new 6-section organization (Header → §1 Anatomy/variation/tokens/specs → §2 Usages → §3 Content → §4 Motion conditional → §5 Accessibility → §6 Real platform examples) instead of the old 7-card listing.
  - Guideline counts corrected: 85 total → 44 fully curated + 41 auto-stubs (was 45 / 40, off by one).

- **plugins/actian-design-system/CLAUDE.md**
  - Key-data-files line updated from "44 component guidelines" to "85 (44 full + 41 auto-stubs awaiting authoring; stubs carry \`_stub: true\`)" so a reader isn't surprised by 41 extra files in `docs/component-guidelines/`.

## Test plan

- [x] No tests touched, no code changes
- [ ] Visual diff review — links and headings still render correctly on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)