### PR TITLE
fix(brief): stop overriding Card padding so Meta Kit edits stick (v1.66.2)

### DIFF
--- a/plugins/actian-design-system/.claude-plugin/plugin.json
+++ b/plugins/actian-design-system/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "actian-design-system",
   "description": "Actian Design System toolkit — sync tokens from Figma, generate wireframe flows with prototype wiring, create component briefs, audit designs, compare flows, and build presentations. 9 skills (with tiered generation: recognized / adapted / improvised), 8 agents, 155 tokens (3 themes, 8 collections), WCAG 2.1 AA.",
-  "version": "1.66.1",
+  "version": "1.66.2",
   "author": {
     "name": "Actian UX Team"
   },

--- a/plugins/actian-design-system/references/component-brief/push-patterns.md
+++ b/plugins/actian-design-system/references/component-brief/push-patterns.md
@@ -97,16 +97,15 @@ if (cardHeader) {
   });
 }
 
-// Find content slot for child injection
+// Find content slot for child injection.
+// IMPORTANT (v1.66.2+): do NOT override padding / itemSpacing / layoutMode
+// here. The detached frame inherits Meta Kit's auto-layout values, and
+// those are the source of truth — overriding them in code makes Meta Kit
+// edits invisible (the "Card padding doesn't pick up" symptom).
+// If a content slot lands without auto-layout (rare, only on legacy
+// instances), fix the Meta Kit component rather than re-introducing
+// hardcoded values here.
 const contentSlot = cardFrame.findOne(n => n.name === "Content");
-if (contentSlot) {
-  contentSlot.layoutMode = "VERTICAL";
-  contentSlot.itemSpacing = 16;
-  contentSlot.paddingTop = 48;
-  contentSlot.paddingBottom = 48;
-  contentSlot.paddingLeft = 80;
-  contentSlot.paddingRight = 80;
-}
 
 // Append to wrapper
 const wrapper = await figma.getNodeByIdAsync("<wrapperId>");

--- a/plugins/actian-design-system/scripts/renderers/html-renderers/brief-renderer.css
+++ b/plugins/actian-design-system/scripts/renderers/html-renderers/brief-renderer.css
@@ -223,10 +223,17 @@ td code {
   overflow: hidden;
   flex-shrink: 0;
   background: white;
-  padding: 48px;
+  padding: 80px;
 }
 .card-section-header {
-  padding: 48px 48px 0;
+  padding: 80px 80px 0;
+}
+/* Scoped to DS-mode brief cards — keep FM .card-content untouched. */
+.brief-card .card-content {
+  padding: 80px;
+}
+.brief-card .card-divider {
+  margin: 0 80px;
 }
 .card-section-header__title {
   font-weight: 600;
@@ -260,6 +267,7 @@ td code {
   font-family:
     "JetBrains Mono", ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
 }
+/* Default divider margin — overridden to 80px inside .brief-card scope above. */
 .card-divider {
   height: 1px;
   background: #e2e7f0;


### PR DESCRIPTION
## Summary

**Reported symptom:** changes Kristina made to Card padding + typography in Meta Kit weren't being picked up by generated briefs.

**Cause:** the push pattern at \`references/component-brief/push-patterns.md\` detached the Card instance and then immediately wrote hardcoded values on top of the Content slot — overwriting whatever auto-layout values Meta Kit defined.

\`\`\`js
const contentSlot = cardFrame.findOne(n => n.name === \"Content\");
if (contentSlot) {
  contentSlot.layoutMode = \"VERTICAL\";
  contentSlot.itemSpacing = 16;
  contentSlot.paddingTop = 48;     // ← clobbered Meta Kit value
  contentSlot.paddingBottom = 48;  // ← clobbered
  contentSlot.paddingLeft = 80;    // ← clobbered
  contentSlot.paddingRight = 80;   // ← clobbered
}
\`\`\`

## Fix

- **Remove the override block.** The detached frame inherits Meta Kit's auto-layout — that's the source of truth for Card chrome.
- **Comment** explaining why the block must stay removed (don't reintroduce in response to layout regressions; fix Meta Kit instead).
- **Sync \`brief-renderer.css\`** to the 80px directive so the HTML preview matches the Figma chrome:
  - \`.brief-card--header\` padding: 48 → 80
  - \`.card-section-header\` padding: 48/48/0 → 80/80/0
  - Scoped \`.brief-card .card-content { padding: 80px }\` (FM mode \`.card-content\` is unaffected — different class scope)
  - Scoped \`.brief-card .card-divider { margin: 0 80px }\`

## Card Header behavior

Card Header (the nested live instance inside the Card after detach) was *already* not overridden — only Title / Subtitle / Show Subtitle text are set via \`setProperties\`. So Kristina's Card Header typography + padding changes will be picked up automatically once:
1. The Meta Kit library is **republished** in Figma.
2. The target Figma file **refreshes the cached library** (Figma sometimes prompts \"Update components\"; otherwise force via Assets panel).

If after both steps the Card Header still looks wrong, the issue is upstream of this plugin.

## Numbers

- Version: \`1.66.1\` → \`1.66.2\`
- Tests: 785/785 passing
- 3 files changed

## Test plan

- [x] Test suite passes (785/785)
- [ ] Visual smoke on Cowork: \`/component-brief Button\` → push to a Figma file with the latest published Meta Kit. Verify Card content padding matches Meta Kit (not 48 top/bottom anymore). Verify Card Header typography matches Meta Kit.
- [ ] HTML preview at v1.66.2 → Card content area visibly tighter (80px padding inside 1200px wide cards) and aligned with Figma push output.

🤖 Generated with [Claude Code](https://claude.com/claude-code)