### PR TITLE
feat(brief): 6-section restructure — Section 1 supercard + Draft tags (v1.67.0)

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Iterate inside the loop with **refine** (paste a screen-frame URL + edit instruc
 
 ## Supporting capabilities
 
-- Generate 7-card component briefs with provenance badges and cross-DS research insights — Phase A transcribes from synced guidelines, Phase B fills gaps with optional research (Material, Carbon, Polaris, Atlassian, Stripe). Direct push using `setProperties` on live MetaKit instances (colored swatches, a11y requirement grids, contrast badges).
+- Generate 6-section component briefs with provenance badges, per-sub-section Draft tags, and cross-DS research insights — Phase A transcribes from synced guidelines, Phase B fills gaps with optional research (Material, Carbon, Polaris, Atlassian, Stripe). Section 1 (Anatomy / Variation / Tokens / Specs) is rendered as a single supercard. Direct push using `setProperties` on live MetaKit instances (colored swatches, a11y requirement grids, contrast badges).
 - Create new Figma components with variants, properties, and correct token binding
 - Review and rewrite copy against DS content guidelines (`/design-audit --scope copy`)
 - Compare two competing designs side by side (also works between branches and variants)
@@ -26,7 +26,7 @@ Iterate inside the loop with **refine** (paste a screen-frame URL + edit instruc
 
 The guidelines hold throughout — tokens, spacing, content rules, accessibility — but the output stays creative within them.
 
-**v1.66.0** · 9 skills (tiered generation: recognized / adapted / improvised) · 9 agents · 23 recipes · 155 design tokens across 8 collections · 3 themes · WCAG 2.1 AA · surgical refine engine · vision-grounded references · interactive gates · MD-as-SoT foundations · 6-section component briefs (anatomy + tokens / usages / content / motion / accessibility / real examples)
+**v1.67.0** · 9 skills (tiered generation: recognized / adapted / improvised) · 9 agents · 23 recipes · 155 design tokens across 8 collections · 3 themes · WCAG 2.1 AA · surgical refine engine · vision-grounded references · interactive gates · MD-as-SoT foundations · 6-section component briefs with Section 1 supercard (anatomy + variation + tokens + specs / usages / content / motion / accessibility / real examples)
 
 ---
 
@@ -169,7 +169,7 @@ Every capability is also available as a direct command. Use these when you know 
 
 | Command | What it does |
 |---------|-------------|
-| `/component-brief` | Component spec organized into 6 sections (v1.66.0+): Header → §1 Anatomy / variation / tokens / specs → §2 Usages → §3 Content guidelines & examples → §4 Motion (conditional, only when applicable) → §5 Accessibility → §6 Real platform examples. Two-pass (v1.62.0+): Phase A transcribes synced guidelines into the data model with provenance badges; Phase B fills gaps and (opt-in) attaches cross-DS research insights. Stub-aware: components with auto-generated stub guidelines route through Phase B fallback and surface a stub footer cue. |
+| `/component-brief` | Component spec organized into 6 sections (v1.67.0+): Header → §1 Anatomy / Variation / Tokens / Specs (single supercard with sub-section dividers and Draft tags on generated content) → §2 Usages → §3 Content guidelines & examples → §4 Motion (conditional, only when a motion pattern exists) → §5 Accessibility → §6 Real platform examples (deferred). Two-pass (v1.62.0+): Phase A transcribes synced guidelines into the data model with provenance badges; Phase B fills gaps and (opt-in) attaches cross-DS research insights. Stub-aware: components with auto-generated stub guidelines route through Phase B fallback and surface a stub footer cue. |
 | `/create-component` | Build Figma components with variants and correct token binding, with a build plan review before push |
 | `/compare-flows` | Side-by-side analysis of two Figma flows — v1 vs v2, competing approaches, branches, variants |
 | `/generate-presentation` | Slide deck with Actian templates, token-bound backgrounds, and chart support |

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Iterate inside the loop with **refine** (paste a screen-frame URL + edit instruc
 
 ## Supporting capabilities
 
-- Generate 6-section component briefs with provenance badges, per-sub-section Draft tags, and cross-DS research insights — Phase A transcribes from synced guidelines, Phase B fills gaps with optional research (Material, Carbon, Polaris, Atlassian, Stripe). Section 1 (Anatomy / Variation / Tokens / Specs) is rendered as a single supercard. Direct push using `setProperties` on live MetaKit instances (colored swatches, a11y requirement grids, contrast badges).
+- Generate component briefs with provenance badges, per-sub-section Draft tags, and cross-DS research insights — Phase A transcribes from synced guidelines, Phase B fills gaps with optional research (Material, Carbon, Polaris, Atlassian, Stripe). Section 1 (Anatomy / Variation / Tokens / Specs) renders as a single supercard. Direct push using `setProperties` on live MetaKit instances (colored swatches, a11y requirement grids, contrast badges).
 - Create new Figma components with variants, properties, and correct token binding
 - Review and rewrite copy against DS content guidelines (`/design-audit --scope copy`)
 - Compare two competing designs side by side (also works between branches and variants)
@@ -26,7 +26,7 @@ Iterate inside the loop with **refine** (paste a screen-frame URL + edit instruc
 
 The guidelines hold throughout — tokens, spacing, content rules, accessibility — but the output stays creative within them.
 
-**v1.67.0** · 9 skills (tiered generation: recognized / adapted / improvised) · 9 agents · 23 recipes · 155 design tokens across 8 collections · 3 themes · WCAG 2.1 AA · surgical refine engine · vision-grounded references · interactive gates · MD-as-SoT foundations · 6-section component briefs with Section 1 supercard (anatomy + variation + tokens + specs / usages / content / motion / accessibility / real examples)
+**v1.67.0** · 9 skills (tiered generation: recognized / adapted / improvised) · 9 agents · 23 recipes · 155 design tokens across 8 collections · 3 themes · WCAG 2.1 AA · surgical refine engine · vision-grounded references · interactive gates · MD-as-SoT foundations · component briefs with Section 1 supercard (anatomy + variation + tokens + specs / usages / content / motion / accessibility) — Section 6 (real platform examples) deferred
 
 ---
 

--- a/plugins/actian-design-system/.claude-plugin/plugin.json
+++ b/plugins/actian-design-system/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "actian-design-system",
   "description": "Actian Design System toolkit — sync tokens from Figma, generate wireframe flows with prototype wiring, create component briefs, audit designs, compare flows, and build presentations. 9 skills (with tiered generation: recognized / adapted / improvised), 8 agents, 155 tokens (3 themes, 8 collections), WCAG 2.1 AA.",
-  "version": "1.66.4",
+  "version": "1.67.0",
   "author": {
     "name": "Actian UX Team"
   },

--- a/plugins/actian-design-system/references/component-brief/push-patterns.md
+++ b/plugins/actian-design-system/references/component-brief/push-patterns.md
@@ -143,6 +143,72 @@ return { cardId: cardFrame.id, contentSlotId: contentSlot?.id || cardFrame.id };
 
 **Card Header stays live after detach.** Use `setProperties` with `Title#140:0`, `Subtitle#140:1`, `Show Subtitle#140:2`. For the Page Header variant (card1), use `"Mode=DS, Type=Page Header"` and set `"Component Name#7:2"` (= `card.name`) and `"Description#7:3"` (= `card.description`) instead. The `cardTitle`/`cardSubtitle` fields still apply but are not surfaced visually on Page Header.
 
+### 1d. Section 1 supercard (v1.67.0+)
+
+Section 1 is ONE card with four nested sub-frames inside, not three separate cards. After Pattern 1 creates the card and contentSlot, build sub-frames in the slot:
+
+```js
+// Inputs from data: briefData.card_component, .card_anatomy, .card_tokens
+// Use cardTitle "Anatomy, variation, tokens & specs" (default in renderer; recipe-overridable).
+
+await figma.loadFontAsync({ family: "Inter", style: "Regular" });
+await figma.loadFontAsync({ family: "Inter", style: "Semibold" });
+
+const slot = await figma.getNodeByIdAsync("<contentSlotId>");
+
+async function appendSubFrame(label, sourceCard) {
+  const sub = figma.createFrame();
+  sub.name = label;
+  sub.layoutMode = "VERTICAL";
+  sub.itemSpacing = 12;
+  sub.primaryAxisSizingMode = "AUTO";
+  sub.counterAxisSizingMode = "AUTO";
+  sub.fills = [];
+
+  // Heading row — label + optional Draft badge
+  const heading = figma.createText();
+  heading.fontName = { family: "Inter", style: "Semibold" };
+  heading.fontSize = 16;
+  heading.characters = label;
+  sub.appendChild(heading);
+
+  if (sourceCard && sourceCard._source === "generated" && sourceCard._authored !== true) {
+    // Append a small "DRAFT" tag next to the heading.
+    // Implementation: a separate text node with monospace upper case styling,
+    // placed in a HORIZONTAL wrapper around heading + tag.
+    // Pattern mirrors Pattern 1b source-badge approach — see that section
+    // for the inline-tag construction details.
+  }
+
+  // Append body content per sub-section type:
+  // label === "Anatomy"   → variant matrix component instance + parts table
+  // label === "Variation" → use existing variant-matrix push from old Card 2 pattern
+  // label === "Tokens"    → reuse old Card 4 push (color rows + sizing/typography tables)
+  // label === "Specs"     → dimension annotations from card_anatomy.specs
+
+  slot.appendChild(sub);
+  return sub;
+}
+
+// Order matches HTML renderer:
+const anatomyFrame = await appendSubFrame("Anatomy", briefData.card_anatomy);
+const divider1 = figma.createLine();  // horizontal divider; or reuse cardDivider styling
+slot.appendChild(divider1);
+
+const variationFrame = await appendSubFrame("Variation", briefData.card_component);
+slot.appendChild(figma.createLine());
+
+const tokensFrame = await appendSubFrame("Tokens", briefData.card_tokens);
+if (briefData.card_anatomy && briefData.card_anatomy.specs && briefData.card_anatomy.specs.length) {
+  slot.appendChild(figma.createLine());
+  await appendSubFrame("Specs", briefData.card_anatomy);
+}
+```
+
+The supercard's outer Card Header (Title #140:0 / Subtitle #140:1) is set on the cardHeader instance once via Pattern 1, using "Anatomy, variation, tokens & specs" / "Structural breakdown, variants, token bindings, and dimension specs" — or the recipe overrides if specified.
+
+Pattern 1b (Source Badge) applies to the supercard as a whole, derived using the same "most permissive wins" logic the HTML renderer uses (see `pickSection1Provenance` in brief-renderer.js).
+
 ---
 
 ## 1b. Source Badge Pattern

--- a/plugins/actian-design-system/references/component-brief/push-patterns.md
+++ b/plugins/actian-design-system/references/component-brief/push-patterns.md
@@ -75,7 +75,7 @@ Every card (except GenLog) uses the Brief Card component. Import it, select vari
 **Detecting silent setProperties failures (post-v1.66.0).** Meta Kit defaults for the Card Header are now the neutral placeholders `"Card title"` / `"Subtitle text"`. Earlier defaults were real strings (e.g. `"Anatomy"`) which masked failed `setProperties` calls — one failed card looked indistinguishable from a real Anatomy card. With the new neutral defaults, any leak is obvious and identifies the failure precisely. If a pushed card shows `"Card title"` or `"Subtitle text"` verbatim, the failure is upstream — investigate before continuing.
 
 ```js
-// Inputs from your data model — e.g., briefData.card3_anatomy
+// Inputs from your data model — e.g., briefData.card_anatomy
 const cardTitle = card.cardTitle;       // "Anatomy"
 const cardSubtitle = card.cardSubtitle; // "Component structure, dimensions, ..."
 
@@ -170,20 +170,35 @@ async function appendSubFrame(label, sourceCard) {
   heading.fontName = { family: "Inter", style: "Semibold" };
   heading.fontSize = 16;
   heading.characters = label;
-  sub.appendChild(heading);
 
   if (sourceCard && sourceCard._source === "generated" && sourceCard._authored !== true) {
     // Append a small "DRAFT" tag next to the heading.
-    // Implementation: a separate text node with monospace upper case styling,
-    // placed in a HORIZONTAL wrapper around heading + tag.
-    // Pattern mirrors Pattern 1b source-badge approach — see that section
-    // for the inline-tag construction details.
+    // Wrap heading + tag in a HORIZONTAL frame so they sit on the same row.
+    // Note: Pattern 1b's badge construction lives in a separate use_figma
+    // call scope and cannot be copy-pasted here — build the tag inline:
+    const headerRow = figma.createFrame();
+    headerRow.layoutMode = "HORIZONTAL";
+    headerRow.itemSpacing = 8;
+    headerRow.primaryAxisSizingMode = "AUTO";
+    headerRow.counterAxisSizingMode = "AUTO";
+    headerRow.counterAxisAlignItems = "CENTER";
+    headerRow.fills = [];
+    headerRow.appendChild(heading);
+    const tag = figma.createText();
+    tag.fontName = { family: "Inter", style: "Semibold" };
+    tag.fontSize = 10;
+    tag.characters = "DRAFT";
+    tag.fills = [{ type: "SOLID", color: { r: 0.44, g: 0.49, b: 0.59 } }];
+    headerRow.appendChild(tag);
+    sub.appendChild(headerRow);
+  } else {
+    sub.appendChild(heading);
   }
 
   // Append body content per sub-section type:
-  // label === "Anatomy"   → variant matrix component instance + parts table
-  // label === "Variation" → use existing variant-matrix push from old Card 2 pattern
-  // label === "Tokens"    → reuse old Card 4 push (color rows + sizing/typography tables)
+  // label === "Anatomy"   → variant matrix component instance + parts table (see Pattern 8 + Pattern 3)
+  // label === "Variation" → variant matrix push (see Pattern 8 — Variant Instance)
+  // label === "Tokens"    → color swatch grid + sizing/typography tables (see Pattern 4 + Pattern 3)
   // label === "Specs"     → dimension annotations from card_anatomy.specs
 
   slot.appendChild(sub);

--- a/plugins/actian-design-system/scripts/renderers/html-renderers/brief-renderer.css
+++ b/plugins/actian-design-system/scripts/renderers/html-renderers/brief-renderer.css
@@ -256,6 +256,25 @@ td code {
   color: #101828;
 }
 
+/* Per-sub-section Draft badge (Brief Refresh v2 / v1.67.0). Renders next to a
+   sub-section heading inside Section 1 when the underlying card data is
+   AI-generated and not yet human-authored. Suppressed when _authored: true. */
+.subsection-draft-badge {
+  display: inline-block;
+  margin-left: 8px;
+  padding: 2px 6px;
+  font-size: 10px;
+  font-weight: 600;
+  line-height: 1;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  color: var(--zen-color-text-secondary, #717d96);
+  background: var(--zen-color-surface-subtle, #f5f5fa);
+  border: 1px solid var(--zen-color-border-subtle, #edf0f7);
+  border-radius: 3px;
+  vertical-align: middle;
+}
+
 /* Inline pattern slug pill on the Behavior & motion card */
 .pattern-slug {
   display: inline-block;

--- a/plugins/actian-design-system/scripts/renderers/html-renderers/brief-renderer.js
+++ b/plugins/actian-design-system/scripts/renderers/html-renderers/brief-renderer.js
@@ -1113,19 +1113,17 @@
           renderFmCard5(d.anatomy, componentHtml),
         ];
       } else {
-        // Section order (Brief Refresh v2 Phase 1):
-        //   Header
-        //   Section 1 — Anatomy, variation, tokens, specs   (Component / Anatomy / Tokens)
-        //   Section 2 — Usages
-        //   Section 3 — Content guidelines & examples
-        //   Section 4 — Motion (microinteraction, when applicable)
-        //   Section 5 — Accessibility
-        //   Section 6 — Real platform examples               (held — Kristina pending)
+        // Section order (Brief Refresh v2 Phase 2 — v1.67.0):
+        //   Header                       (always)
+        //   Section 1 supercard          (Anatomy + Variation + Tokens + Specs merged)
+        //   Section 2 — Usages           (always if data)
+        //   Section 3 — Content          (always if data)
+        //   Section 4 — Motion           (conditional)
+        //   Section 5 — Accessibility    (always)
+        //   Section 6 — Real examples    (deferred entirely; not rendered)
         cards = [
           renderCard1(d.header),
-          renderCard2(d.component, componentHtml),
-          renderCard3(d.anatomy, componentHtml),
-          renderCard4(d.tokens),
+          renderSection1(d.component, d.anatomy, d.tokens, componentHtml),
           renderCard6(d.usage),
           renderCard7(d.content),
           renderCardMotion(d.motion),

--- a/plugins/actian-design-system/scripts/renderers/html-renderers/brief-renderer.js
+++ b/plugins/actian-design-system/scripts/renderers/html-renderers/brief-renderer.js
@@ -159,8 +159,9 @@
       sourceCard._source === "generated" &&
       sourceCard._authored !== true
     ) {
+      // Spacing handled by .subsection-draft-badge { margin-left: 8px }.
       draft =
-        ' <span class="subsection-draft-badge" ' +
+        '<span class="subsection-draft-badge" ' +
         'title="AI-drafted; not yet human-authored">Draft</span>';
     }
     return '<div class="section-title">' + esc(label) + draft + "</div>";
@@ -395,7 +396,7 @@
       });
       structHtml += "</div></div>";
       parts.push(
-        '<div class="section" data-name="Structure">' +
+        '<div class="section" data-name="Anatomy">' +
           subsectionTitle("Anatomy", anatomy) +
           structHtml +
           "</div>",
@@ -516,7 +517,7 @@
         );
       });
       parts.push(
-        '<div class="section" data-name="Color tokens">' +
+        '<div class="section" data-name="Tokens">' +
           subsectionTitle("Tokens", tokens) +
           specTable(headers, rows) +
           "</div>",

--- a/plugins/actian-design-system/scripts/renderers/html-renderers/brief-renderer.js
+++ b/plugins/actian-design-system/scripts/renderers/html-renderers/brief-renderer.js
@@ -278,11 +278,12 @@
     );
   }
 
-  function renderCard2(comp, componentHtml) {
+  // Section 1 sub-section: Variation. Returns the inner content body — no
+  // cardShell wrapper. Reused by renderCard2 (back-compat) and renderSection1.
+  function renderVariationContent(comp, componentHtml) {
     if (!comp) return "";
     var parts = [];
 
-    // Variant matrix
     if (comp.variantMatrix && comp.variantMatrix.length) {
       var cols = comp.variantMatrix[0].columns;
       var matrixHtml = '<table class="variant-matrix"><thead><tr><th>Type</th>';
@@ -311,7 +312,6 @@
       );
     }
 
-    // Theme comparison (HTML can't do Figma variable modes — show labeled placeholders)
     if (comp.themeComparison) {
       var themes = ["Actian", "Studio", "Explorer"];
       var themeHtml = '<div class="theme-row">';
@@ -338,21 +338,27 @@
       );
     }
 
+    return parts.join("");
+  }
+
+  function renderCard2(comp, componentHtml) {
+    if (!comp) return "";
     return cardShell(
       (comp && comp.cardTitle) || "Component",
       (comp && comp.cardSubtitle) ||
         "Live component across all states and theme modes",
-      parts.join(""),
+      renderVariationContent(comp, componentHtml),
       null,
       comp,
     );
   }
 
-  function renderCard3(anatomy, componentHtml) {
+  // Section 1 sub-section: Anatomy (parts diagram + parts table + states).
+  // Specs are intentionally separated — see renderSpecsContent.
+  function renderAnatomyContent(anatomy, componentHtml) {
     if (!anatomy) return "";
     var parts = [];
 
-    // Structure
     if (anatomy.parts && anatomy.parts.length) {
       var structHtml =
         '<div class="anatomy-box"><div class="anatomy-component">' +
@@ -378,35 +384,6 @@
       );
     }
 
-    // Specs (dimension annotations — simplified for HTML preview)
-    if (anatomy.specs && anatomy.specs.length) {
-      var specsHtml =
-        '<div class="anatomy-box">' +
-        '<div class="anatomy-component">' +
-        '<span class="anatomy-component__label">Specs</span>' +
-        componentHtml("default") +
-        '</div><div class="anatomy-props">';
-      anatomy.specs.forEach(function (s) {
-        specsHtml +=
-          '<div class="anatomy-prop">' +
-          '<div class="anatomy-badge anatomy-badge--dim">' +
-          esc(s.value) +
-          "</div>" +
-          '<div class="anatomy-prop__label">' +
-          esc(s.layerName || s.orientation || s.direction || "") +
-          "</div></div>";
-      });
-      specsHtml += "</div></div>";
-      parts.push(
-        cardDivider() +
-          '<div class="section" data-name="Specs">' +
-          sectionTitle("Specs") +
-          specsHtml +
-          "</div>",
-      );
-    }
-
-    // States
     if (anatomy.states && anatomy.states.length) {
       var statesHtml = '<div class="state-grid">';
       anatomy.states.forEach(function (state) {
@@ -427,7 +404,6 @@
       );
     }
 
-    // Parts reference table
     if (anatomy.partsTable && anatomy.partsTable.length) {
       var pRows = anatomy.partsTable.map(function (r) {
         return [
@@ -446,6 +422,44 @@
       );
     }
 
+    return parts.join("");
+  }
+
+  // Section 1 sub-section: Specs (dimension annotations).
+  // Reads anatomy.specs; previously nested inside renderCard3, now its own helper.
+  function renderSpecsContent(anatomy, componentHtml) {
+    if (!anatomy || !anatomy.specs || !anatomy.specs.length) return "";
+    var specsHtml =
+      '<div class="anatomy-box">' +
+      '<div class="anatomy-component">' +
+      '<span class="anatomy-component__label">Specs</span>' +
+      componentHtml("default") +
+      '</div><div class="anatomy-props">';
+    anatomy.specs.forEach(function (s) {
+      specsHtml +=
+        '<div class="anatomy-prop">' +
+        '<div class="anatomy-badge anatomy-badge--dim">' +
+        esc(s.value) +
+        "</div>" +
+        '<div class="anatomy-prop__label">' +
+        esc(s.layerName || s.orientation || s.direction || "") +
+        "</div></div>";
+    });
+    specsHtml += "</div></div>";
+    return (
+      '<div class="section" data-name="Specs">' +
+      sectionTitle("Specs") +
+      specsHtml +
+      "</div>"
+    );
+  }
+
+  function renderCard3(anatomy, componentHtml) {
+    if (!anatomy) return "";
+    var anatomyParts = renderAnatomyContent(anatomy, componentHtml);
+    var specsParts = renderSpecsContent(anatomy, componentHtml);
+    var parts = [anatomyParts];
+    if (specsParts) parts.push(cardDivider() + specsParts);
     return cardShell(
       (anatomy && anatomy.cardTitle) || "Anatomy",
       (anatomy && anatomy.cardSubtitle) ||
@@ -456,11 +470,11 @@
     );
   }
 
-  function renderCard4(tokens) {
+  // Section 1 sub-section: Tokens (color + sizing + typography tables).
+  function renderTokensContent(tokens) {
     if (!tokens) return "";
     var parts = [];
 
-    // Color tokens table — grid: one row per state, swatch dot per column
     if (tokens.colorTokens && tokens.colorTokens.length) {
       var headers = ["Variant · State"].concat(
         tokens.colorTokens[0].columns.map(function (c) {
@@ -482,7 +496,6 @@
       );
     }
 
-    // Sizing tokens table
     if (tokens.sizingTokens && tokens.sizingTokens.length) {
       var sRows = tokens.sizingTokens.map(function (r) {
         return [
@@ -500,7 +513,6 @@
       );
     }
 
-    // Typography
     if (tokens.typography && tokens.typography.length) {
       var tRows = tokens.typography.map(function (t) {
         return [
@@ -519,11 +531,16 @@
       );
     }
 
+    return parts.join("");
+  }
+
+  function renderCard4(tokens) {
+    if (!tokens) return "";
     return cardShell(
       (tokens && tokens.cardTitle) || "Design tokens",
       (tokens && tokens.cardSubtitle) ||
         "Color, sizing, spacing, and typography tokens",
-      parts.join(""),
+      renderTokensContent(tokens),
       null,
       tokens,
     );
@@ -1090,7 +1107,10 @@
       renderCard6: renderCard6,
       renderCard7: renderCard7,
       renderCard8: renderCard8,
-      // helpers added in Task 2 will be appended here
+      renderVariationContent: renderVariationContent,
+      renderAnatomyContent: renderAnatomyContent,
+      renderTokensContent: renderTokensContent,
+      renderSpecsContent: renderSpecsContent,
     };
   }
 })(); // end IIFE

--- a/plugins/actian-design-system/scripts/renderers/html-renderers/brief-renderer.js
+++ b/plugins/actian-design-system/scripts/renderers/html-renderers/brief-renderer.js
@@ -568,19 +568,23 @@
     if (!anatomyHtml && !variationHtml && !tokensHtml && !specsHtml) return "";
 
     var parts = [];
-    if (anatomyHtml) parts.push(anatomyHtml);
-    if (variationHtml)
-      parts.push((parts.length ? cardDivider() : "") + variationHtml);
-    if (tokensHtml)
-      parts.push((parts.length ? cardDivider() : "") + tokensHtml);
-    if (specsHtml) parts.push((parts.length ? cardDivider() : "") + specsHtml);
+    function appendSubsection(html) {
+      if (!html) return;
+      if (parts.length) parts.push(cardDivider());
+      parts.push(html);
+    }
+    appendSubsection(anatomyHtml);
+    appendSubsection(variationHtml);
+    appendSubsection(tokensHtml);
+    appendSubsection(specsHtml);
 
     // Pick a representative card object for source-badge / research insights.
     // Per spec: "most permissive wins" — figma > generated > generated+fallback.
     var representative = pickSection1Provenance(component, anatomy, tokens);
 
-    // Default title and subtitle (overridable by recipe via component.cardTitle etc.,
-    // but we read from the representative card if it carries one).
+    // Default title and subtitle. If the representative card (the provenance
+    // winner from pickSection1Provenance) carries cardTitle/cardSubtitle from
+    // its recipe, those override the defaults below.
     var title =
       (representative && representative.cardTitle) ||
       "Anatomy, variation, tokens & specs";
@@ -611,7 +615,7 @@
       if (inputs[j]._source === "generated" && !inputs[j]._fallback)
         return inputs[j];
     }
-    return inputs[0];
+    return inputs[0]; // default: first input — covers cards with no _source set
   }
 
   // Card 5 (numbered) — Behavior & motion. Conditional: returns "" when the

--- a/plugins/actian-design-system/scripts/renderers/html-renderers/brief-renderer.js
+++ b/plugins/actian-design-system/scripts/renderers/html-renderers/brief-renderer.js
@@ -555,6 +555,65 @@
     );
   }
 
+  // Section 1 supercard — Brief Refresh v2 / Kristina's must-have list.
+  // Composes Anatomy + Variation + Tokens + Specs into a single card frame.
+  // Sub-sections separated by cardDivider(); each one only renders if the
+  // corresponding input data is populated.
+  function renderSection1(component, anatomy, tokens, componentHtml) {
+    var anatomyHtml = renderAnatomyContent(anatomy, componentHtml);
+    var variationHtml = renderVariationContent(component, componentHtml);
+    var tokensHtml = renderTokensContent(tokens);
+    var specsHtml = renderSpecsContent(anatomy, componentHtml);
+
+    if (!anatomyHtml && !variationHtml && !tokensHtml && !specsHtml) return "";
+
+    var parts = [];
+    if (anatomyHtml) parts.push(anatomyHtml);
+    if (variationHtml)
+      parts.push((parts.length ? cardDivider() : "") + variationHtml);
+    if (tokensHtml)
+      parts.push((parts.length ? cardDivider() : "") + tokensHtml);
+    if (specsHtml) parts.push((parts.length ? cardDivider() : "") + specsHtml);
+
+    // Pick a representative card object for source-badge / research insights.
+    // Per spec: "most permissive wins" — figma > generated > generated+fallback.
+    var representative = pickSection1Provenance(component, anatomy, tokens);
+
+    // Default title and subtitle (overridable by recipe via component.cardTitle etc.,
+    // but we read from the representative card if it carries one).
+    var title =
+      (representative && representative.cardTitle) ||
+      "Anatomy, variation, tokens & specs";
+    var subtitle =
+      (representative && representative.cardSubtitle) ||
+      "Structural breakdown, variants, token bindings, and dimension specs";
+
+    return cardShell(title, subtitle, parts.join(""), null, representative);
+  }
+
+  // Pick the "most permissive" provenance among Section 1's three input cards.
+  // Used to drive the single source badge on the supercard.
+  function pickSection1Provenance(component, anatomy, tokens) {
+    var inputs = [component, anatomy, tokens].filter(Boolean);
+    if (!inputs.length) return null;
+
+    // figma wins
+    for (var i = 0; i < inputs.length; i++) {
+      if (inputs[i]._source === "figma") return inputs[i];
+    }
+    // all fallback?
+    var allFallback = inputs.every(function (c) {
+      return c._fallback === true;
+    });
+    if (allFallback) return inputs[0];
+    // pick any generated (non-fallback)
+    for (var j = 0; j < inputs.length; j++) {
+      if (inputs[j]._source === "generated" && !inputs[j]._fallback)
+        return inputs[j];
+    }
+    return inputs[0];
+  }
+
   // Card 5 (numbered) — Behavior & motion. Conditional: returns "" when the
   // component has no curated motion pattern. Source data comes from
   // foundations/interaction-motion.json#patterns.<slug>; component-guideline
@@ -1120,6 +1179,8 @@
       renderAnatomyContent: renderAnatomyContent,
       renderTokensContent: renderTokensContent,
       renderSpecsContent: renderSpecsContent,
+      renderSection1: renderSection1,
+      pickSection1Provenance: pickSection1Provenance,
     };
   }
 })(); // end IIFE

--- a/plugins/actian-design-system/scripts/renderers/html-renderers/brief-renderer.js
+++ b/plugins/actian-design-system/scripts/renderers/html-renderers/brief-renderer.js
@@ -149,6 +149,23 @@
     return '<div class="section-title">' + esc(title) + "</div>";
   }
 
+  // Sub-section heading with optional Draft badge. The badge appears only
+  // when the source card is AI-generated AND not flagged as human-authored.
+  // Hybrid contract from spec Q8=C.
+  function subsectionTitle(label, sourceCard) {
+    var draft = "";
+    if (
+      sourceCard &&
+      sourceCard._source === "generated" &&
+      sourceCard._authored !== true
+    ) {
+      draft =
+        ' <span class="subsection-draft-badge" ' +
+        'title="AI-drafted; not yet human-authored">Draft</span>';
+    }
+    return '<div class="section-title">' + esc(label) + draft + "</div>";
+  }
+
   function cardDivider() {
     return '<div class="card-divider"></div>';
   }
@@ -307,6 +324,7 @@
       matrixHtml += "</tbody></table>";
       parts.push(
         '<div class="section" data-name="Variant matrix">' +
+          subsectionTitle("Variation", comp) +
           matrixHtml +
           "</div>",
       );
@@ -378,7 +396,7 @@
       structHtml += "</div></div>";
       parts.push(
         '<div class="section" data-name="Structure">' +
-          sectionTitle("Structure") +
+          subsectionTitle("Anatomy", anatomy) +
           structHtml +
           "</div>",
       );
@@ -448,7 +466,7 @@
     specsHtml += "</div></div>";
     return (
       '<div class="section" data-name="Specs">' +
-      sectionTitle("Specs") +
+      subsectionTitle("Specs", anatomy) +
       specsHtml +
       "</div>"
     );
@@ -499,7 +517,7 @@
       });
       parts.push(
         '<div class="section" data-name="Color tokens">' +
-          sectionTitle("Color tokens") +
+          subsectionTitle("Tokens", tokens) +
           specTable(headers, rows) +
           "</div>",
       );
@@ -1186,6 +1204,7 @@
       renderSpecsContent: renderSpecsContent,
       renderSection1: renderSection1,
       pickSection1Provenance: pickSection1Provenance,
+      subsectionTitle: subsectionTitle,
     };
   }
 })(); // end IIFE

--- a/plugins/actian-design-system/scripts/renderers/html-renderers/brief-renderer.js
+++ b/plugins/actian-design-system/scripts/renderers/html-renderers/brief-renderer.js
@@ -1113,7 +1113,10 @@
           renderFmCard5(d.anatomy, componentHtml),
         ];
       } else {
-        // Section order (Brief Refresh v2 Phase 2 — v1.67.0):
+        // Section order (Brief Refresh v2 Phase 2 — v1.67.0).
+        // Spec: comms/SPEC-brief-6-section-restructure.md
+        // Plan: comms/PLAN-brief-6-section-restructure.md
+        //
         //   Header                       (always)
         //   Section 1 supercard          (Anatomy + Variation + Tokens + Specs merged)
         //   Section 2 — Usages           (always if data)
@@ -1122,12 +1125,12 @@
         //   Section 5 — Accessibility    (always)
         //   Section 6 — Real examples    (deferred entirely; not rendered)
         cards = [
-          renderCard1(d.header),
-          renderSection1(d.component, d.anatomy, d.tokens, componentHtml),
-          renderCard6(d.usage),
-          renderCard7(d.content),
-          renderCardMotion(d.motion),
-          renderCard8(d.accessibility),
+          renderCard1(d.header), // Header
+          renderSection1(d.component, d.anatomy, d.tokens, componentHtml), // Section 1
+          renderCard6(d.usage), // Section 2
+          renderCard7(d.content), // Section 3
+          renderCardMotion(d.motion), // Section 4 (conditional)
+          renderCard8(d.accessibility), // Section 5
         ];
       }
 

--- a/plugins/actian-design-system/scripts/renderers/html-renderers/brief-renderer.js
+++ b/plugins/actian-design-system/scripts/renderers/html-renderers/brief-renderer.js
@@ -980,100 +980,117 @@
 
   // --- Entry Point ---
 
-  document.addEventListener("DOMContentLoaded", function () {
-    var dataEl = document.getElementById("spec-data");
-    if (!dataEl) return;
-    var data = JSON.parse(dataEl.textContent);
-    var container = document.getElementById("cards-container");
-    if (!container) return;
+  if (typeof document !== "undefined") {
+    document.addEventListener("DOMContentLoaded", function () {
+      var dataEl = document.getElementById("spec-data");
+      if (!dataEl) return;
+      var data = JSON.parse(dataEl.textContent);
+      var container = document.getElementById("cards-container");
+      if (!container) return;
 
-    var componentHtml =
-      window.componentHtml ||
-      function () {
-        return '<div style="padding:20px;background:#f5f5f5;border-radius:8px;color:#888;text-align:center;">Component preview</div>';
+      var componentHtml =
+        window.componentHtml ||
+        function () {
+          return '<div style="padding:20px;background:#f5f5f5;border-radius:8px;color:#888;text-align:center;">Component preview</div>';
+        };
+      var isFm =
+        data.meta && (data.meta.library === "fm" || data.meta.mode === "fm");
+
+      // Support both new-style flat keys (card_header) and old-style numbered keys (card1_header)
+      // card_api (was card5) and card_code (was card9) retired; validator blocks them.
+      var d = {
+        header: data.card_header || data.card1_header,
+        component: data.card_component || data.card2_component,
+        anatomy: data.card_anatomy || data.card3_anatomy,
+        tokens: data.card_tokens || data.card4_tokens,
+        motion: data.card_motion,
+        usage: data.card_usage || data.card6_usage,
+        content: data.card_content || data.card7_content,
+        accessibility: data.card_accessibility || data.card8_accessibility,
+        // FM keys
+        designGuidelines:
+          data.card_design_guidelines || data.card3_design_guidelines,
+        contentGuidelines:
+          data.card_content_guidelines || data.card4_content_guidelines,
       };
-    var isFm =
-      data.meta && (data.meta.library === "fm" || data.meta.mode === "fm");
 
-    // Support both new-style flat keys (card_header) and old-style numbered keys (card1_header)
-    // card_api (was card5) and card_code (was card9) retired; validator blocks them.
-    var d = {
-      header: data.card_header || data.card1_header,
-      component: data.card_component || data.card2_component,
-      anatomy: data.card_anatomy || data.card3_anatomy,
-      tokens: data.card_tokens || data.card4_tokens,
-      motion: data.card_motion,
-      usage: data.card_usage || data.card6_usage,
-      content: data.card_content || data.card7_content,
-      accessibility: data.card_accessibility || data.card8_accessibility,
-      // FM keys
-      designGuidelines:
-        data.card_design_guidelines || data.card3_design_guidelines,
-      contentGuidelines:
-        data.card_content_guidelines || data.card4_content_guidelines,
+      var cards;
+      if (isFm) {
+        cards = [
+          renderFmCard1(d.header),
+          renderFmCard2(d.component, componentHtml),
+          renderFmCard3(d.designGuidelines),
+          renderFmCard4(d.contentGuidelines),
+          renderFmCard5(d.anatomy, componentHtml),
+        ];
+      } else {
+        // Section order (Brief Refresh v2 Phase 1):
+        //   Header
+        //   Section 1 — Anatomy, variation, tokens, specs   (Component / Anatomy / Tokens)
+        //   Section 2 — Usages
+        //   Section 3 — Content guidelines & examples
+        //   Section 4 — Motion (microinteraction, when applicable)
+        //   Section 5 — Accessibility
+        //   Section 6 — Real platform examples               (held — Kristina pending)
+        cards = [
+          renderCard1(d.header),
+          renderCard2(d.component, componentHtml),
+          renderCard3(d.anatomy, componentHtml),
+          renderCard4(d.tokens),
+          renderCard6(d.usage),
+          renderCard7(d.content),
+          renderCardMotion(d.motion),
+          renderCard8(d.accessibility),
+        ];
+      }
+
+      // Insert gen card before the cards container (as sibling in brief-row)
+      var briefRow = container.parentElement;
+      if (briefRow && data.meta) {
+        var genCardEl = document.createElement("div");
+        genCardEl.innerHTML = genCard(data.meta);
+        briefRow.insertBefore(genCardEl.firstChild, container);
+      }
+
+      container.innerHTML = cards.filter(Boolean).join("\n");
+
+      // Stub footer cue (v1.64.0+): surfaced when meta._stubGuideline is true so
+      // designers know the brief is registry-derived only and the DS team owes
+      // a curated guideline for this component.
+      if (briefRow && data.meta && data.meta._stubGuideline === true) {
+        var slug = esc(data.meta.slug || "this-component");
+        var footer = document.createElement("div");
+        footer.className = "stub-footer";
+        footer.style.cssText =
+          "margin-top: 24px; padding: 16px 20px; " +
+          "background: var(--zen-color-background-grey-1, #fbfbff); " +
+          "border-left: 3px solid var(--zen-color-status-warning, #d27b00); " +
+          "color: var(--zen-color-text-secondary, #3f3f4a); font-size: 13px;";
+        footer.innerHTML =
+          "<strong>Guidance pending curation.</strong> " +
+          "This brief is based on registry data only. The DS team has not yet " +
+          "curated content / design / a11y guidelines for this component. " +
+          "Briefs will improve once the guideline is fleshed out at " +
+          "<code>docs/component-guidelines/" +
+          slug +
+          ".json</code>.";
+        briefRow.appendChild(footer);
+      }
+    });
+  } // end typeof document guard
+
+  // Node-compatible exports — mirror fm-html-map.js so tests can require this module.
+  if (typeof module !== "undefined" && module.exports) {
+    module.exports = {
+      renderCard1: renderCard1,
+      renderCard2: renderCard2,
+      renderCard3: renderCard3,
+      renderCard4: renderCard4,
+      renderCardMotion: renderCardMotion,
+      renderCard6: renderCard6,
+      renderCard7: renderCard7,
+      renderCard8: renderCard8,
+      // helpers added in Task 2 will be appended here
     };
-
-    var cards;
-    if (isFm) {
-      cards = [
-        renderFmCard1(d.header),
-        renderFmCard2(d.component, componentHtml),
-        renderFmCard3(d.designGuidelines),
-        renderFmCard4(d.contentGuidelines),
-        renderFmCard5(d.anatomy, componentHtml),
-      ];
-    } else {
-      // Section order (Brief Refresh v2 Phase 1):
-      //   Header
-      //   Section 1 — Anatomy, variation, tokens, specs   (Component / Anatomy / Tokens)
-      //   Section 2 — Usages
-      //   Section 3 — Content guidelines & examples
-      //   Section 4 — Motion (microinteraction, when applicable)
-      //   Section 5 — Accessibility
-      //   Section 6 — Real platform examples               (held — Kristina pending)
-      cards = [
-        renderCard1(d.header),
-        renderCard2(d.component, componentHtml),
-        renderCard3(d.anatomy, componentHtml),
-        renderCard4(d.tokens),
-        renderCard6(d.usage),
-        renderCard7(d.content),
-        renderCardMotion(d.motion),
-        renderCard8(d.accessibility),
-      ];
-    }
-
-    // Insert gen card before the cards container (as sibling in brief-row)
-    var briefRow = container.parentElement;
-    if (briefRow && data.meta) {
-      var genCardEl = document.createElement("div");
-      genCardEl.innerHTML = genCard(data.meta);
-      briefRow.insertBefore(genCardEl.firstChild, container);
-    }
-
-    container.innerHTML = cards.filter(Boolean).join("\n");
-
-    // Stub footer cue (v1.64.0+): surfaced when meta._stubGuideline is true so
-    // designers know the brief is registry-derived only and the DS team owes
-    // a curated guideline for this component.
-    if (briefRow && data.meta && data.meta._stubGuideline === true) {
-      var slug = esc(data.meta.slug || "this-component");
-      var footer = document.createElement("div");
-      footer.className = "stub-footer";
-      footer.style.cssText =
-        "margin-top: 24px; padding: 16px 20px; " +
-        "background: var(--zen-color-background-grey-1, #fbfbff); " +
-        "border-left: 3px solid var(--zen-color-status-warning, #d27b00); " +
-        "color: var(--zen-color-text-secondary, #3f3f4a); font-size: 13px;";
-      footer.innerHTML =
-        "<strong>Guidance pending curation.</strong> " +
-        "This brief is based on registry data only. The DS team has not yet " +
-        "curated content / design / a11y guidelines for this component. " +
-        "Briefs will improve once the guideline is fleshed out at " +
-        "<code>docs/component-guidelines/" +
-        slug +
-        ".json</code>.";
-      briefRow.appendChild(footer);
-    }
-  });
+  }
 })(); // end IIFE

--- a/plugins/actian-design-system/scripts/renderers/html-renderers/brief-renderer.js
+++ b/plugins/actian-design-system/scripts/renderers/html-renderers/brief-renderer.js
@@ -454,6 +454,15 @@
     );
   }
 
+  // Back-compat wrapper. Pre-refactor renderCard3 emitted Specs BETWEEN
+  // States and Parts reference (middle of the card). Post-refactor Specs
+  // renders at the end of the card. This positional change is acceptable
+  // because (a) Task 4 replaces renderCard3 in the default DOM array with
+  // renderSection1, where Specs is intentionally the 4th sub-section
+  // (last), and (b) renderCard3 is only on a back-compat code path. If a
+  // future caller relies on the historical mid-card Specs position, split
+  // renderAnatomyContent into Structure / States / Parts helpers and
+  // interleave Specs between States and Parts here.
   function renderCard3(anatomy, componentHtml) {
     if (!anatomy) return "";
     var anatomyParts = renderAnatomyContent(anatomy, componentHtml);

--- a/plugins/actian-design-system/skills/component-brief/SKILL.md
+++ b/plugins/actian-design-system/skills/component-brief/SKILL.md
@@ -27,25 +27,26 @@ Parse URL (`fileKey` + `nodeId` per `../../references/figma/figma-output.md`). O
 
 Before generating the data model, present the available cards and let the user choose. Present the card list for the detected mode:
 
-**DS Kit mode (7 cards, organized into 6 sections):**
+**DS Kit mode (5 cards):**
 ```
-Component brief for [Name] — 7 cards available:
+Component brief for [Name] — 5 cards available:
 
-| # | Section            | Card           | Content                                          |
-|---|--------------------|----------------|--------------------------------------------------|
-| 1 | Header             | Header         | Component name, description, metadata           |
-| 2 | 1. Anatomy + tokens| Component      | Real library instances — all variants           |
-| 3 | 1. Anatomy + tokens| Anatomy        | Structural breakdown with labeled parts         |
-| 4 | 1. Anatomy + tokens| Tokens         | Design token bindings (colors, spacing, type)   |
-| 5 | 2. Usages          | Usage          | Do/don't, when to use, when not to              |
-| 6 | 3. Content         | Content        | Copy guidelines, label patterns, error text     |
-| 7 | 5. Accessibility   | Accessibility  | WCAG compliance, keyboard, screen reader        |
+| # | Section                    | Card                   | Content                                          |
+|---|----------------------------|------------------------|--------------------------------------------------|
+| 1 | Header                     | Header                 | Component name, description, metadata           |
+| 2 | 1. Anatomy/var/tokens/specs | Section 1 (supercard) | Variation matrix, anatomy parts, token tables, dimension specs |
+| 3 | 2. Usages                  | Usage                  | When to use, when not to use, do/don't pairs    |
+| 4 | 3. Content                 | Content                | Copy guidelines, label patterns, terminology    |
+| 5 | 5. Accessibility           | Accessibility          | Keyboard, ARIA, contrast                        |
 
 Section 4 (Motion) is added automatically when the component has a curated motion pattern.
-Section 6 (Real platform examples) is not yet implemented — pending authoring contract.
+Section 6 (Real platform examples) is deferred — not generated yet.
 
-Cards: generate **all 7** or pick specific (e.g., "2,4,6").
-Research: cross-DS patterns can be researched before generating cards 5, 6, 7
+Cards: generate **all 5** or pick specific (e.g., "2,4").
+       Card numbering matches the gate; the data model still uses card_header,
+       card_component, card_anatomy, card_tokens, card_usage, card_content,
+       card_motion, card_accessibility keys (no schema migration in v1.67.0).
+Research: cross-DS patterns can be researched before generating cards 3, 4, 5
           to surface insights, recommendations, and divergences from existing
           context. Skip by default (faster, lower token cost).
           Reply: "research all" / "research usage,content" / nothing to skip.
@@ -69,14 +70,14 @@ Generate **all 5** or pick specific cards (e.g., "1,2,5").
 If the user pre-specifies cards in the prompt (e.g., "brief Button cards 2,4,5"), skip this gate and generate only those cards. The research scope can also ride the prompt: "brief Button cards 2,4,5 research content" → 3 cards + research only on card_content.
 
 Parser rules for the response:
-- Empty (just enter) → all 7 cards, no research
-- `"all"` → all 7 cards, no research
-- `"2,4,6"` → cards 2/4/6 only, no research
-- `"all research all"` → all 7 cards + research on cards 5/6/7
-- `"all research usage,content"` → all 7 + research on cards 5+6 only
-- `"2,4,6 research content"` → cards 2/4/6 + research only on card 6
+- Empty (just enter) → all 5 cards, no research
+- `"all"` → all 5 cards, no research
+- `"2,4"` → cards 2/4 only, no research
+- `"all research all"` → all 5 cards + research on cards 3/4/5
+- `"all research usage,content"` → all 5 + research on cards 3+4 only
+- `"2,4 research content"` → cards 2/4 + research only on card 4
 - `"research all"` (no card list) → treats as `"all research all"`
-- Invalid card number (e.g., 99) → re-prompt with "Card 99 doesn't exist. Valid: 1-7."
+- Invalid card number (e.g., 99) → re-prompt with "Card 99 doesn't exist. Valid: 1-5."
 - Invalid research scope (e.g., `research foo`) → re-prompt with "Unknown research scope `foo`. Valid: all, usage, content, accessibility."
 - Gate is re-enterable on parse failure (3 retry attempts then abort).
 
@@ -184,14 +185,13 @@ Read your `brief-data.json` and push directly to Figma using small `use_figma` c
 
 1. Create wrapper frame (Pattern 0 from component-brief/push-patterns.md — MUST be HORIZONTAL)
 2. Create GenLog instance (Pattern 0b — import by key, set 6 meta props, append to wrapper)
-3. **Card 1 — Page Header — create EXACTLY ONCE.** Use Pattern 1 with variant `"Mode=DS, Type=Page Header"`. **Set ALL three text properties** in a single `setProperties` call: `"Component Name#7:2"` = `card_header.name`, `"Description#7:3"` = `card_header.description`, `"Source#7:4"` = `"DS Kit"` (or appropriate library label). If you don't override these, Meta Kit's Page Header variant defaults leak through — you'll see "Button" / "The Button component is a surface-level element..." regardless of which component you're documenting (regression: see PR #23 follow-up). After creating + appending the Page Header, do NOT recreate it under any condition — proceed directly to card 2.
-4. For each remaining card in the data model (cards 2-N, skip `card_header`):
+3. **Card 1 — Page Header — create EXACTLY ONCE.** Use Pattern 1 with variant `"Mode=DS, Type=Page Header"`. **Set ALL three text properties** in a single `setProperties` call: `"Component Name#7:2"` = `card_header.name`, `"Description#7:3"` = `card_header.description`, `"Source#7:4"` = `"DS Kit"` (or appropriate library label). If you don't override these, Meta Kit's Page Header variant defaults leak through — you'll see "Button" / "The Button component is a surface-level element..." regardless of which component you're documenting (regression: see PR #23 follow-up). After creating + appending the Page Header, do NOT recreate it under any condition — proceed directly to Section 1.
+4. **Section 1 supercard — create EXACTLY ONCE (replaces former Cards 2/3/4).** Use Pattern 1 with variant `"Mode=DS, Type=Standard"`. Card title: `"Anatomy, variation, tokens & specs"`. Card subtitle: `"Structural breakdown, variants, token bindings, and dimension specs"` (both overridable from data model `card.cardTitle` / `card.cardSubtitle` if set). Inside the contentSlot, build four nested sub-frames per Pattern 1d: Anatomy / Variation / Tokens / Specs. Each sub-frame gets a 16px Semibold heading; if the corresponding source card (`card_anatomy` / `card_component` / `card_tokens` / `card_anatomy` for Specs) has `_source: "generated"` AND `_authored !== true`, append a small DRAFT tag next to the heading. Specs sub-frame is included only when `card_anatomy.specs` is non-empty.
+5. For each remaining card in the data model (Section 2 Usage, Section 3 Content, Section 4 Motion if present, Section 5 Accessibility — skip `card_header`, `card_component`, `card_anatomy`, `card_tokens`):
    a. Create card shell (Pattern 1). Read `card.cardTitle` and `card.cardSubtitle` from the data model — pass them straight to `setProperties` as `Title#140:0` and `Subtitle#140:1`. Do NOT hardcode card titles. **Default-leak detection (post-v1.66.0):** the Meta Kit Card Header now defaults to the generic placeholders `"Card title"` / `"Subtitle text"`. If a pushed card displays either string verbatim, `setProperties` silently failed (wrong property ID, wrong nested instance, or unresolved Card Header lookup) — fix the push call rather than ignoring the leak.
    b. Populate content: translate data model fields to Plugin API calls using component-brief/push-patterns.md
-   c. Anatomy card (`card_anatomy`): use the anatomy diagram pattern (~4-6KB inline call)
-   d. Tokens card (`card_tokens`): compact grid table — one row per state, Color Swatch per cell. Set `.fills` directly on swatch instance (flat, no children). Use `setProperties` for Section Headers (Pattern 2).
-   e. Accessibility card (`card_accessibility`): use the simplified Pattern 6 — render `requirements` as a vertical bulleted list with bold-title + plain-body rows (one row per requirement, no per-card frames, no embedded code blocks). This replaces the 2×3 a11y-card grid retired in v1.66.3. Then render the Contrast table and ARIA table after the requirements list. Use Contrast Badge `setProperties` and A11y Spec Row `setProperties` for the table rows.
-4. After all cards pushed, report to user with count
+   c. Accessibility card (`card_accessibility`): use the simplified Pattern 6 — render `requirements` as a vertical bulleted list with bold-title + plain-body rows (one row per requirement, no per-card frames, no embedded code blocks). This replaces the 2×3 a11y-card grid retired in v1.66.3. Then render the Contrast table and ARIA table after the requirements list. Use Contrast Badge `setProperties` and A11y Spec Row `setProperties` for the table rows.
+6. After all cards pushed, report to user with count
 
 **Rules:**
 - Each `use_figma` call creates 1-3 nodes max — keep calls small

--- a/plugins/actian-design-system/skills/component-brief/SKILL.md
+++ b/plugins/actian-design-system/skills/component-brief/SKILL.md
@@ -37,9 +37,10 @@ Component brief for [Name] — 5 cards available:
 | 2 | 1. Anatomy/var/tokens/specs | Section 1 (supercard) | Variation matrix, anatomy parts, token tables, dimension specs |
 | 3 | 2. Usages                  | Usage                  | When to use, when not to use, do/don't pairs    |
 | 4 | 3. Content                 | Content                | Copy guidelines, label patterns, terminology    |
+| — | 4. Motion (auto)           | Motion                 | Added automatically when a motion pattern exists |
 | 5 | 5. Accessibility           | Accessibility          | Keyboard, ARIA, contrast                        |
 
-Section 4 (Motion) is added automatically when the component has a curated motion pattern.
+Section 4 (Motion) is auto-added (not user-selectable in this gate) when the component has a curated motion pattern.
 Section 6 (Real platform examples) is deferred — not generated yet.
 
 Cards: generate **all 5** or pick specific (e.g., "2,4").

--- a/plugins/actian-design-system/tests/renderers/brief-renderer.test.js
+++ b/plugins/actian-design-system/tests/renderers/brief-renderer.test.js
@@ -1,0 +1,55 @@
+"use strict";
+
+var test = require("node:test");
+var assert = require("node:assert/strict");
+var path = require("path");
+var fs = require("fs");
+
+var renderer = require("../../scripts/renderers/html-renderers/brief-renderer.js");
+var BUTTON_FIXTURE = path.resolve(
+  __dirname, "..", "fixtures", "button-brief-data.json"
+);
+var fix = JSON.parse(fs.readFileSync(BUTTON_FIXTURE, "utf8"));
+
+function ph(name) { return '<div data-stub-component="' + name + '"></div>'; }
+
+test("renderSection1 returns one supercard with 4 sub-section headings", function () {
+  var html = renderer.renderSection1(
+    fix.card_component, fix.card_anatomy, fix.card_tokens, ph
+  );
+
+  // Single card frame
+  var cardFrameMatches = html.match(/<div class="brief-card"/g) || [];
+  assert.equal(cardFrameMatches.length, 1, "exactly one .brief-card frame");
+
+  // All four sub-section headings present
+  assert.ok(html.includes(">Structure<"), "Anatomy structure heading");
+  assert.ok(html.includes(">States<"), "Anatomy states heading");
+  assert.ok(html.includes(">Specs<"), "Specs heading");
+  assert.ok(html.includes(">Color tokens<") ||
+    html.includes(">Sizing & spacing<") ||
+    html.includes(">Typography<"), "at least one Tokens table heading");
+  // Variant matrix is data-name only (no sectionTitle today), so check that:
+  assert.ok(html.includes('data-name="Variant matrix"'), "Variation block present");
+
+  // Default card title ("Anatomy, variation, tokens & specs") visible
+  assert.ok(html.includes("Anatomy, variation, tokens"),
+    "supercard default title rendered");
+});
+
+test("renderSection1 returns empty string when all three inputs are empty", function () {
+  var html = renderer.renderSection1(null, null, null, ph);
+  assert.equal(html, "");
+});
+
+test("renderSection1 omits Specs sub-section when anatomy.specs absent", function () {
+  var anatomyNoSpecs = Object.assign({}, fix.card_anatomy);
+  delete anatomyNoSpecs.specs;
+  var html = renderer.renderSection1(
+    fix.card_component, anatomyNoSpecs, fix.card_tokens, ph
+  );
+  // Specs heading should be absent
+  assert.equal(html.indexOf(">Specs<"), -1);
+  // Other sub-sections should still be present
+  assert.ok(html.includes(">Color tokens<") || html.includes(">Sizing & spacing<"));
+});

--- a/plugins/actian-design-system/tests/renderers/brief-renderer.test.js
+++ b/plugins/actian-design-system/tests/renderers/brief-renderer.test.js
@@ -7,15 +7,23 @@ var fs = require("fs");
 
 var renderer = require("../../scripts/renderers/html-renderers/brief-renderer.js");
 var BUTTON_FIXTURE = path.resolve(
-  __dirname, "..", "fixtures", "button-brief-data.json"
+  __dirname,
+  "..",
+  "fixtures",
+  "button-brief-data.json",
 );
 var fix = JSON.parse(fs.readFileSync(BUTTON_FIXTURE, "utf8"));
 
-function ph(name) { return '<div data-stub-component="' + name + '"></div>'; }
+function ph(name) {
+  return '<div data-stub-component="' + name + '"></div>';
+}
 
 test("renderSection1 returns one supercard with 4 sub-section headings", function () {
   var html = renderer.renderSection1(
-    fix.card_component, fix.card_anatomy, fix.card_tokens, ph
+    fix.card_component,
+    fix.card_anatomy,
+    fix.card_tokens,
+    ph,
   );
 
   // Single card frame
@@ -26,15 +34,23 @@ test("renderSection1 returns one supercard with 4 sub-section headings", functio
   assert.ok(html.includes(">Structure<"), "Anatomy structure heading");
   assert.ok(html.includes(">States<"), "Anatomy states heading");
   assert.ok(html.includes(">Specs<"), "Specs heading");
-  assert.ok(html.includes(">Color tokens<") ||
-    html.includes(">Sizing & spacing<") ||
-    html.includes(">Typography<"), "at least one Tokens table heading");
+  assert.ok(
+    html.includes(">Color tokens<") ||
+      html.includes(">Sizing & spacing<") ||
+      html.includes(">Typography<"),
+    "at least one Tokens table heading",
+  );
   // Variant matrix is data-name only (no sectionTitle today), so check that:
-  assert.ok(html.includes('data-name="Variant matrix"'), "Variation block present");
+  assert.ok(
+    html.includes('data-name="Variant matrix"'),
+    "Variation block present",
+  );
 
   // Default card title ("Anatomy, variation, tokens & specs") visible
-  assert.ok(html.includes("Anatomy, variation, tokens"),
-    "supercard default title rendered");
+  assert.ok(
+    html.includes("Anatomy, variation, tokens"),
+    "supercard default title rendered",
+  );
 });
 
 test("renderSection1 returns empty string when all three inputs are empty", function () {
@@ -46,10 +62,57 @@ test("renderSection1 omits Specs sub-section when anatomy.specs absent", functio
   var anatomyNoSpecs = Object.assign({}, fix.card_anatomy);
   delete anatomyNoSpecs.specs;
   var html = renderer.renderSection1(
-    fix.card_component, anatomyNoSpecs, fix.card_tokens, ph
+    fix.card_component,
+    anatomyNoSpecs,
+    fix.card_tokens,
+    ph,
   );
   // Specs heading should be absent
   assert.equal(html.indexOf(">Specs<"), -1);
   // Other sub-sections should still be present
-  assert.ok(html.includes(">Color tokens<") || html.includes(">Sizing & spacing<"));
+  assert.ok(
+    html.includes(">Color tokens<") || html.includes(">Sizing & spacing<"),
+  );
+});
+
+test("renderSection1 + sibling renders together produce 6-card sequence (DS mode)", function () {
+  // Simulate the DOM cards array assembly the way DOMContentLoaded does it.
+  var cards = [
+    renderer.renderCard1(fix.card_header),
+    renderer.renderSection1(
+      fix.card_component,
+      fix.card_anatomy,
+      fix.card_tokens,
+      ph,
+    ),
+    renderer.renderCard6(fix.card_usage),
+    renderer.renderCard7(fix.card_content),
+    renderer.renderCardMotion(fix.card_motion),
+    renderer.renderCard8(fix.card_accessibility),
+  ].filter(Boolean);
+
+  // Button fixture has no card_motion → renderCardMotion returns "" → filtered out.
+  // So expect 5 visible cards.
+  assert.ok(
+    cards.length === 5 || cards.length === 6,
+    "5 or 6 cards depending on motion presence",
+  );
+
+  // Joined HTML should contain exactly one Section 1 supercard title.
+  var joined = cards.join("\n");
+  assert.ok(
+    joined.includes("Anatomy, variation, tokens"),
+    "supercard title appears in assembled output",
+  );
+
+  // Three legacy data-names should NOT appear as standalone cards
+  var componentDataName =
+    joined.match(/<div class="brief-card" data-name="Component"/g) || [];
+  var anatomyDataName =
+    joined.match(/<div class="brief-card" data-name="Anatomy"/g) || [];
+  var tokensDataName =
+    joined.match(/<div class="brief-card" data-name="Design tokens"/g) || [];
+  assert.equal(componentDataName.length, 0, "no separate Component card");
+  assert.equal(anatomyDataName.length, 0, "no separate Anatomy card");
+  assert.equal(tokensDataName.length, 0, "no separate Design tokens card");
 });

--- a/plugins/actian-design-system/tests/renderers/brief-renderer.test.js
+++ b/plugins/actian-design-system/tests/renderers/brief-renderer.test.js
@@ -30,20 +30,34 @@ test("renderSection1 returns one supercard with 4 sub-section headings", functio
   var cardFrameMatches = html.match(/<div class="brief-card"/g) || [];
   assert.equal(cardFrameMatches.length, 1, "exactly one .brief-card frame");
 
-  // All four sub-section headings present
-  assert.ok(html.includes(">Structure<"), "Anatomy structure heading");
-  assert.ok(html.includes(">States<"), "Anatomy states heading");
-  assert.ok(html.includes(">Specs<"), "Specs heading");
+  // All four sub-section headings present. First headings per sub-section now
+  // carry Draft badges (when _source is "generated"), so text is followed by a
+  // space and a <span> — check for ">Anatomy " and ">Variation " etc.
+  // Note: renderAnatomyContent now emits "Anatomy" as the first heading (was
+  // "Structure"); inner headings "States" and "Parts reference" are unchanged.
   assert.ok(
-    html.includes(">Color tokens<") ||
+    html.includes(">Anatomy<") || html.includes(">Anatomy "),
+    "Anatomy heading (first sub-section)",
+  );
+  assert.ok(html.includes(">States<"), "Anatomy states heading");
+  assert.ok(
+    html.includes(">Specs<") || html.includes(">Specs "),
+    "Specs heading",
+  );
+  // renderTokensContent now emits "Tokens" as the first heading (was
+  // "Color tokens"); inner headings "Sizing & spacing" / "Typography" are
+  // unchanged.
+  assert.ok(
+    html.includes(">Tokens<") ||
+      html.includes(">Tokens ") ||
       html.includes(">Sizing & spacing<") ||
       html.includes(">Typography<"),
     "at least one Tokens table heading",
   );
-  // Variant matrix is data-name only (no sectionTitle today), so check that:
+  // Variant matrix now has a "Variation" sectionTitle heading.
   assert.ok(
-    html.includes('data-name="Variant matrix"'),
-    "Variation block present",
+    html.includes(">Variation<") || html.includes(">Variation "),
+    "Variation heading present",
   );
 
   // Default card title ("Anatomy, variation, tokens & specs") visible
@@ -69,9 +83,71 @@ test("renderSection1 omits Specs sub-section when anatomy.specs absent", functio
   );
   // Specs heading should be absent
   assert.equal(html.indexOf(">Specs<"), -1);
+  assert.equal(html.indexOf(">Specs "), -1);
   // Other sub-sections should still be present
+  // Note: first Tokens heading is now "Tokens" (not "Color tokens").
   assert.ok(
-    html.includes(">Color tokens<") || html.includes(">Sizing & spacing<"),
+    html.includes(">Tokens<") ||
+      html.includes(">Tokens ") ||
+      html.includes(">Sizing & spacing<"),
+  );
+});
+
+test("Draft badge appears for generated sub-sections without _authored flag", function () {
+  // Button fixture is AI-generated (Phase B), no _authored flags.
+  var html = renderer.renderSection1(
+    fix.card_component,
+    fix.card_anatomy,
+    fix.card_tokens,
+    ph,
+  );
+  // Expect at least 3 Draft badges (one per sub-section heading where source is set)
+  var matches = html.match(/class="subsection-draft-badge"/g) || [];
+  assert.ok(
+    matches.length >= 3,
+    "at least 3 Draft badges (Anatomy / Variation / Tokens / Specs minus any missing)",
+  );
+});
+
+test("Draft badge suppressed when sub-section card has _authored: true", function () {
+  // Mark anatomy as authored. Anatomy and Specs both source from card_anatomy,
+  // so both their sub-section headings should drop the badge.
+  var anatomyAuthored = Object.assign({}, fix.card_anatomy, {
+    _authored: true,
+  });
+  var html = renderer.renderSection1(
+    fix.card_component,
+    anatomyAuthored,
+    fix.card_tokens,
+    ph,
+  );
+  // Variation and Tokens still draft → 2 badges remain
+  var matches = html.match(/class="subsection-draft-badge"/g) || [];
+  assert.equal(
+    matches.length,
+    2,
+    "Anatomy + Specs badges suppressed; Variation + Tokens still drafted",
+  );
+});
+
+test("Draft badge suppressed when sub-section card has _source: 'figma'", function () {
+  // Figma-sourced sub-section is treated as canonical; no badge.
+  var componentFigma = Object.assign({}, fix.card_component, {
+    _source: "figma",
+  });
+  var html = renderer.renderSection1(
+    componentFigma,
+    fix.card_anatomy,
+    fix.card_tokens,
+    ph,
+  );
+  // Variation badge suppressed; Anatomy + Tokens + Specs still draft (assuming
+  // their _source remains "generated"). Specs derives from anatomy so it gets
+  // anatomy's source state — counted with Anatomy.
+  var matches = html.match(/class="subsection-draft-badge"/g) || [];
+  assert.ok(
+    matches.length >= 2 && matches.length <= 3,
+    "Variation badge suppressed; others still draft (Specs may or may not)",
   );
 });
 

--- a/plugins/actian-design-system/tests/renderers/brief-renderer.test.js
+++ b/plugins/actian-design-system/tests/renderers/brief-renderer.test.js
@@ -92,10 +92,12 @@ test("renderSection1 + sibling renders together produce 6-card sequence (DS mode
   ].filter(Boolean);
 
   // Button fixture has no card_motion → renderCardMotion returns "" → filtered out.
-  // So expect 5 visible cards.
-  assert.ok(
-    cards.length === 5 || cards.length === 6,
-    "5 or 6 cards depending on motion presence",
+  // So expect EXACTLY 5 cards. (If a future fixture adds motion, write a
+  // separate test asserting === 6 — don't loosen this one to OR.)
+  assert.equal(
+    cards.length,
+    5,
+    "exactly 5 cards (no motion in Button fixture)",
   );
 
   // Joined HTML should contain exactly one Section 1 supercard title.


### PR DESCRIPTION
## Summary

- Restructures component briefs to Kristina's 6-section model. Section 1 (Anatomy / Variation / Tokens / Specs) now renders as a single supercard with sub-section dividers; Section 6 (real platform examples) is deferred until the authoring contract lands.
- New `renderSection1` composes four content helpers (`renderAnatomyContent`, `renderVariationContent`, `renderTokensContent`, `renderSpecsContent`) and picks an outer provenance via `pickSection1Provenance` (most-permissive-wins: figma > generated > generated+fallback).
- Per-sub-section Draft tags fire when `_source === "generated"` AND `_authored !== true` (Q8=C hybrid rollout). CSS class `.subsection-draft-badge` added.

## Implementation notes

- `brief-renderer.js` is now Node-importable behind `typeof document` guard (enables the new test suite).
- Legacy `renderCard2/3/4` retained as back-compat wrappers; default DS-mode cards array is now 6 entries (Header / Section 1 / Usage / Content / Motion / A11y).
- Push patterns updated with new `### 1d. Section 1 supercard (v1.67.0+)` and matching SKILL.md card-selection gate (5 user-selectable + Motion auto-add).
- Stale `card3_anatomy` reference in Pattern 1 example also fixed.

## Test plan

- [x] Full plugin test suite: 792/792 passing
- [x] New `tests/renderers/brief-renderer.test.js` covers supercard structure, empty inputs, Specs omission, Draft badge counts (generated / authored / figma cases), 6-card assembly
- [x] Spec compliance review (Tasks 1–6) approved
- [x] Code quality review (Tasks 1–6 + final branch) approved
- [ ] Smoke test in Figma after marketplace auto-update (visual confirmation that Section 1 renders as one card with four sub-frames + dividers)

## Related

- Spec/plan: `comms/SPEC-brief-6-section-restructure.md`, `comms/PLAN-brief-6-section-restructure.md` (gitignored locally)
- Touches `references/component-brief/push-patterns.md` — minor potential conflict with PR #25 (different sections of the file).

Generated with Claude Code