### PR TITLE
fix(brief): simplify a11y push to list + guard double page header (v1.66.3)

### DIFF
--- a/plugins/actian-design-system/.claude-plugin/plugin.json
+++ b/plugins/actian-design-system/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "actian-design-system",
   "description": "Actian Design System toolkit — sync tokens from Figma, generate wireframe flows with prototype wiring, create component briefs, audit designs, compare flows, and build presentations. 9 skills (with tiered generation: recognized / adapted / improvised), 8 agents, 155 tokens (3 themes, 8 collections), WCAG 2.1 AA.",
-  "version": "1.66.2",
+  "version": "1.66.3",
   "author": {
     "name": "Actian UX Team"
   },

--- a/plugins/actian-design-system/references/component-brief/push-patterns.md
+++ b/plugins/actian-design-system/references/component-brief/push-patterns.md
@@ -294,72 +294,56 @@ return { pairId: pair.id };
 
 ## 6. Accessibility Card Pattern
 
-**Layout:** The 6 a11y requirement cards MUST be arranged in a **2×3 grid** (2 columns, 3 rows). Create a grid container frame first, then add cards to it.
+**Layout (v1.66.3+):** Requirements render as a **simple vertical bulleted list** — bold title + plain body, one per row. The previous 2×3 a11y-card grid is retired (visual noise without proportional information density). This matches the simplified HTML renderer (Brief Refresh v2 Phase 1).
 
 ```js
-// First: create the 2-column grid container
-const grid = figma.createFrame();
-grid.name = "Requirements grid";
-grid.layoutMode = "HORIZONTAL";
-grid.layoutWrap = "WRAP";
-grid.itemSpacing = 16;
-grid.counterAxisSpacing = 16;
-grid.primaryAxisSizingMode = "FIXED";
-grid.counterAxisSizingMode = "AUTO";
-grid.resize(1040, 10);
-grid.fills = [];
+await figma.loadFontAsync({ family: "Inter", style: "Regular" });
+await figma.loadFontAsync({ family: "Inter", style: "Semibold" });
 
-const parent = await figma.getNodeByIdAsync("<contentSlotId>");
-parent.appendChild(grid);
-grid.layoutSizingHorizontal = "FILL";
-grid.layoutSizingVertical = "HUG";  // ← auto-grow to fit rows
-
-return { gridId: grid.id };
-```
-
-Then for each of the 6 requirement cards, create and append to the grid. **CRITICAL: resize each card to 512px wide** so two fit per row in the 1040px grid (512 + 16 gap + 512 = 1040).
-
-```js
-const set = await figma.importComponentSetByKeyAsync("b4779a13f4097d682413a669eaaf9ead1b49f115");
-let variant = set.findChild(n => n.name === "Mode=DS");
-if (!variant) variant = set.defaultVariant || set.children[0];
-const inst = variant.createInstance();
-inst.setProperties({ "Title#47:2": "Role & semantics" });
-const card = inst.detachInstance();
-card.layoutSizingHorizontal = "FIXED";
-card.resize(512, card.height);  // ← MUST be 512px for 2-column grid
-card.clipsContent = false;
-
-// Remove placeholder text, find content area
-const content = card.findOne(n => n.name === "Content");
-if (content) {
-  const ph = content.findOne(n => n.type === "TEXT" && n.characters && n.characters.includes("Content goes here"));
-  if (ph) ph.remove();
+function hexToRgb(hex) {
+  const h = hex.replace("#", "");
+  return {
+    r: parseInt(h.substring(0,2),16)/255,
+    g: parseInt(h.substring(2,4),16)/255,
+    b: parseInt(h.substring(4,6),16)/255
+  };
 }
 
-// Body text
-await figma.loadFontAsync({ family: "Inter", style: "Regular" });
-const body = figma.createText();
-body.characters = "Use native HTML <input> element...";
-body.fontSize = 13;
-body.fontName = { family: "Inter", style: "Regular" };
-body.fills = [{ type: "SOLID", color: hexToRgb("#3A3A4A") }];
-if (content) { content.appendChild(body); body.layoutSizingHorizontal = "FILL"; }
+const list = figma.createFrame();
+list.name = "Requirements";
+list.layoutMode = "VERTICAL";
+list.itemSpacing = 8;
+list.primaryAxisSizingMode = "AUTO";
+list.counterAxisSizingMode = "AUTO";
+list.fills = [];
 
-// Code block via setProperties (do NOT detach)
-const codeComp = await figma.importComponentByKeyAsync("1bf10eee1751a46da5f90a9671be6c9abf0073b7");
-const codeInst = codeComp.createInstance();
-codeInst.setProperties({
-  "Show Header#8:0": false,
-  "Code#8:2": '<label for="name">Name</label>'
-});
-if (content) { content.appendChild(codeInst); codeInst.layoutSizingHorizontal = "FILL"; }
+const parent = await figma.getNodeByIdAsync("<contentSlotId>");
+parent.appendChild(list);
+list.layoutSizingHorizontal = "FILL";
 
-const grid = await figma.getNodeByIdAsync("<gridId>");
-grid.appendChild(card);
+// One row per requirement: "Title — body description". The title portion
+// is bold; the rest is regular body weight.
+for (const req of requirements) {
+  const t = figma.createText();
+  t.fontName = { family: "Inter", style: "Regular" };
+  t.fontSize = 14;
+  t.lineHeight = { unit: "PERCENT", value: 160 };
+  t.fills = [{ type: "SOLID", color: hexToRgb("#2d3648") }];
+  const sep = " — ";
+  t.characters = req.title + sep + req.body;
+  // Bold + darker color for the title portion only.
+  t.setRangeFontName(0, req.title.length, { family: "Inter", style: "Semibold" });
+  t.setRangeFills(0, req.title.length, [{ type: "SOLID", color: hexToRgb("#101828") }]);
+  list.appendChild(t);
+  t.layoutSizingHorizontal = "FILL";
+}
 
-return { a11yCardId: card.id };
+return { listId: list.id };
 ```
+
+**No more 6-card grid, no per-card code blocks.** The `code` field on each requirement (still in the data schema for back-compat) is ignored by this pattern. If a requirement genuinely needs a code example, surface it in the body text or move it to the ARIA table — don't bring back the grid.
+
+After the requirements list, render the Contrast and ARIA tables (unchanged — Patterns 4 / 8 etc.).
 
 ---
 

--- a/plugins/actian-design-system/skills/component-brief/SKILL.md
+++ b/plugins/actian-design-system/skills/component-brief/SKILL.md
@@ -184,12 +184,13 @@ Read your `brief-data.json` and push directly to Figma using small `use_figma` c
 
 1. Create wrapper frame (Pattern 0 from component-brief/push-patterns.md — MUST be HORIZONTAL)
 2. Create GenLog instance (Pattern 0b — import by key, set 6 meta props, append to wrapper)
-3. For each card in the data model:
+3. **Card 1 — Page Header — create EXACTLY ONCE.** Use Pattern 1 with variant `"Mode=DS, Type=Page Header"`. **Set ALL three text properties** in a single `setProperties` call: `"Component Name#7:2"` = `card_header.name`, `"Description#7:3"` = `card_header.description`, `"Source#7:4"` = `"DS Kit"` (or appropriate library label). If you don't override these, Meta Kit's Page Header variant defaults leak through — you'll see "Button" / "The Button component is a surface-level element..." regardless of which component you're documenting (regression: see PR #23 follow-up). After creating + appending the Page Header, do NOT recreate it under any condition — proceed directly to card 2.
+4. For each remaining card in the data model (cards 2-N, skip `card_header`):
    a. Create card shell (Pattern 1). Read `card.cardTitle` and `card.cardSubtitle` from the data model — pass them straight to `setProperties` as `Title#140:0` and `Subtitle#140:1`. Do NOT hardcode card titles. **Default-leak detection (post-v1.66.0):** the Meta Kit Card Header now defaults to the generic placeholders `"Card title"` / `"Subtitle text"`. If a pushed card displays either string verbatim, `setProperties` silently failed (wrong property ID, wrong nested instance, or unresolved Card Header lookup) — fix the push call rather than ignoring the leak.
    b. Populate content: translate data model fields to Plugin API calls using component-brief/push-patterns.md
    c. Anatomy card (`card_anatomy`): use the anatomy diagram pattern (~4-6KB inline call)
    d. Tokens card (`card_tokens`): compact grid table — one row per state, Color Swatch per cell. Set `.fills` directly on swatch instance (flat, no children). Use `setProperties` for Section Headers (Pattern 2).
-   e. Accessibility card (`card_accessibility`): MUST create Requirements grid (Pattern 6) with all 6 a11y cards at 512px wide BEFORE the contrast/ARIA tables — do NOT skip the requirement cards. Use Contrast Badge `setProperties` and A11y Spec Row `setProperties`.
+   e. Accessibility card (`card_accessibility`): use the simplified Pattern 6 — render `requirements` as a vertical bulleted list with bold-title + plain-body rows (one row per requirement, no per-card frames, no embedded code blocks). This replaces the 2×3 a11y-card grid retired in v1.66.3. Then render the Contrast table and ARIA table after the requirements list. Use Contrast Badge `setProperties` and A11y Spec Row `setProperties` for the table rows.
 4. After all cards pushed, report to user with count
 
 **Rules:**


### PR DESCRIPTION
## Summary

Two issues from a v1.66.1 smoke test on a Tooltip brief — both fixed here.

### 1. Double Card 1 (Page Header)

The Figma metadata showed **two Page Header frames** in the same brief:
- First: Meta Kit defaults visible (\"Button\" / \"The Button component is a surface-level element...\") — \`Component Name#7:2\` and \`Description#7:3\` were never overridden
- Second: Tooltip-specific content, properly populated

Same default-leak family as the Card Header bug fixed yesterday — but at the **outer Card level**, where \`meta-chrome-brief-card\`'s Page Header variant still defaults to \"Button\"-themed strings.

**Fix (SKILL.md):** card_header is now an explicit named step before the for-each-card loop, with:
- \"Create EXACTLY ONCE\" instruction
- Required \`setProperties\` keys called out (\`Component Name#7:2\`, \`Description#7:3\`, \`Source#7:4\`)
- Don't-recreate clause
- For-each loop now scoped to cards 2-N (skips \`card_header\`)

**Meta Kit follow-up needed (Kristina):** change \`meta-chrome-brief-card\` Page Header variant defaults to neutral placeholders matching yesterday's Card Header fix:
- \`Component Name#7:2\`: \"Button\" → \"Component name\"
- \`Description#7:3\`: \"The Button component is...\" → \"Component description\"
- \`Source#7:4\`: \"FAT MARKER WIREFRAME KIT\" → \"DS Kit\" (or just blank)

Until those land, the SKILL.md guidance is the only safety net.

### 2. Accessibility card still showed the old 2×3 grid

v1.66.0 simplified the HTML renderer to a bulleted list, but the **Figma push uses a completely separate code path** (\`push-patterns.md\` Pattern 6) which still mandated the 2×3 a11y-card grid with 512px-wide cards and per-card code blocks. So the simplification never reached Figma.

**Fix (push-patterns.md Pattern 6):** replace the 2×3 grid with a vertical bulleted list — bold title + plain body, one row per requirement. Uses \`setRangeFontName\`/\`setRangeFills\` for the bold prefix. No card frames, no embedded code blocks. Matches the HTML 1:1.

**Data shape unchanged** — \`requirements[].icon\` and \`requirements[].code\` stay in the schema for back-compat, just ignored by the renderer + push. Future re-elevation requires no migration.

## Numbers

- Version: \`1.66.2\` → \`1.66.3\`
- Tests: 785/785 passing
- 3 files changed, +45/-60 (push-patterns.md Pattern 6 dropped ~50 lines)

## Test plan

- [x] Test suite passes
- [ ] Visual smoke on Cowork after merge: \`/component-brief Tooltip\` → push → verify (a) only one Page Header card with Tooltip content, (b) accessibility card renders as a bulleted list rather than 2×3 grid

🤖 Generated with [Claude Code](https://claude.com/claude-code)