### PR TITLE
fix(brief): broaden Card Header selector + read-back assertion (v1.66.4)

### DIFF
--- a/plugins/actian-design-system/.claude-plugin/plugin.json
+++ b/plugins/actian-design-system/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "actian-design-system",
   "description": "Actian Design System toolkit — sync tokens from Figma, generate wireframe flows with prototype wiring, create component briefs, audit designs, compare flows, and build presentations. 9 skills (with tiered generation: recognized / adapted / improvised), 8 agents, 155 tokens (3 themes, 8 collections), WCAG 2.1 AA.",
-  "version": "1.66.3",
+  "version": "1.66.4",
   "author": {
     "name": "Actian UX Team"
   },

--- a/plugins/actian-design-system/references/component-brief/push-patterns.md
+++ b/plugins/actian-design-system/references/component-brief/push-patterns.md
@@ -87,14 +87,41 @@ const inst = variant.createInstance();
 inst.name = cardTitle;
 const cardFrame = inst.detachInstance();
 
-// Card Header stays as a live instance — set properties on it
-const cardHeader = cardFrame.findOne(n => n.name === "Card Header" && n.type === "INSTANCE");
-if (cardHeader) {
-  cardHeader.setProperties({
-    "Title#140:0": cardTitle,
-    "Subtitle#140:1": cardSubtitle,
-    "Show Subtitle#140:2": Boolean(cardSubtitle)
-  });
+// Card Header stays as a live instance — set properties on it.
+// IMPORTANT (v1.66.4+): match the Card Header instance by NAME SUBSTRING, not
+// exact equality. Depending on Meta Kit publish state, the instance may be
+// named "Card Header", "Brief Card Header", or "Meta / Chrome / Brief Card
+// Header" (full library path). An exact-match selector silently fails, the
+// `if (cardHeader)` branch is skipped, no setProperties call runs, and the
+// neutral Meta Kit defaults ("Card title" / "Subtitle text") leak into the
+// brief.
+const cardHeader = cardFrame.findOne(n =>
+  n.type === "INSTANCE" && /Card Header/i.test(n.name)
+);
+if (!cardHeader) {
+  // Loud fail rather than silent leak — Meta Kit structure may have changed.
+  throw new Error(
+    "Card Shell push: no nested Card Header instance found in detached " +
+    "frame. Expected name to contain 'Card Header'. Inspect the variant " +
+    "structure and update this selector."
+  );
+}
+cardHeader.setProperties({
+  "Title#140:0": cardTitle,
+  "Subtitle#140:1": cardSubtitle,
+  "Show Subtitle#140:2": Boolean(cardSubtitle)
+});
+
+// Read-back verification — catch silent setProperties failures (e.g. property
+// IDs renamed in a future Meta Kit publish). If the title still equals the
+// neutral default, the property assignment didn't take effect.
+const titleNode = cardHeader.findOne(n => n.type === "TEXT" && /^Title$/i.test(n.name));
+if (titleNode && titleNode.characters === "Card title") {
+  throw new Error(
+    "Card Header title shows the Meta Kit default ('Card title') after " +
+    "setProperties — the assignment didn't apply. Check property IDs " +
+    "(#140:0 / #140:1) against the current Meta Kit publish."
+  );
 }
 
 // Find content slot for child injection.


### PR DESCRIPTION
## Symptom

Latest Tooltip brief test (Figma file W3TdaJmxVNL3ozdhimYE8d, node 17629:222) shows:

\`\`\`
Card title
Subtitle text
\`\`\`

…in every standard card. These are the **neutral Meta Kit defaults** Kristina set yesterday — leaking through because \`setProperties\` failed silently.

## Diagnosis

\`get_metadata\` on node 17629:222 returns:

\`\`\`
<instance id=\"17629:222\" name=\"Meta / Chrome / Brief Card Header\" .../>
\`\`\`

The push pattern's selector is exact-match:

\`\`\`js
const cardHeader = cardFrame.findOne(n =>
  n.name === \"Card Header\" && n.type === \"INSTANCE\"
);
\`\`\`

Yesterday's Meta Kit edit (Card Header neutral defaults) appears to have also restructured the variant — the Card Header instance now retains its full library name \`\"Meta / Chrome / Brief Card Header\"\` rather than being renamed to \`\"Card Header\"\`. The selector returned null, the \`if (cardHeader)\` block was skipped, no \`setProperties\` ran, defaults leaked.

**The neutral defaults did their job.** Yesterday's fix was the canary — it surfaced a silent failure that would have been invisible with the old \"Anatomy\" defaults.

## Fix

\`references/component-brief/push-patterns.md\` Pattern 1:

1. **Substring selector** (case-insensitive) — survives \`Card Header\` / \`Brief Card Header\` / \`Meta / Chrome / Brief Card Header\` variants:
   \`\`\`js
   const cardHeader = cardFrame.findOne(n =>
     n.type === \"INSTANCE\" && /Card Header/i.test(n.name)
   );
   \`\`\`
2. **Throw if null** — loud fail beats silent leak. Future Meta Kit restructures will make their failure mode obvious immediately.
3. **Read-back assertion** — after \`setProperties\`, check the Title text node's actual characters. If still equal to \`\"Card title\"\` (the neutral default), throw. Catches a different failure mode: property IDs being renamed in a future Meta Kit publish.

## Numbers

- Version: \`1.66.3\` → \`1.66.4\`
- Tests: 785/785 passing (doc-only change)
- 2 files changed

## Test plan

- [x] Test suite green
- [ ] Smoke on Cowork after merge: \`/component-brief Tooltip\` → push to a Figma file with the latest published Meta Kit. Verify card titles + subtitles appear correctly (no \`\"Card title\"\` / \`\"Subtitle text\"\` leaks). If a leak occurs, the agent should now throw a descriptive error instead of producing a broken brief silently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)