### PR TITLE
Brief Section 1 visuals — Phase 2 PR 1 (runtime primitives + Token Tag + card-width fix)

### DIFF
--- a/plugins/actian-design-system/.claude-plugin/plugin.json
+++ b/plugins/actian-design-system/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "actian-design-system",
   "description": "Actian Design System toolkit — sync tokens from Figma, generate wireframe flows with prototype wiring, create component briefs, audit designs, compare flows, and build presentations. 9 skills (with tiered generation: recognized / adapted / improvised), 8 agents, 155 tokens (3 themes, 8 collections), WCAG 2.1 AA.",
-  "version": "1.68.0",
+  "version": "1.69.0",
   "author": {
     "name": "Actian UX Team"
   },

--- a/plugins/actian-design-system/references/component-brief/push-patterns.md
+++ b/plugins/actian-design-system/references/component-brief/push-patterns.md
@@ -132,7 +132,18 @@ if (titleNode && titleNode.characters === "Card title") {
 // If a content slot lands without auto-layout (rare, only on legacy
 // instances), fix the Meta Kit component rather than re-introducing
 // hardcoded values here.
+//
+// CARD WIDTH HUG FIX (v1.69.0+): the content slot's primary axis sizing
+// must be AUTO so the supercard grows to fit the widest table. Phase 1
+// smoke (2026-05-06) showed Tokens tables clipping at the right edge
+// because the content slot was inheriting a FIXED width from Meta Kit.
+// Override here at slot level only — Meta Kit's padding/itemSpacing stay
+// intact.
 const contentSlot = cardFrame.findOne(n => n.name === "Content");
+if (contentSlot) {
+  contentSlot.primaryAxisSizingMode = "AUTO";
+  contentSlot.counterAxisSizingMode = "AUTO";
+}
 
 // Append to wrapper
 const wrapper = await figma.getNodeByIdAsync("<wrapperId>");

--- a/plugins/actian-design-system/references/component-brief/push-patterns.md
+++ b/plugins/actian-design-system/references/component-brief/push-patterns.md
@@ -320,6 +320,37 @@ headerRow.layoutSizingHorizontal = "FILL";
 return { tableId: headerRow.id };
 ```
 
+**Token Tag styling (v1.69.0+):** When a table cell contains a `--zen-*` token name, render the cell as a Token Tag pill instead of plain text. Use the same construction as Pattern 14's `tokenTagSpec`:
+
+```js
+async function appendTokenTagCell(parentRow, tokenText) {
+  await figma.loadFontAsync({ family: "Inter", style: "Medium" });
+  const labelFrame = figma.createFrame();
+  labelFrame.name = "Token: " + tokenText;
+  labelFrame.layoutMode = "HORIZONTAL";
+  labelFrame.primaryAxisSizingMode = "AUTO";
+  labelFrame.counterAxisSizingMode = "AUTO";
+  labelFrame.paddingLeft = 5;
+  labelFrame.paddingRight = 5;
+  labelFrame.paddingTop = 2;
+  labelFrame.paddingBottom = 2;
+  labelFrame.cornerRadius = 3;
+  labelFrame.fills = [{ type: "SOLID", color: { r: 0.941, g: 0.949, b: 0.984 } }]; // ~#F0F2FA
+
+  const text = figma.createText();
+  text.fontName = { family: "Inter", style: "Medium" };
+  text.fontSize = 12;
+  text.characters = tokenText;
+  text.fills = [{ type: "SOLID", color: { r: 0.020, g: 0.314, b: 0.863 } }]; // ~#0550DC
+  labelFrame.appendChild(text);
+
+  parentRow.appendChild(labelFrame);
+  return labelFrame;
+}
+```
+
+Use this for token-name cells in: parts table (Pattern 9 anatomy parts table), sizing table (Card 1 supercard Tokens sub-frame), typography table (same), contrast row token columns. Plain-text cells remain for non-token columns (Element name, Notes, Value).
+
 ---
 
 ## 4. Color Swatch Cell Pattern (Card 4 Color Token Grid)
@@ -373,6 +404,8 @@ cell.appendChild(textStack);
 ```
 
 Regression guard: if the cell or its parent row uses `counterAxisSizingMode = "FIXED"` or sets a hard `cell.resize(_, 20)`, the second line clips. Always Hug.
+
+**Token Tag styling (v1.69.0+):** The token-name text below the swatch dot must use the Token Tag pill style — same construction as Pattern 3's `appendTokenTagCell`. The hex value text below the token name stays as plain monospace text (it's not a token reference). Replace the `// token-name text node` placeholder with a call to `appendTokenTagCell(textStack, tokenName)` or the inline equivalent.
 
 **Table layout:** Build as a header row (state + column names) + data rows. Each data row: state label text + N swatch cells. The data row frame should use `layoutMode = "HORIZONTAL"`, `counterAxisAlignItems = "CENTER"`, and `counterAxisSizingMode = "AUTO"` so it grows to the tallest cell. Batch 2-3 rows per `use_figma` call.
 

--- a/plugins/actian-design-system/references/component-brief/push-patterns.md
+++ b/plugins/actian-design-system/references/component-brief/push-patterns.md
@@ -914,13 +914,13 @@ return { divergencesAndSourcesDone: true };
 
 ---
 
-## 14. Specs Redline Pattern (Section 1 Specs sub-frame, v1.68.0+)
+## 14. Specs Redline Pattern (Section 1 Specs sub-frame, v1.69.0+)
 
-Auto-extracted dimension annotations from the live component instance. Imports `Meta / Content / Dimension Annotation` and `Meta / Content / Pointer Badge` (both already in Meta Kit). Walks the instance for padding/itemSpacing, resolves bound variables to design-token names, falls back to raw px when unbound.
+Auto-extracted dimension annotations from the live component instance. Generates dimension lines from Plugin API primitives at runtime — `figma.createVector` for the line, two `figma.createLine` endcaps, `figma.createFrame` + `figma.createText` for the label pill. Replaces the v1.68.0 Meta Kit `Dimension Annotation` component path, which was blocked by the Plugin API's `resize()` limitation on component-instance children. Mirrors figma-measure (https://github.com/ph1p/figma-measure, MIT).
 
 The `card_anatomy.specs[]` field in `brief-data.json` is an **optional override** — if non-empty, those entries drive placement instead of the auto-extracted set. Default flow leaves it empty.
 
-Single ~4-6KB `use_figma` call. Mirrors Pattern 9's bounding-box approach.
+Single ~5-7KB `use_figma` call.
 
 ```js
 function hexToRgb(hex) {
@@ -928,17 +928,143 @@ function hexToRgb(hex) {
   return { r: parseInt(h.substring(0,2),16)/255, g: parseInt(h.substring(2,4),16)/255, b: parseInt(h.substring(4,6),16)/255 };
 }
 
-const PADDING = 64;  // larger than Pattern 9's 48px to give annotations room
-const DIMENSION_KEY = "49bf6a1b210a403ba145a3fdee9b1994eb54069a";  // Meta / Content / Dimension Annotation
-const POINTER_KEY   = "7e066fc21d9a2bbbcd1149113787cf59140162d4";  // Meta / Content / Pointer Badge
+const PADDING = 64;                              // larger than Pattern 9's 48px to give annotations room
+const REDLINE_COLOR = hexToRgb("#FF4D8E");       // pink — industry standard for redlines
+const STROKE_WEIGHT = 1;
+const ENDCAP_LENGTH = STROKE_WEIGHT + 6;         // figma-measure convention
+const LABEL_GAP = 4;                             // gap between line and label
 
-// 1. Container
+await figma.loadFontAsync({ family: "Inter", style: "Medium" });
+
+// --- Inline pure functions (mirrors scripts/lib/dimension-line.js + token-tag.js) ---
+
+function vectorPathFor(distance, orientation) {
+  if (orientation === "horizontal") return "M 0 0 L " + distance + " 0 Z";
+  return "M 0 0 L 0 " + distance + " Z";
+}
+
+function endcapPositionsFor(distance, orientation) {
+  if (orientation === "horizontal") {
+    return {
+      cap1: { x: 0, y: -ENDCAP_LENGTH / 2, rotation: 90 },
+      cap2: { x: distance, y: -ENDCAP_LENGTH / 2, rotation: 90 },
+    };
+  }
+  return {
+    cap1: { x: -ENDCAP_LENGTH / 2, y: 0, rotation: 0 },
+    cap2: { x: -ENDCAP_LENGTH / 2, y: distance, rotation: 0 },
+  };
+}
+
+function labelAnchor(distance, orientation, labelW, labelH) {
+  if (orientation === "horizontal") {
+    return { x: (distance - labelW) / 2, y: -labelH - LABEL_GAP };
+  }
+  return { x: LABEL_GAP, y: (distance - labelH) / 2 };
+}
+
+function tokenTagSpec(text) {
+  return {
+    text: text,
+    bgColor: { r: 0.941, g: 0.949, b: 0.984 }, // ~#F0F2FA
+    fgColor: { r: 0.020, g: 0.314, b: 0.863 }, // ~#0550DC
+    fontName: { family: "Inter", style: "Medium" },
+    fontSize: 12,
+    paddingX: 5,
+    paddingY: 2,
+    cornerRadius: 3,
+  };
+}
+
+function annotationVariant(prop, autolayout) {
+  if (prop === "paddingLeft" || prop === "paddingRight") return "horizontal";
+  if (prop === "paddingTop" || prop === "paddingBottom") return "vertical";
+  if (prop === "itemSpacing") return autolayout === "HORIZONTAL" ? "horizontal" : "vertical";
+  throw new Error("Unknown property: " + prop);
+}
+
+function formatLabel(value) {
+  return value.token ? `${value.px}px — ${value.token}` : `${value.px}px`;
+}
+
+// --- Build a single dimension annotation (line + caps + label pill) ---
+
+function buildDimensionAnnotation(distance, orientation, labelText) {
+  const wrapper = figma.createFrame();
+  wrapper.layoutMode = "NONE";
+  wrapper.fills = [];
+  wrapper.clipsContent = false;
+
+  // Line vector
+  const line = figma.createVector();
+  line.vectorPaths = [{ windingRule: "NONE", data: vectorPathFor(distance, orientation) }];
+  line.strokes = [{ type: "SOLID", color: REDLINE_COLOR }];
+  line.strokeWeight = STROKE_WEIGHT;
+  if (orientation === "horizontal") line.resize(distance, STROKE_WEIGHT);
+  else line.resize(STROKE_WEIGHT, distance);
+  line.x = 0;
+  line.y = 0;
+  wrapper.appendChild(line);
+
+  // Endcap ticks
+  const caps = endcapPositionsFor(distance, orientation);
+  function makeCap(c) {
+    const cap = figma.createLine();
+    cap.resize(ENDCAP_LENGTH, 0);
+    cap.strokes = [{ type: "SOLID", color: REDLINE_COLOR }];
+    cap.strokeWeight = STROKE_WEIGHT;
+    cap.rotation = c.rotation;
+    cap.x = c.x;
+    cap.y = c.y;
+    wrapper.appendChild(cap);
+  }
+  makeCap(caps.cap1);
+  makeCap(caps.cap2);
+
+  // Label pill
+  const spec = tokenTagSpec(labelText);
+  const labelFrame = figma.createFrame();
+  labelFrame.layoutMode = "HORIZONTAL";
+  labelFrame.primaryAxisSizingMode = "AUTO";
+  labelFrame.counterAxisSizingMode = "AUTO";
+  labelFrame.paddingLeft = spec.paddingX;
+  labelFrame.paddingRight = spec.paddingX;
+  labelFrame.paddingTop = spec.paddingY;
+  labelFrame.paddingBottom = spec.paddingY;
+  labelFrame.cornerRadius = spec.cornerRadius;
+  labelFrame.fills = [{ type: "SOLID", color: spec.bgColor }];
+
+  const labelText_ = figma.createText();
+  labelText_.fontName = spec.fontName;
+  labelText_.fontSize = spec.fontSize;
+  labelText_.characters = spec.text;
+  labelText_.fills = [{ type: "SOLID", color: spec.fgColor }];
+  labelFrame.appendChild(labelText_);
+  wrapper.appendChild(labelFrame);
+
+  // Position label after auto-layout has sized it
+  const anchor = labelAnchor(distance, orientation, labelFrame.width, labelFrame.height);
+  labelFrame.x = anchor.x;
+  labelFrame.y = anchor.y;
+
+  // Wrapper sizing — bound the visible area
+  if (orientation === "horizontal") {
+    wrapper.resize(Math.max(distance, labelFrame.width), labelFrame.height + LABEL_GAP + ENDCAP_LENGTH);
+  } else {
+    wrapper.resize(labelFrame.width + LABEL_GAP + ENDCAP_LENGTH, Math.max(distance, labelFrame.height));
+  }
+
+  return wrapper;
+}
+
+// --- Walk the target instance + place annotations ---
+
 const container = figma.createFrame();
 container.name = "Specs redline";
 container.fills = [{ type: "SOLID", color: hexToRgb("#FAFAFF") }];
-container.layoutMode = "NONE";  // freeform — annotations placed by absolute math
+container.layoutMode = "NONE";
+container.clipsContent = false;
 
-// 2. Target instance (same variant rule as Pattern 9)
 const targetNode = await figma.getNodeByIdAsync("<targetNodeId>");
 let variantComp;
 if (targetNode.type === "COMPONENT_SET") {
@@ -953,10 +1079,8 @@ inst.x = PADDING;
 inst.y = PADDING;
 container.resize(inst.width + PADDING * 2, inst.height + PADDING * 2);
 
-// 3. Walk frames — collect surface candidates
-// Top-level always surfaces; nested surfaces only when a direct child name matches an anatomy part.
-// Skip deeper nesting.
-const anatomyParts = card_anatomy.parts || [];  // from brief-data.json
+// Auto-extraction default path (override path described below)
+const anatomyParts = card_anatomy.parts || [];
 const partNameSet = new Set(anatomyParts.map(p => p.figmaLayerName));
 
 function shouldSurface(node, isTopLevel) {
@@ -973,7 +1097,6 @@ function walk(node, isTopLevel) {
 }
 walk(inst, true);
 
-// 4. For each surface, collect spacing values + bind ids, then resolve to token names
 async function resolveValue(numericPx, boundId) {
   if (!boundId) return { px: numericPx, token: null };
   try {
@@ -985,26 +1108,15 @@ async function resolveValue(numericPx, boundId) {
   }
 }
 
-function annotationVariant(prop, autolayout) {
-  if (prop === "paddingLeft" || prop === "paddingRight") return "Horizontal";
-  if (prop === "paddingTop" || prop === "paddingBottom") return "Vertical";
-  if (prop === "itemSpacing") return autolayout === "HORIZONTAL" ? "Horizontal" : "Vertical";
-  throw new Error("Unknown property: " + prop);
-}
-
-function formatLabel(v) {
-  return v.token ? `${v.px}px — ${v.token}` : `${v.px}px`;
-}
-
-// 5. Place Dimension Annotations per surface
-const dimSet = await figma.importComponentSetByKeyAsync(DIMENSION_KEY);
-let collisions = 0;
 let extractedFrames = 0;
 let boundVariablesCount = 0;
 let unresolvedVariables = 0;
+let tokenTagsRendered = 0;
+let annotationCollisions = 0;
+const placedAnnotations = []; // for collision detection
 
 for (const surface of surfaces) {
-  if (surface.layoutMode === "NONE") continue;  // not autolayout — skip
+  if (surface.layoutMode === "NONE") continue;
   extractedFrames += 1;
 
   const props = ["paddingLeft", "paddingRight", "paddingTop", "paddingBottom", "itemSpacing"];
@@ -1017,44 +1129,46 @@ for (const surface of surfaces) {
     if (value.token) boundVariablesCount += 1;
     else if (boundId) unresolvedVariables += 1;
 
-    const variantName = "Orientation=" + annotationVariant(prop, surface.layoutMode);
-    const variant = dimSet.findChild(n => n.name === variantName) ||
-                    dimSet.defaultVariant ||
-                    dimSet.children[0];
-    const ann = variant.createInstance();
-    ann.setProperties({ "Value#45:7": formatLabel(value) });
+    const orientation = annotationVariant(prop, surface.layoutMode);
+    const annotation = buildDimensionAnnotation(px, orientation, formatLabel(value));
+    tokenTagsRendered += 1;
 
-    // Position the annotation against the surface's bounding box.
-    // Convention: paddingLeft → annotation left of left edge; paddingRight → right of right edge;
-    //             paddingTop → above top edge; paddingBottom → below bottom edge;
-    //             itemSpacing → centered between first two children along the autolayout axis.
+    // Position annotation against the surface's bounding box
     const sbb = surface.absoluteBoundingBox;
     const cbb = container.absoluteBoundingBox;
     const sx = sbb.x - cbb.x;
     const sy = sbb.y - cbb.y;
     const GAP = 8;
     if (prop === "paddingLeft") {
-      ann.x = sx - ann.width - GAP;
-      ann.y = sy + sbb.height / 2 - ann.height / 2;
+      annotation.x = sx - annotation.width - GAP;
+      annotation.y = sy + sbb.height / 2 - annotation.height / 2;
     } else if (prop === "paddingRight") {
-      ann.x = sx + sbb.width + GAP;
-      ann.y = sy + sbb.height / 2 - ann.height / 2;
+      annotation.x = sx + sbb.width + GAP;
+      annotation.y = sy + sbb.height / 2 - annotation.height / 2;
     } else if (prop === "paddingTop") {
-      ann.x = sx + sbb.width / 2 - ann.width / 2;
-      ann.y = sy - ann.height - GAP;
+      annotation.x = sx + sbb.width / 2 - annotation.width / 2;
+      annotation.y = sy - annotation.height - GAP;
     } else if (prop === "paddingBottom") {
-      ann.x = sx + sbb.width / 2 - ann.width / 2;
-      ann.y = sy + sbb.height + GAP;
+      annotation.x = sx + sbb.width / 2 - annotation.width / 2;
+      annotation.y = sy + sbb.height + GAP;
     } else if (prop === "itemSpacing") {
-      // Place at the center of the surface — this is approximate; refine in Phase 2 if it overlaps content.
-      ann.x = sx + sbb.width / 2 - ann.width / 2;
-      ann.y = sy + sbb.height / 2 - ann.height / 2;
+      annotation.x = sx + sbb.width / 2 - annotation.width / 2;
+      annotation.y = sy + sbb.height / 2 - annotation.height / 2;
     }
-    container.appendChild(ann);
+
+    // Collision detection — increment counter when within 8px of an existing annotation
+    for (const placed of placedAnnotations) {
+      if (Math.abs(annotation.x - placed.x) < 8 && Math.abs(annotation.y - placed.y) < 8) {
+        annotationCollisions += 1;
+        break;
+      }
+    }
+    placedAnnotations.push({ x: annotation.x, y: annotation.y });
+
+    container.appendChild(annotation);
   }
 }
 
-// 6. Append the redline container to the Specs sub-frame
 const parent = await figma.getNodeByIdAsync("<specsSubFrameId>");
 parent.appendChild(container);
 
@@ -1065,21 +1179,35 @@ return {
     boundVariables: boundVariablesCount,
     unresolvedVariables,
     authorOverrides: 0,
-    annotationCollisions: collisions
-  }
+    annotationCollisions,
+    tokenTagsRendered,
+  },
 };
 ```
 
-**When `card_anatomy.specs[]` is non-empty (author override):** skip step 3 (frame walk) and place one Dimension Annotation per `specs[i]` instead, anchored by `specs[i].layerName` (drop the entry if the layer doesn't exist in the rendered variant — log to manifest). Use `specs[i].value` and `specs[i].tokenName` directly without resolution. Set `pattern14.authorOverrides` to the count placed.
+**When `card_anatomy.specs[]` is non-empty (author override path):** skip the surface walk above and emit one annotation per `specs[i]` entry instead. For each entry, find the layer named `specs[i].layerName` in the rendered instance via `inst.findOne(n => n.name === specs[i].layerName)`. If the layer is missing, drop the entry and increment a `droppedSpecs` counter for the manifest. Otherwise read the layer's relevant dimension (`specs[i].value`) and call `buildDimensionAnnotation(specs[i].value, specs[i].orientation || "horizontal", formatLabel({ px: specs[i].value, token: specs[i].tokenName || null }))`. Append the annotation to the container at the layer's bounding-box edge per `specs[i].side`. Set `pattern14.authorOverrides` to the placed count.
 
-**Failure modes** (from Phase 1 design spec):
+**Pointer Badge sizing path** — for components with explicit `width` or `height` token bindings on the top-level instance frame, emit a "pointer badge" pill instead of a dimension line. The pointer badge is a single Token Tag pill (no line, no caps) anchored at the instance's closest edge. Build with the same `tokenTagSpec` helper:
 
-- Component has no autolayout → render text-table fallback (`Pattern 3`) with note "Auto-extraction unavailable — no autolayout."
+```js
+const wbid = inst.boundVariables?.width?.id || null;
+const hbid = inst.boundVariables?.height?.id || null;
+if (wbid || hbid) {
+  const wValue = await resolveValue(inst.width, wbid);
+  const hValue = await resolveValue(inst.height, hbid);
+  // emit pointer-style Token Tag at edge — see Pattern 8 / Pattern 4 for token tag construction details
+  // (caller composes the same labelFrame as inside buildDimensionAnnotation, positions at instance edge)
+}
+```
+
+Skip if both are unbound (most common case).
+
+**Failure modes** (from Phase 2 design spec):
+
+- Component has no autolayout → skip redline render. Emit a primitive text node footnote in the Specs sub-frame: "Auto-extraction unavailable — no autolayout detected on this component."
 - `getVariableByIdAsync` returns null → keep raw px, increment `unresolvedVariables`.
-- Layer referenced by author-supplied spec doesn't exist → drop spec entry, log to manifest.
-- Annotations would overlap → reduce `Value#45:7` font to 9pt before colliding (Phase 2 will add proper collision routing).
-
-**Pointer Badge sizing annotations:** for components with explicit `width`/`height` token bindings on the top-level frame, place a `Meta / Content / Pointer Badge` instead of a Dimension Annotation, with `Direction` matching the closest container edge and `Label#45:4 = formatLabel(value)`. Skip if dimensions are unbound (most common case).
+- Layer referenced by author-supplied spec doesn't exist → drop spec entry, increment `droppedSpecs` in manifest.
+- Two annotations within 8px of each other → increment `annotationCollisions` in manifest. Phase 3 adds proper collision routing.
 
 ---
 

--- a/plugins/actian-design-system/scripts/lib/dimension-line.js
+++ b/plugins/actian-design-system/scripts/lib/dimension-line.js
@@ -40,7 +40,20 @@ function endcapPositions(distance, orientation, strokeWeight) {
 }
 
 function labelAnchorFor(distance, orientation, labelDimensions) {
-  throw new Error("not implemented");
+  var LABEL_GAP = 4;
+  if (orientation === "horizontal") {
+    return {
+      x: (distance - labelDimensions.width) / 2,
+      y: -labelDimensions.height - LABEL_GAP,
+    };
+  }
+  if (orientation === "vertical") {
+    return {
+      x: LABEL_GAP,
+      y: (distance - labelDimensions.height) / 2,
+    };
+  }
+  throw new Error("Unknown orientation: " + orientation);
 }
 
 module.exports = {

--- a/plugins/actian-design-system/scripts/lib/dimension-line.js
+++ b/plugins/actian-design-system/scripts/lib/dimension-line.js
@@ -15,7 +15,9 @@
  */
 
 function vectorPathFor(distance, orientation) {
-  throw new Error("not implemented");
+  if (orientation === "horizontal") return "M 0 0 L " + distance + " 0 Z";
+  if (orientation === "vertical") return "M 0 0 L 0 " + distance + " Z";
+  throw new Error("Unknown orientation: " + orientation);
 }
 
 function endcapPositions(distance, orientation, strokeWeight) {

--- a/plugins/actian-design-system/scripts/lib/dimension-line.js
+++ b/plugins/actian-design-system/scripts/lib/dimension-line.js
@@ -1,0 +1,33 @@
+"use strict";
+
+/**
+ * Pure decision functions for the runtime-primitive dimension annotation used
+ * by component-brief Pattern 14 (Specs Redline). Replaces the Meta Kit
+ * "Dimension Annotation" component path that was blocked by the Plugin API's
+ * resize() limitation on component-instance children (Phase 1 finding).
+ *
+ * Algorithm mirrors figma-measure (https://github.com/ph1p/figma-measure, MIT)
+ * — createVector for the line, two createLine endcaps rotated 90° at each end,
+ * label centered above (horizontal) or to the right (vertical).
+ *
+ * The push-pattern code in references/component-brief/push-patterns.md inlines
+ * this logic for Figma sandbox execution; this module exists for unit testing.
+ */
+
+function vectorPathFor(distance, orientation) {
+  throw new Error("not implemented");
+}
+
+function endcapPositions(distance, orientation, strokeWeight) {
+  throw new Error("not implemented");
+}
+
+function labelAnchorFor(distance, orientation, labelDimensions) {
+  throw new Error("not implemented");
+}
+
+module.exports = {
+  vectorPathFor,
+  endcapPositions,
+  labelAnchorFor,
+};

--- a/plugins/actian-design-system/scripts/lib/dimension-line.js
+++ b/plugins/actian-design-system/scripts/lib/dimension-line.js
@@ -21,7 +21,22 @@ function vectorPathFor(distance, orientation) {
 }
 
 function endcapPositions(distance, orientation, strokeWeight) {
-  throw new Error("not implemented");
+  var length = strokeWeight + 6;
+  if (orientation === "horizontal") {
+    return {
+      length: length,
+      cap1: { x: 0, y: -length / 2, rotation: 90 },
+      cap2: { x: distance, y: -length / 2, rotation: 90 },
+    };
+  }
+  if (orientation === "vertical") {
+    return {
+      length: length,
+      cap1: { x: -length / 2, y: 0, rotation: 0 },
+      cap2: { x: -length / 2, y: distance, rotation: 0 },
+    };
+  }
+  throw new Error("Unknown orientation: " + orientation);
 }
 
 function labelAnchorFor(distance, orientation, labelDimensions) {

--- a/plugins/actian-design-system/scripts/lib/token-tag.js
+++ b/plugins/actian-design-system/scripts/lib/token-tag.js
@@ -1,0 +1,24 @@
+"use strict";
+
+/**
+ * Pure decision functions for the Token Tag pill style used across the brief.
+ * Used by component-brief Pattern 14 (Specs Redline) labels AND by Pattern 3
+ * (Table) cells + Pattern 4 (Color Swatch) labels wherever a --zen-* token
+ * name appears.
+ *
+ * The push-pattern code in references/component-brief/push-patterns.md inlines
+ * this logic for Figma sandbox execution; this module exists for unit testing.
+ */
+
+function tokenTagSpec(text) {
+  throw new Error("not implemented");
+}
+
+function tokenTagDimensions(text, fontMetrics) {
+  throw new Error("not implemented");
+}
+
+module.exports = {
+  tokenTagSpec,
+  tokenTagDimensions,
+};

--- a/plugins/actian-design-system/scripts/lib/token-tag.js
+++ b/plugins/actian-design-system/scripts/lib/token-tag.js
@@ -11,7 +11,16 @@
  */
 
 function tokenTagSpec(text) {
-  throw new Error("not implemented");
+  return {
+    text: text,
+    bgColor: { r: 0.941, g: 0.949, b: 0.984 }, // ~#F0F2FA — light blue tint
+    fgColor: { r: 0.02, g: 0.314, b: 0.863 }, // ~#0550DC — primary blue
+    fontName: { family: "Inter", style: "Medium" },
+    fontSize: 12,
+    paddingX: 5,
+    paddingY: 2,
+    cornerRadius: 3,
+  };
 }
 
 function tokenTagDimensions(text, fontMetrics) {

--- a/plugins/actian-design-system/scripts/lib/token-tag.js
+++ b/plugins/actian-design-system/scripts/lib/token-tag.js
@@ -24,7 +24,11 @@ function tokenTagSpec(text) {
 }
 
 function tokenTagDimensions(text, fontMetrics) {
-  throw new Error("not implemented");
+  var paddingX = 5;
+  var paddingY = 2;
+  var width = (text || "").length * fontMetrics.avgCharWidth + 2 * paddingX;
+  var height = fontMetrics.lineHeight + 2 * paddingY;
+  return { width: width, height: height };
 }
 
 module.exports = {

--- a/plugins/actian-design-system/tests/integration/contract.test.js
+++ b/plugins/actian-design-system/tests/integration/contract.test.js
@@ -291,52 +291,29 @@ describe("Contract Tests", function () {
 });
 
 // ---------------------------------------------------------------------------
-// Part 5: Meta Kit redline component key contracts
+// Part 5: Pattern 14 runtime-primitive module contracts (v1.69.0+)
 // ---------------------------------------------------------------------------
 //
-// Pattern 14 (Specs Redline) imports two Meta Kit components by key. If a
-// future Meta Kit sync renames or republishes these components, the keys
-// silently change and Pattern 14 falls over at push time. Pin both keys here.
+// Pattern 14 (Specs Redline) was rewritten in v1.69.0 to use runtime
+// primitives (createVector + createLine + createFrame) instead of Meta Kit
+// component instances. The rewrite extracted pure decision logic into
+// scripts/lib/dimension-line.js and scripts/lib/token-tag.js so the algorithm
+// can be unit-tested. Pin those module exports here — catches accidental
+// breakage in the Pattern 14 push-pattern code path.
 
-describe("Pattern 14 redline component keys", function () {
-  var pushPatternsPath = path.join(
-    PLUGIN_ROOT,
-    "references",
-    "component-brief",
-    "push-patterns.md",
-  );
-  var pushPatterns = fs.readFileSync(pushPatternsPath, "utf8");
-
-  it("references Meta / Content / Dimension Annotation key", function () {
-    assert.ok(
-      pushPatterns.includes("49bf6a1b210a403ba145a3fdee9b1994eb54069a"),
-      "push-patterns.md must reference the Dimension Annotation component key",
+describe("Pattern 14 runtime-primitive module exports", function () {
+  it("dimension-line.js exports the three pure functions", function () {
+    var mod = require(
+      path.join(PLUGIN_ROOT, "scripts", "lib", "dimension-line.js"),
     );
+    assert.strictEqual(typeof mod.vectorPathFor, "function");
+    assert.strictEqual(typeof mod.endcapPositions, "function");
+    assert.strictEqual(typeof mod.labelAnchorFor, "function");
   });
 
-  it("references Meta / Content / Pointer Badge key", function () {
-    assert.ok(
-      pushPatterns.includes("7e066fc21d9a2bbbcd1149113787cf59140162d4"),
-      "push-patterns.md must reference the Pointer Badge component key",
-    );
-  });
-
-  it("Meta Kit registry still ships both components", function () {
-    var registryPath = path.join(
-      PLUGIN_ROOT,
-      "docs",
-      "generated",
-      "metakit.json",
-    );
-    var registry = JSON.parse(fs.readFileSync(registryPath, "utf8"));
-    var dim = registry.components["meta-content-dimension-annotation"];
-    var ptr = registry.components["meta-content-pointer-badge"];
-    assert.ok(
-      dim,
-      "metakit.json must include meta-content-dimension-annotation",
-    );
-    assert.ok(ptr, "metakit.json must include meta-content-pointer-badge");
-    assert.strictEqual(dim.key, "49bf6a1b210a403ba145a3fdee9b1994eb54069a");
-    assert.strictEqual(ptr.key, "7e066fc21d9a2bbbcd1149113787cf59140162d4");
+  it("token-tag.js exports the two pure functions", function () {
+    var mod = require(path.join(PLUGIN_ROOT, "scripts", "lib", "token-tag.js"));
+    assert.strictEqual(typeof mod.tokenTagSpec, "function");
+    assert.strictEqual(typeof mod.tokenTagDimensions, "function");
   });
 });

--- a/plugins/actian-design-system/tests/lib/dimension-line.test.js
+++ b/plugins/actian-design-system/tests/lib/dimension-line.test.js
@@ -12,3 +12,23 @@ describe("dimension-line — wiring", function () {
     assert.strictEqual(typeof mod.labelAnchorFor, "function");
   });
 });
+
+describe("vectorPathFor", function () {
+  it("horizontal line goes left to right", function () {
+    assert.strictEqual(mod.vectorPathFor(16, "horizontal"), "M 0 0 L 16 0 Z");
+  });
+
+  it("vertical line goes top to bottom", function () {
+    assert.strictEqual(mod.vectorPathFor(24, "vertical"), "M 0 0 L 0 24 Z");
+  });
+
+  it("returns valid path even for zero distance (defensive — caller filters)", function () {
+    assert.strictEqual(mod.vectorPathFor(0, "horizontal"), "M 0 0 L 0 0 Z");
+  });
+
+  it("throws on unknown orientation", function () {
+    assert.throws(function () {
+      mod.vectorPathFor(16, "diagonal");
+    }, /Unknown orientation: diagonal/);
+  });
+});

--- a/plugins/actian-design-system/tests/lib/dimension-line.test.js
+++ b/plugins/actian-design-system/tests/lib/dimension-line.test.js
@@ -75,3 +75,39 @@ describe("endcapPositions", function () {
     }, /Unknown orientation: diagonal/);
   });
 });
+
+describe("labelAnchorFor", function () {
+  it("horizontal — label centered horizontally above the line", function () {
+    var anchor = mod.labelAnchorFor(100, "horizontal", {
+      width: 40,
+      height: 20,
+    });
+    assert.strictEqual(anchor.x, 30); // (100 - 40) / 2 = 30
+    assert.strictEqual(anchor.y, -24); // -labelHeight - LABEL_GAP = -20 - 4
+  });
+
+  it("vertical — label positioned to the right of the line, centered vertically", function () {
+    var anchor = mod.labelAnchorFor(100, "vertical", { width: 40, height: 20 });
+    assert.strictEqual(anchor.x, 4); // LABEL_GAP
+    assert.strictEqual(anchor.y, 40); // (100 - 20) / 2 = 40
+  });
+
+  it("horizontal — handles label wider than line (negative x is acceptable)", function () {
+    var anchor = mod.labelAnchorFor(20, "horizontal", {
+      width: 60,
+      height: 20,
+    });
+    assert.strictEqual(anchor.x, -20); // (20 - 60) / 2 = -20
+  });
+
+  it("vertical — handles label taller than line", function () {
+    var anchor = mod.labelAnchorFor(10, "vertical", { width: 40, height: 30 });
+    assert.strictEqual(anchor.y, -10); // (10 - 30) / 2 = -10
+  });
+
+  it("throws on unknown orientation", function () {
+    assert.throws(function () {
+      mod.labelAnchorFor(100, "diagonal", { width: 40, height: 20 });
+    }, /Unknown orientation: diagonal/);
+  });
+});

--- a/plugins/actian-design-system/tests/lib/dimension-line.test.js
+++ b/plugins/actian-design-system/tests/lib/dimension-line.test.js
@@ -1,0 +1,14 @@
+#!/usr/bin/env node
+"use strict";
+
+var { describe, it } = require("node:test");
+var assert = require("node:assert");
+var mod = require("../../scripts/lib/dimension-line.js");
+
+describe("dimension-line — wiring", function () {
+  it("exports the three pure functions", function () {
+    assert.strictEqual(typeof mod.vectorPathFor, "function");
+    assert.strictEqual(typeof mod.endcapPositions, "function");
+    assert.strictEqual(typeof mod.labelAnchorFor, "function");
+  });
+});

--- a/plugins/actian-design-system/tests/lib/dimension-line.test.js
+++ b/plugins/actian-design-system/tests/lib/dimension-line.test.js
@@ -32,3 +32,46 @@ describe("vectorPathFor", function () {
     }, /Unknown orientation: diagonal/);
   });
 });
+
+describe("endcapPositions", function () {
+  it("horizontal — cap1 at x=0, cap2 at x=distance, both rotated 90°", function () {
+    var caps = mod.endcapPositions(16, "horizontal", 1);
+    assert.strictEqual(caps.cap1.x, 0);
+    assert.strictEqual(caps.cap2.x, 16);
+    assert.strictEqual(caps.cap1.rotation, 90);
+    assert.strictEqual(caps.cap2.rotation, 90);
+  });
+
+  it("horizontal — caps centered vertically on the line (y = -length/2)", function () {
+    var caps = mod.endcapPositions(16, "horizontal", 1);
+    var expectedLength = 1 + 6; // strokeWeight + 6
+    assert.strictEqual(caps.cap1.y, -expectedLength / 2);
+    assert.strictEqual(caps.cap2.y, -expectedLength / 2);
+  });
+
+  it("vertical — cap1 at y=0, cap2 at y=distance, both rotated 0°", function () {
+    var caps = mod.endcapPositions(24, "vertical", 1);
+    assert.strictEqual(caps.cap1.y, 0);
+    assert.strictEqual(caps.cap2.y, 24);
+    assert.strictEqual(caps.cap1.rotation, 0);
+    assert.strictEqual(caps.cap2.rotation, 0);
+  });
+
+  it("vertical — caps centered horizontally on the line (x = -length/2)", function () {
+    var caps = mod.endcapPositions(24, "vertical", 1);
+    var expectedLength = 1 + 6;
+    assert.strictEqual(caps.cap1.x, -expectedLength / 2);
+    assert.strictEqual(caps.cap2.x, -expectedLength / 2);
+  });
+
+  it("length scales with strokeWeight (cap = strokeWeight + 6)", function () {
+    var caps = mod.endcapPositions(16, "horizontal", 2);
+    assert.strictEqual(caps.length, 8); // 2 + 6
+  });
+
+  it("throws on unknown orientation", function () {
+    assert.throws(function () {
+      mod.endcapPositions(16, "diagonal", 1);
+    }, /Unknown orientation: diagonal/);
+  });
+});

--- a/plugins/actian-design-system/tests/lib/token-tag.test.js
+++ b/plugins/actian-design-system/tests/lib/token-tag.test.js
@@ -11,3 +11,38 @@ describe("token-tag — wiring", function () {
     assert.strictEqual(typeof mod.tokenTagDimensions, "function");
   });
 });
+
+describe("tokenTagSpec", function () {
+  it("returns the style object with the input text", function () {
+    var spec = mod.tokenTagSpec("--zen-spacing-md");
+    assert.strictEqual(spec.text, "--zen-spacing-md");
+  });
+
+  it("uses Inter Medium 12px monospace-style font", function () {
+    var spec = mod.tokenTagSpec("--zen-color-primary");
+    assert.deepStrictEqual(spec.fontName, { family: "Inter", style: "Medium" });
+    assert.strictEqual(spec.fontSize, 12);
+  });
+
+  it("returns RGB color objects (not hex strings) for fills", function () {
+    var spec = mod.tokenTagSpec("--zen-radius-sm");
+    assert.strictEqual(typeof spec.bgColor.r, "number");
+    assert.strictEqual(typeof spec.bgColor.g, "number");
+    assert.strictEqual(typeof spec.bgColor.b, "number");
+    assert.strictEqual(typeof spec.fgColor.r, "number");
+    assert.strictEqual(typeof spec.fgColor.g, "number");
+    assert.strictEqual(typeof spec.fgColor.b, "number");
+  });
+
+  it("returns padding 5 horizontal × 2 vertical and corner radius 3", function () {
+    var spec = mod.tokenTagSpec("--zen-spacing-2xs");
+    assert.strictEqual(spec.paddingX, 5);
+    assert.strictEqual(spec.paddingY, 2);
+    assert.strictEqual(spec.cornerRadius, 3);
+  });
+
+  it("preserves empty string input", function () {
+    var spec = mod.tokenTagSpec("");
+    assert.strictEqual(spec.text, "");
+  });
+});

--- a/plugins/actian-design-system/tests/lib/token-tag.test.js
+++ b/plugins/actian-design-system/tests/lib/token-tag.test.js
@@ -1,0 +1,13 @@
+#!/usr/bin/env node
+"use strict";
+
+var { describe, it } = require("node:test");
+var assert = require("node:assert");
+var mod = require("../../scripts/lib/token-tag.js");
+
+describe("token-tag — wiring", function () {
+  it("exports the two pure functions", function () {
+    assert.strictEqual(typeof mod.tokenTagSpec, "function");
+    assert.strictEqual(typeof mod.tokenTagDimensions, "function");
+  });
+});

--- a/plugins/actian-design-system/tests/lib/token-tag.test.js
+++ b/plugins/actian-design-system/tests/lib/token-tag.test.js
@@ -46,3 +46,49 @@ describe("tokenTagSpec", function () {
     assert.strictEqual(spec.text, "");
   });
 });
+
+describe("tokenTagDimensions", function () {
+  // Standard fontMetrics for Inter Medium 12px — avgCharWidth ≈ 6.5, lineHeight ≈ 18
+  var STANDARD = { avgCharWidth: 6.5, lineHeight: 18 };
+
+  it("width grows linearly with text length", function () {
+    var short = mod.tokenTagDimensions("ab", STANDARD);
+    var long = mod.tokenTagDimensions("abcdefgh", STANDARD);
+    assert.ok(long.width > short.width, "longer text → wider tag");
+    // 6 extra chars × 6.5 avgCharWidth = 39px wider
+    assert.ok(long.width - short.width >= 39 && long.width - short.width <= 40);
+  });
+
+  it("includes horizontal padding (5px each side = 10px)", function () {
+    var dims = mod.tokenTagDimensions("a", STANDARD);
+    // 1 char × 6.5 avgCharWidth + 10 padding = 16.5
+    assert.ok(dims.width >= 16 && dims.width <= 17);
+  });
+
+  it("height is constant — lineHeight + 2*paddingY (regardless of text length)", function () {
+    var short = mod.tokenTagDimensions("a", STANDARD);
+    var long = mod.tokenTagDimensions("--zen-spacing-very-long-name", STANDARD);
+    assert.strictEqual(short.height, long.height);
+    // lineHeight 18 + 2*paddingY 2 = 22
+    assert.strictEqual(short.height, 22);
+  });
+
+  it("handles empty text — width is just padding (10)", function () {
+    var dims = mod.tokenTagDimensions("", STANDARD);
+    assert.strictEqual(dims.width, 10);
+  });
+
+  it("uses provided fontMetrics — different metrics produce different widths", function () {
+    var narrow = mod.tokenTagDimensions("hello", {
+      avgCharWidth: 5,
+      lineHeight: 18,
+    });
+    var wide = mod.tokenTagDimensions("hello", {
+      avgCharWidth: 8,
+      lineHeight: 18,
+    });
+    assert.ok(wide.width > narrow.width);
+    // 5 chars × (8-5) = 15px difference
+    assert.strictEqual(wide.width - narrow.width, 15);
+  });
+});


### PR DESCRIPTION
## Summary

Phase 2 PR 1 of the brief Section 1 visuals sprint. Resolves three issues observed in Phase 1 smoke (PR #27) by replacing the Meta Kit `Dimension Annotation` component path with runtime-generated primitives, adding a Token Tag helper for consistent token rendering, and forcing the Section 1 supercard content slot to AUTO sizing.

- **Pattern 14 → runtime primitives** — drops `DIMENSION_KEY` and `POINTER_KEY` Meta Kit component constants. Dimension lines are now generated via `figma.createVector` (line) + `figma.createLine` ×2 (endcap ticks) + `figma.createFrame` + `figma.createText` (label pill) per the figma-measure technique. Annotations resize correctly because primitives aren't constrained by the Plugin API's `resize()` limit on component-instance children. `buildDimensionAnnotation(distance, orientation, labelText)` helper inlines the algorithm, mirroring the unit-tested module functions.
- **Token Tag runtime helper** — new `scripts/lib/token-tag.js` with `tokenTagSpec` (style object: `#F0F2FA` bg, `#0550DC` fg, Inter Medium 12px, 5×2 padding, 3px corner radius) and `tokenTagDimensions` (heuristic predictor for layout math). Wired into Pattern 3 (tables) and Pattern 4 (color swatch labels) so token names render as consistent blue pills everywhere — eliminates the blue-vs-grey divergence observed on Checkbox vs Button in Phase 1.
- **Card width Hug fix** — Pattern 1's content-slot lookup now sets `primaryAxisSizingMode = "AUTO"` and `counterAxisSizingMode = "AUTO"` after locating the slot. Supercard grows to fit the widest table; Tokens tables no longer clip at the right edge. Honors the existing `IMPORTANT (v1.66.2+)` contract by overriding only at slot level, not touching Meta Kit's padding/itemSpacing.
- **Pattern 14 prose-only branches** (deferred from PR #27 review) naturally addressed during the rewrite — author override + Pointer Badge sizing now have concrete code stubs.
- **`v1.68.0 → v1.69.0`** (MINOR — visible new behavior across redlines, tables, and supercard sizing).

Phase 2 PR 2 (Anatomy sub-frame redesign + Sidebar component-resolution diagnosis) is scoped but deferred until PR 1 smoke evidence lands.

Spec: `docs/superpowers/specs/2026-05-06-brief-section1-visuals-phase-2-design.md` (gitignored)
Plan: `docs/superpowers/plans/2026-05-06-brief-section1-visuals-phase-2-pr1.md` (gitignored)

## Architecture notes

- Two new pure-function modules extracted from the push-pattern code so the algorithms are unit-testable without a Figma sandbox: `scripts/lib/dimension-line.js` (3 functions, 16 leaf assertions) and `scripts/lib/token-tag.js` (2 functions, 11 leaf assertions). Total: 27 new unit tests, all green.
- Push code in `push-patterns.md` Pattern 14 inlines the same algorithm with slightly renamed helpers (`endcapPositionsFor`, `labelAnchor`) to avoid shadowing — same separation Phase 1 used since the Figma sandbox can't `require()` modules.
- Contract test (`tests/integration/contract.test.js`) drops the 3 Phase 1 Meta Kit key pin assertions (no longer load-bearing) and replaces them with 2 module-export pins for the new modules. Net: tighter contract surface against accidental breakage.

## Test plan

- [x] All 843 plugin tests pass (28 test files: 26 Phase 1 + 2 new modules)
- [x] `dimension-line.test.js` — 16 leaf assertions covering vectorPathFor, endcapPositions, labelAnchorFor across both orientations + edge cases (zero distance, negative anchor, throw on unknown orientation)
- [x] `token-tag.test.js` — 11 leaf assertions covering tokenTagSpec style object + tokenTagDimensions linear scaling, padding, height constancy, empty input, font metrics variance
- [x] Contract test pins both new module exports (drops obsolete Meta Kit key pins)
- [ ] **Manual smoke test on Cowork Desktop after marketplace auto-update** — same three components as Phase 1 (Sidebar / Checkbox / Button) for direct comparison:
  - [ ] Pattern 14 dimension lines align with the measured edges (Phase 1 misalignment is gone)
  - [ ] Token names render as consistent blue pills across Anatomy, Specs, Tokens (color/sizing/typography), Contrast tables — no more blue-vs-grey divergence
  - [ ] Tables no longer clip at the supercard's right edge — supercard grows to fit widest table
- [ ] Across all three components: at least one raw-px fallback observed (graceful degradation when variables are unbound)

## Subagent execution notes

Execution followed the subagent-driven-development workflow: 12 agent tasks, each implemented by a fresh subagent with two-stage review (spec compliance → code quality). One review caught a defect during execution — Task 9's `appendTokenTagCell` code block used quadruple-backticks instead of triple. The implementer amended via SendMessage and re-review approved. Otherwise all tasks landed clean on first review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)