### PR TITLE
v1.70.2 — Pattern 14 single-return + bypass override (eliminates dual-return ambiguity)

### DIFF
--- a/plugins/actian-design-system/.claude-plugin/plugin.json
+++ b/plugins/actian-design-system/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "actian-design-system",
   "description": "Actian Design System toolkit — sync tokens from Figma, generate wireframe flows with prototype wiring, create component briefs, audit designs, compare flows, and build presentations. 9 skills (with tiered generation: recognized / adapted / improvised), 8 agents, 155 tokens (3 themes, 8 collections), WCAG 2.1 AA.",
-  "version": "1.70.1",
+  "version": "1.70.2",
   "author": {
     "name": "Actian UX Team"
   },

--- a/plugins/actian-design-system/references/component-brief/push-patterns.md
+++ b/plugins/actian-design-system/references/component-brief/push-patterns.md
@@ -1351,6 +1351,8 @@ let boundVariablesCount = 0;
 let unresolvedVariables = 0;
 let tokenTagsRendered = 0;
 let annotationCollisions = 0;
+let droppedSpecs = 0;
+let authorOverrideCount = 0;
 const placedAnnotations = []; // for collision detection
 
 // v1.70.1: gutter-rendering helper used by BOTH auto-extract path (Pass 2 below)
@@ -1442,98 +1444,16 @@ async function buildGutterFromEntries(entries, surface) {
   return entries.length;
 }
 
-// Pass 1 — collect all annotation entries per surface
-const entriesPerSurface = new Map();
-for (const surface of surfaces) {
-  if (surface.layoutMode === "NONE") continue;
-  extractedFrames += 1;
-
-  const surfaceEntries = [];
-  const props = ["paddingLeft", "paddingRight", "paddingTop", "paddingBottom", "itemSpacing"];
-  for (const prop of props) {
-    const px = surface[prop];
-    if (!px || px === 0) continue;
-    const boundId = surface.boundVariables?.[prop]?.id || null;
-    const value = await resolveValue(px, boundId);
-    if (value.token) boundVariablesCount += 1;
-    else if (boundId) unresolvedVariables += 1;
-    const anchorY = computeAnchorY(surface, prop, container);
-    surfaceEntries.push({ prop, px, value, anchorY, surface });
-  }
-  if (surfaceEntries.length > 0) entriesPerSurface.set(surface, surfaceEntries);
-}
-
-// Pass 2 — render each surface's entries (gutter mode if N > 1, inline if N = 1)
+// v1.70.2: override path (when card_anatomy.specs[] is non-empty) BYPASSES
+// the auto-extract surface walk entirely. Author intent (the specs[] array)
+// drives which measurements to show. Both branches feed the same
+// buildGutterFromEntries helper for visual consistency.
+const useOverridePath =
+  card_anatomy && card_anatomy.specs && card_anatomy.specs.length > 0;
 const gutterEntriesPerSurface = [];
-for (const [surface, surfaceEntries] of entriesPerSurface) {
-  if (surfaceEntries.length === 1) {
-    // Inline mode — preserve v1.69.0 single-annotation placement
-    const e = surfaceEntries[0];
-    const orientation = annotationVariant(e.prop, surface.layoutMode);
-    const annotation = buildDimensionAnnotation(e.px, orientation, formatLabel(e.value));
-    tokenTagsRendered += 1;
-    const sbb = surface.absoluteBoundingBox;
-    const cbb = container.absoluteBoundingBox;
-    const sx = sbb.x - cbb.x;
-    const sy = sbb.y - cbb.y;
-    const GAP = 8;
-    if (e.prop === "paddingLeft") {
-      annotation.x = sx - annotation.width - GAP;
-      annotation.y = sy + sbb.height / 2 - annotation.height / 2;
-    } else if (e.prop === "paddingRight") {
-      annotation.x = sx + sbb.width + GAP;
-      annotation.y = sy + sbb.height / 2 - annotation.height / 2;
-    } else if (e.prop === "paddingTop") {
-      annotation.x = sx + sbb.width / 2 - annotation.width / 2;
-      annotation.y = sy - annotation.height - GAP;
-    } else if (e.prop === "paddingBottom") {
-      annotation.x = sx + sbb.width / 2 - annotation.width / 2;
-      annotation.y = sy + sbb.height + GAP;
-    } else if (e.prop === "itemSpacing") {
-      annotation.x = sx + sbb.width / 2 - annotation.width / 2;
-      annotation.y = sy + sbb.height / 2 - annotation.height / 2;
-    }
-    container.appendChild(annotation);
-    gutterEntriesPerSurface.push(0);
-  } else {
-    // Gutter mode — N > 1 annotations on this surface
-    // v1.70.1: extracted to buildGutterFromEntries helper (defined above)
-    // so the override path can reuse the same gutter renderer.
-    surfaceEntries.sort((a, b) => a.anchorY - b.anchorY);
-    const placedCount = await buildGutterFromEntries(surfaceEntries, surface);
-    tokenTagsRendered += placedCount;
-    gutterEntriesPerSurface.push(placedCount);
-  }
-}
 
-const parent = await figma.getNodeByIdAsync("<specsSubFrameId>");
-parent.appendChild(container);
-
-return {
-  redlineId: container.id,
-  pattern14: {
-    extractedFrames,
-    boundVariables: boundVariablesCount,
-    unresolvedVariables,
-    authorOverrides: 0,
-    annotationCollisions,
-    tokenTagsRendered,
-    gutterEntriesPerSurface,
-  },
-};
-```
-
-**Author override path (v1.70.1+):** when `card_anatomy.specs[]` is non-empty, BYPASS the surface walk + auto-extract logic above. Build entries directly from author-supplied specs and render them through the same `buildGutterFromEntries` helper. This guarantees the override produces real gutter geometry (not a static text table).
-
-Insert this block AFTER the auto-extract render loop completes (after the `for (const [surface, surfaceEntries] of entriesPerSurface)` loop), BEFORE the manifest return statement:
-
-```js
-// v1.70.1: author override path — render card_anatomy.specs[] as a gutter on the
-// top-level instance. Bypasses surface walk; entries come directly from author
-// specs. Same buildGutterFromEntries helper used by auto-extract path above.
-let droppedSpecs = 0;
-let authorOverrideCount = 0;
-if (card_anatomy && card_anatomy.specs && card_anatomy.specs.length > 0) {
+if (useOverridePath) {
+  // Override path — render card_anatomy.specs[] as a gutter on the top-level instance
   const overrideEntries = [];
   const cbb = container.absoluteBoundingBox;
   for (const spec of card_anatomy.specs) {
@@ -1556,12 +1476,71 @@ if (card_anatomy && card_anatomy.specs && card_anatomy.specs.length > 0) {
     tokenTagsRendered += placed;
     authorOverrideCount = placed;
   }
+} else {
+  // Auto-extract path — Pass 1 collect, Pass 2 render
+  const entriesPerSurface = new Map();
+  for (const surface of surfaces) {
+    if (surface.layoutMode === "NONE") continue;
+    extractedFrames += 1;
+
+    const surfaceEntries = [];
+    const props = ["paddingLeft", "paddingRight", "paddingTop", "paddingBottom", "itemSpacing"];
+    for (const prop of props) {
+      const px = surface[prop];
+      if (!px || px === 0) continue;
+      const boundId = surface.boundVariables?.[prop]?.id || null;
+      const value = await resolveValue(px, boundId);
+      if (value.token) boundVariablesCount += 1;
+      else if (boundId) unresolvedVariables += 1;
+      const anchorY = computeAnchorY(surface, prop, container);
+      surfaceEntries.push({ prop, px, value, anchorY, surface });
+    }
+    if (surfaceEntries.length > 0) entriesPerSurface.set(surface, surfaceEntries);
+  }
+
+  for (const [surface, surfaceEntries] of entriesPerSurface) {
+    if (surfaceEntries.length === 1) {
+      // Inline mode — preserve v1.69.0 single-annotation placement
+      const e = surfaceEntries[0];
+      const orientation = annotationVariant(e.prop, surface.layoutMode);
+      const annotation = buildDimensionAnnotation(e.px, orientation, formatLabel(e.value));
+      tokenTagsRendered += 1;
+      const sbb = surface.absoluteBoundingBox;
+      const cbb = container.absoluteBoundingBox;
+      const sx = sbb.x - cbb.x;
+      const sy = sbb.y - cbb.y;
+      const GAP = 8;
+      if (e.prop === "paddingLeft") {
+        annotation.x = sx - annotation.width - GAP;
+        annotation.y = sy + sbb.height / 2 - annotation.height / 2;
+      } else if (e.prop === "paddingRight") {
+        annotation.x = sx + sbb.width + GAP;
+        annotation.y = sy + sbb.height / 2 - annotation.height / 2;
+      } else if (e.prop === "paddingTop") {
+        annotation.x = sx + sbb.width / 2 - annotation.width / 2;
+        annotation.y = sy - annotation.height - GAP;
+      } else if (e.prop === "paddingBottom") {
+        annotation.x = sx + sbb.width / 2 - annotation.width / 2;
+        annotation.y = sy + sbb.height + GAP;
+      } else if (e.prop === "itemSpacing") {
+        annotation.x = sx + sbb.width / 2 - annotation.width / 2;
+        annotation.y = sy + sbb.height / 2 - annotation.height / 2;
+      }
+      container.appendChild(annotation);
+      gutterEntriesPerSurface.push(0);
+    } else {
+      // Gutter mode — N > 1 annotations on this surface
+      surfaceEntries.sort((a, b) => a.anchorY - b.anchorY);
+      const placedCount = await buildGutterFromEntries(surfaceEntries, surface);
+      tokenTagsRendered += placedCount;
+      gutterEntriesPerSurface.push(placedCount);
+    }
+  }
 }
-```
 
-Then update the manifest return to surface the new fields:
+const parent = await figma.getNodeByIdAsync("<specsSubFrameId>");
+parent.appendChild(container);
 
-```js
 return {
   redlineId: container.id,
   pattern14: {
@@ -1576,6 +1555,8 @@ return {
   },
 };
 ```
+
+**Author override path (v1.70.2+):** when `card_anatomy.specs[]` is non-empty, the override branch in the main code above BYPASSES the surface walk + auto-extract logic. Entries are built directly from author-supplied specs and rendered through the same `buildGutterFromEntries` helper. This guarantees the override produces real gutter geometry (not a static text table) — the render code is in the main block, not a separate documentation snippet, so there is no instruction-to-coordinate-elsewhere ambiguity.
 
 The override path uses the same gutter geometry as auto-extract — vector lines, label pills, ticks at the component's left edge. Author intent (specs[] entries) drives WHICH measurements to show; the renderer guarantees HOW they look. No improvisation surface for the AI.
 


### PR DESCRIPTION
## Summary

PATCH fix for the v1.70.1 Specs sub-frame issue that **wasn't actually fixed by v1.70.1**. Smoke on Checkbox after v1.70.1 ship confirmed the override path STILL improvised into a static text table because the AI didn't coordinate edits across the dual-return-statement boundary in Pattern 14's documentation.

This patch eliminates the boundary entirely — Pattern 14 now has ONE main JS code block with ONE return statement, structured as `if (useOverridePath) { override } else { auto-extract }`. The AI executing it has no ambiguous "second code path" to pick.

## What changed

Pattern 14 in `references/component-brief/push-patterns.md`:
- **Hoisted declarations** — `let droppedSpecs = 0;` and `let authorOverrideCount = 0;` moved to the counter declaration block at the top of the main JS code, alongside `let extractedFrames = 0;` etc.
- **Mutually exclusive branches** — auto-extract logic (Pass 1 collect + Pass 2 render) wrapped in `else` of `if (useOverridePath) { ... }`. Override path now lives INSIDE the main code block, not as a separate documentation snippet. When `card_anatomy.specs[]` is non-empty, override fires and auto-extract is BYPASSED entirely.
- **Single return statement** — manifest at the bottom always references `authorOverrides: authorOverrideCount` and `droppedSpecs` (no v1.70.1's `authorOverrides: 0` placeholder).
- **Prose section cleanup** — the two standalone code blocks (override logic + updated return shape) are deleted. Only concise prose explaining override semantics remains.
- **`v1.70.1 → v1.70.2`** — PATCH bump.

## Why v1.70.1 didn't fix it

PR #29 review and Task 3 spec reviewer in v1.70.1 both flagged the dual-return-statement risk:

> "The original `return { ..., authorOverrides: 0 ... }` is INSIDE the main JS code block. The override section then has a SEPARATE second code block with the updated return shape. This requires three coordinated edits driven by prose: insert override block before the existing return, AND modify the existing return..."

v1.70.1 smoke confirmed the prediction. The AI:
1. Executed the main JS (auto-extract loop with original return)
2. Saw the override prose + code blocks below as a SEPARATE thing to render
3. Improvised the override into a static "Spec | Value | Token" table

v1.70.2 eliminates the structure that produced the ambiguity. There's no longer a "first return" and "updated return shape" to coordinate — there's just one block of code that runs linearly.

## Architecture notes

The semantics change: previously v1.70.1 documentation suggested both auto-extract AND override could run on the same brief (with override appended). v1.70.2 makes them MUTUALLY EXCLUSIVE — when author specs are present, only override runs. This matches the original spec ("BYPASS the surface walk + auto-extract logic") AND matches what the smoke evidence demanded (running both produced visual conflict — floating pills around component PLUS a bottom table).

The `gutterEntriesPerSurface` array is declared BEFORE the if/else so both branches reference the same scope. In override mode it stays empty (no surfaces walked); in auto-extract mode it's populated normally.

## Test plan

- [x] All 888 plugin tests pass (unchanged from v1.70.1 — markdown-only patch, no JS code modified)
- [x] Hoisted declarations verified — `droppedSpecs` and `authorOverrideCount` each appear exactly once at the top of the main JS code
- [x] `useOverridePath` declared and used in if/else dispatch
- [x] Single return statement at the bottom with full manifest shape
- [x] Both standalone code blocks deleted from prose section (zero `Insert this block AFTER` and `Then update the manifest return` strings remain)
- [x] `gutterEntriesPerSurface` declared BEFORE if/else for shared scope (highest-risk failure mode for this refactor — confirmed correct)
- [ ] **Manual smoke test on Cowork Desktop after marketplace auto-update of v1.70.2** — `/component-brief Checkbox` Specs sub-frame must show:
  - [ ] **Single left gutter** with N entries (one per `card_anatomy.specs[]` entry that resolved to a layer in the Default state)
  - [ ] **Leader lines pointing right** to ticks at the Checkbox's left edge — gutter geometry, not table
  - [ ] **One Checkbox instance** visible alongside the gutter (positioned to the right per Patch A's inst.x shift)
  - [ ] **NO bottom Spec/Value/Token table** — that was the v1.70.1 improvisation
  - [ ] **NO floating pills around the Checkbox** — those were v1.70.1's auto-extract output, which v1.70.2 BYPASSES when override fires
- [ ] Optional: `/component-brief` for a component WITHOUT `card_anatomy.specs[]` (if any exist) to confirm auto-extract path still works in isolation

## Subagent execution notes

Executed via subagent-driven-development workflow: 2 agent tasks with two-stage review (spec compliance + code quality). The single architectural edit in Task 1 was complex (3 coordinated changes to the same file: hoist declarations, restructure if/else, delete prose code blocks) but landed clean on first review. Reviewer specifically verified the `gutterEntriesPerSurface` scoping (declared BEFORE if/else) which was the highest-risk failure mode for this refactor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)