### PR TITLE
docs: update content guidelines integration for renamed section files

### DIFF
--- a/plugins/actian-design-system/agents/card-generator.md
+++ b/plugins/actian-design-system/agents/card-generator.md
@@ -58,5 +58,6 @@ Example for cards 4-6:
 - All token names must use `--zen-` prefix (DS Kit) or `--fm-` prefix (FM)
 - No hardcoded hex values in token fields
 - No truncation — complete all arrays, all variant rows, all properties
+- **Content cards copy:** For `card_content` (DS Kit) and `card4_content_guidelines` (FM), all example copy must comply with `docs/content-guidelines.md` — sentence case, verb + object buttons, no banned words, realistic placeholder text
 - Write the file silently — do not output the JSON to chat
 - If you cannot generate a card (missing information), write the card key with an empty object and report DONE_WITH_CONCERNS

--- a/plugins/actian-design-system/agents/screen-generator.md
+++ b/plugins/actian-design-system/agents/screen-generator.md
@@ -67,6 +67,7 @@ Example for screens 4-6:
 - Use `primaryAxisAlignItems: "SPACE_BETWEEN"` for push-apart layouts — never Spacer frames
 - **Glossary:** If `meta._glossary` is present, use it as the single source for entity names in page headers/breadcrumbs/body text, action verbs in button labels/CTAs, and the active sidebar item. Never invent alternative phrasings for glossary terms.
 - **Entity properties:** If generating form fields, table columns, or detail page content for a known entity, read `docs/app-context.json` → `entities[entityId].properties` for standard field names. Use these instead of generic placeholders.
+- **Copy:** All visible text must follow Actian content guidelines — sentence case everywhere, verb + object button labels ("Create data product", "Delete connection"), no banned words (please, sorry, ensure, execute, abort, sign in), empty states include a headline + body + CTA, placeholder text models input and never repeats the label. Reference `docs/content-guidelines.md` for the full rules.
 - Feature focus: spotlight the feature, placeholder everything else
 - Write the file silently — do not output the JSON to chat
 - If you cannot generate a screen (missing information), include a minimal placeholder screen and report DONE_WITH_CONCERNS

--- a/plugins/actian-design-system/docs/content-guidelines.md
+++ b/plugins/actian-design-system/docs/content-guidelines.md
@@ -1,184 +1,434 @@
-# Content Guidelines — Actian Design System 2026
+# Content guidelines — Actian Data Intelligence
 
-<!-- AUTO-GENERATED from docs/foundations/content-guidelines.json -->
-<!-- To update: run /sync-guidelines or /sync-design-system -->
-<!-- Do not edit manually — changes will be overwritten -->
-
-Source: [Content guidelines page](https://www.figma.com/design/<DS Kit_FILE_KEY>?node-id=7397:3249)
-Generated: 2026-03-26
-
----
-
-> Shared writing standards for all UI text. Apply these rules in every skill: component briefs, design audits, flow generation, and analysis.
+> Source of truth for all UI copy. Apply these rules in every skill: component briefs, design audits, flow generation, and analysis.
+>
+> **Full section files (local):** `{project_working_directory}/content-guidelines/` — read from disk if available  
+> **Full section files (remote):** `https://raw.githubusercontent.com/levita99zeenea/actian-content-guidelines/main/{filename}` — fetch if local files not present  
+> **Live site:** https://levita99zeenea.github.io/actian-content-guidelines
 
 ---
 
-## Content Guidelines Checklist
+## Quick reference checklist
 
-Use this handy checklist to confirm content is in the right state for reviews. Before meeting with Jeff or Jessie, or asking for review, ensure you've fixed any content issues during design and checked them off here.
-
----
-
-## Words to Avoid
-
-Guidance on what content works best, including text, imagery, and messaging.
-
----
-
-## Capitalization
-
-Don't overuse capitalization as it makes copy harder to read and de-emphasizes the important content.
-
-### Rules
-- **Sentence case** for all UI text (buttons, labels, headings, tooltips, banners). Only capitalize the first word and proper nouns.
+Before any design review, verify:
+- [ ] Sentence case on all UI text (buttons, labels, headings, tooltips, banners)
+- [ ] No "please," "sorry," "ensure," "execute," "abort," "sign in," or other banned words
+- [ ] Buttons use verb + object ("Create report," not "Report")
+- [ ] No terminal punctuation on buttons, labels, menu items, column headers
+- [ ] Placeholder text models input — never repeats the label
+- [ ] Error messages say what went wrong and how to fix it (no "Invalid")
+- [ ] Empty states include a headline, body sentence, and one CTA
+- [ ] Destructive actions confirmed with title that names the action ("Delete connection")
 
 ---
 
-## Writing Style
+## 1. Global guidelines
 
-Use present, active tense in all possible cases. In some cases, you can use passive voice, if the focus needs to be on a system instead of a person, for example.
+Actian Data Intelligence speaks to data professionals: engineers, analysts, and catalog administrators. The voice is direct, precise, and professional without being formal or stiff.
 
----
+### Voice and tone rules
 
-## Numerical Formatting
+- Use **active voice**: "Export the dataset" not "The dataset can be exported."
+- Use **present tense**: "Saves automatically" not "Will save automatically."
+- Use **sentence case** for all UI text, including headings and button labels.
+- No exclamation points except in genuine success states.
+- No "please" or "sorry."
 
-### Rules
-- **Numbers:** Use digits for quantities (3 items, 12 results). Spell out numbers in prose only when they start a sentence.
-- **Dates:** Use the product locale format. Default: `Mar 19, 2026`.
+### Words to avoid
 
----
-
-## Punctuation
-
-To help readers scan text at a glance, avoid using punctuation in places where it isn't necessary.
-
-### Rules
-- **No terminal punctuation** on buttons, labels, menu items, or column headers.
-- **Use periods** in body text, descriptions, and helper text that forms complete sentences.
-- **No exclamation marks** except in celebratory moments ("Got it!" is an exception for informal confirmation).
-
----
-
-## Prepositions
-
-Prepositions indicate relationships between different elements, actions, or concepts. Proper use of prepositions helps maintain clarity and precision, while misuse can lead to confusion or overly complex sentences. This section provides guidelines for how to effectively and consistently use prepositions across the product.
-
----
-
-## Acronyms
+| Term to avoid | Use instead |
+|---|---|
+| Please / Sorry | Omit or rephrase |
+| We / Us (referring to Actian) | "Actian" or omit |
+| Execute / Abort | Run / Cancel or Stop |
+| Master / Slave | Primary / Secondary |
+| Blacklist / Whitelist | Deny list / Allow list |
+| Press / Type (as verbs) | Click / Enter or Provide |
+| CTA | Button or link |
+| Caution / Danger | Remember: / Note: |
+| Disabled | Blocked / Off |
+| Ensure | Verify |
+| Agnostic | Independent |
+| Sign in / Signin | Log in |
+| Action on | Omit; use a direct verb |
 
 ---
 
-## Plurals
+## 2. Buttons
+
+**Formula:** verb + object. "Create report," "Delete dataset," "Add connection."
+
+- Sentence case. 1–3 words ideally. No punctuation.
+- One primary button per view.
+- Disable primary until required fields are complete.
+
+### Term pairs
+
+| Term | Rule |
+|---|---|
+| Cancel vs Close | Cancel = back out of entered/confirmed state. Close = read-only screens. |
+| Create vs Add vs Insert | Create = new. Add = existing item. Insert = existing + ordering matters. |
+| Submit vs Send vs Save | Submit = form. Send = email only. Save = adding/changing selections on modal. |
+| Select vs Choose | Select = limited list. Choose = large or open-ended. |
+| Accept vs Decline | Legal terms of service, or accepting/declining AI-proposed changes. |
+| Got it! | Confirmation modals requiring no user action. |
+| Back / Next / Create | Stepper navigation. Final step = "Create" (or object-specific verb), not "Finish." |
 
 ---
 
-## Abbreviations and Articles
+## 3. Links
+
+- Descriptive text only: "View pipeline details" not "Click here."
+- Sentence case, no terminal punctuation.
+- Same tab unless labeled external (use external link icon).
+- Use links for navigation; use ghost buttons for actions.
 
 ---
 
-## Additional Rules (hand-authored)
+## 4. Checkboxes
 
-The following rules are not present in the JSON foundation data but were included in the hand-authored content guidelines. They are preserved here until they are added to the Figma source.
+- Labels in positive form: "Show archived items" not "Don't hide archived items."
+- Parallel labels in each group.
+- Card format: use when each option needs rich context (title, description, image, metadata).
 
-### General Writing Rules
+---
 
-#### Voice & Tone
-- **Clear:** Use plain language. Avoid jargon unless the audience is technical.
-- **Concise:** Say it in fewer words. Cut filler ("just", "simply", "please note that").
-- **Consistent:** Same action = same label everywhere in the product.
-- **Actionable:** Lead with what the user can do, not what the system did.
+## 5. Dropdown / Select
 
-#### Formatting
-- **Lists:** Use bullet points. Start each item with a capital letter. No periods unless items are full sentences.
+- Opens on click, not hover. Closes on Escape or outside click.
+- Menu items: verb + noun ("Download PDF," "Add tag," "Delete record").
+- Multi-select: include checkboxes; selections persist until menu closes.
 
-### Button Labels
+---
 
-#### Rules
-- Use **verb + object** for clarity: "Create dataset", "Add connection", "Download report".
-- Keep labels to **1-3 words** when possible.
-- One **Primary** button per view. Its label is the page's main action.
-- Use the **same verb** on the trigger button and the confirmation -- don't use "Create" to open a form and then "Submit" to finish it.
+## 6. Filters
 
-#### Terminology
+- Labels: short noun phrases matching the attribute ("Owner," "Status," "Data domain").
+- Show active count when collapsed: "Filters (3)."
+- Provide "Clear all" / "Reset filters" when filters are active.
+- Persist filter state on navigation.
 
-| Term | When to use |
-|------|-------------|
-| **Cancel** vs **Close** | Cancel when data has been entered or confirmation is required -- allows return to previous state without saving. Close for read-only messages or screens. |
-| **Create** vs **Add** vs **Insert** | Create = making something new. Add = bringing in something that exists elsewhere. Insert = placing in a specific position where order matters. The + icon is only needed when creating a new object. |
-| **OK** | Read-only informational pages that are not legally required to accept. |
-| **Accept** & **Decline** | Accept for legal terms of service. Accept/Decline when user must choose whether to implement proposed changes (from another user or AI). |
-| **Got it!** | Informational confirmation modals where the user doesn't need to take action. |
-| **Select** vs **Choose** | Select when picking from a limited list. Choose when picking from a large set or open-ended decision. |
-| **Submit** vs **Send** vs **Save** | Submit for forms. Send for email only. Save for adding or changing selections in a modal. |
-| **View** vs **See** | View as a noun ("Grid view", "Table view"). See as a verb only with a modifier ("See all results"). |
+---
 
-#### Stepper Buttons
-- Use **verb + object** for the creation button ("Create dataset", "Add connection").
-- Use **only the verb** (without the object) when finishing a stepper ("Create", "Finish").
-- Exception: When the button is a dropdown (like a Create menu on the Home page), the verb alone is sufficient.
-- The initial button and final button should use the **same term** in most cases.
+## 7. Cards
 
-### Link Labels
+**Item card:** Entire card is clickable. Use item name as title; sentence case; match name used elsewhere.
 
-#### Rules
-- Use **meaningful, descriptive text** that tells the user where the link goes: "View item details", not "Click here".
-- **Never use raw URLs** as visible link text -- they are long, complex, and hard to interpret.
-- Use **action verbs** for links that lead to tasks: "Download orders", "Learn more".
-- Use **sentence case**, no terminal punctuation.
-- Link only the **relevant portion** of text -- never entire sentences or paragraphs.
-- Keep link text **brief but meaningful** -- long enough to be clear, short enough to scan.
-- Use **consistent phrasing** for similar actions across the product. If "Learn more" is used in one area, don't switch to "Read details" elsewhere.
+**Selectable card:** Radio (single) or checkbox (multi). Title = short noun phrase. One sentence description max.
 
-#### Link vs Button
-- **Link = navigation** (goes to a page, URL, or anchor).
-- **Button = action** (submits, saves, deletes, toggles).
-- Avoid using links styled as buttons or buttons styled as links.
+**Topic card:** Noun/noun phrase title. One sentence describing the topic's scope.
 
-### Form Labels & Helper Text
+---
 
-#### Rules
-- Use **noun or noun phrase** for input labels: "Email address", "Dataset name".
-- Add **required indicator** (asterisk `*`) for mandatory fields.
-- Use **helper text** (below the input) for format hints: "Must be at least 8 characters".
-- Use **placeholder text** sparingly -- it disappears on focus. Prefer helper text.
-- Error messages: State **what went wrong** and **how to fix it**: "Email is required" not "Invalid input".
+## 8. Empty and system states
 
-### Status & Feedback Messages
+### Empty state
+- Short instructive headline + one-sentence body + one primary CTA.
+- Never "No results found" without guidance.
+- Example: "No items found / Add your first dataset to start exploring. / Create dataset"
 
-#### Alerts & Toasts
-- **Success:** Past tense, confirms what happened. "Policy created successfully."
-- **Error:** Present tense, states the problem + fix. "Failed to save. Check your connection and try again."
-- **Warning:** Describes the consequence. "This action cannot be undone."
-- **Info:** Neutral, provides context. "Changes will take effect after approval."
+### Error state
+- Specific about what went wrong. Offer a resolution. No technical codes as primary message. No user blame.
+- Example: "Something went wrong / There was an error creating your item. Try again or contact support."
 
-#### Empty States
-- Tell the user **what the page is for** and **how to start**: "No datasets yet. Add your first dataset to get started."
-- Include a **CTA button** that takes the user to the creation flow.
+### Maintenance state
+- What is affected + estimated resolution time + single action ("Refresh").
 
-### Modal & Dialog Copy
+### Success state
+- Confirm what was completed. Brief (one line). Offer logical next action.
 
-- **Title:** Action-oriented. "Delete dataset?" not "Confirm deletion".
-- **Body:** Explain the consequence in 1-2 sentences. "This will permanently remove the dataset and all associated metadata."
-- **Actions:** Primary button matches the action in the title. "Delete" not "OK".
-- **Destructive confirmation:** Require typing the resource name for irreversible actions.
+---
 
-### Table & List Labels
+## 9. Forms
 
-- **Column headers:** Noun, sentence case, no punctuation. "Dataset name", "Last modified", "Owner".
-- **Empty rows:** Use em dash (--) for missing values, not "N/A" or blank.
-- **Truncation:** Truncate with ellipsis (...) and show full text on hover via tooltip.
-- **Action columns:** Use icon buttons (edit, delete, more) -- not text links in table rows.
+- Sentence case for labels: "Group name" not "Group Name."
+- Mark required fields with asterisk (*).
+- Helper text explains the "why" — never just restates the label.
+- Error text guides correction: "Enter a valid date" not "Invalid input."
+- Primary CTA at bottom right; disabled until all required fields filled.
+- Validate on blur (field exit), not on keystroke.
+- Single-column layouts preferred.
 
-### Navigation & Menu Items
+### Toggle vs Checkbox vs Radio button
 
-- Use **nouns or verb + noun** for navigation items: "Dashboard", "Projects", "Requests".
-- Keep to **1-2 words** maximum.
-- Active item should be visually distinct (not just by color -- also weight or background).
+| Use | When |
+|---|---|
+| Toggle / Switch | Immediate effect, binary system state (ON/OFF, dark mode) |
+| Checkbox | Multi-select OR action not immediate (form submission, terms) |
+| Radio button | Single select from 2–6 visible options |
 
-### Accessibility Copy
+### Dropdown in forms
+- 5–20 options. Label = category of options (not action).
 
-- All **icon-only buttons** must have `aria-label` or visually hidden text.
-- All **external links** must indicate they open in a new tab.
-- All **disabled elements** should explain why via tooltip or `aria-describedby`.
-- **Don't rely on color alone** to convey meaning -- pair with text or icon.
+### Calendar
+- Labels: "From" / "To" or "Start date" / "End date." Never pre-fill. Support both typing and picker.
+
+---
+
+## 10. Sticky footer
+
+- Exactly one primary action (exception: add a destructive button like Delete).
+- Max 3 buttons.
+- Stepper labels: "Back" / "Next" / final verb (e.g., "Create").
+- Never mix "Continue" and "Next" or "Finish" and "Submit" in the same flow.
+
+---
+
+## 11. Modal
+
+- Title matches the triggering button/link label.
+- Body: 1–2 sentences, actionable.
+- Primary + secondary button pair.
+- No nested modals.
+- Destructive modals: Title names the action ("Delete dataset"), primary CTA repeats verb ("Delete"), secondary = "Cancel."
+
+---
+
+## 12. Search
+
+- Placeholder: "Search [asset names]" or "Search in [asset names]" (plural).
+- No period at end of placeholder text.
+- Examples: "Search items," "Search topics," "Search users," "Search properties."
+
+---
+
+## 13. Text input
+
+- Placeholder = example of expected input, not a label substitute.
+- Validate on blur (when user exits field).
+- Never use placeholder if the label is sufficient.
+- Example: Label "Dataset name" / Placeholder "e.g. Q4_sales_report"
+
+---
+
+## 14. Notifications and messaging
+
+**Notification:** 1–2 sentences. Include timestamp. Include action if user must respond.
+
+**Tooltip:** Few words or one sentence. Never repeat the label. Use popover for multi-sentence explanations.
+
+**Toast / Snackbar:** One short sentence. Include "Undo" where relevant. Not for actions requiring user input.
+- Examples: "Dataset deleted. Undo" / "Export ready. Download" / "Connection failed. Try again"
+
+---
+
+## 15. Navigation
+
+**Global header:** Utility icons (notifications, help, profile) unlabeled with tooltips.
+
+**Side nav:** Short descriptive labels matching page headers. Consistent naming and order.
+
+**Breadcrumbs:** Main component / Sub component / Specific item. Current page = plain text (not a link).
+
+**Tabs:** Short nouns/noun phrases ("Overview," "Lineage," "Settings"). Sentence case. No verbs.
+
+**Pagination:** "Previous" and "Next." Show count: "Showing 1–25 of 340 results."
+
+---
+
+## 16. Loading and progress
+
+**Loading indicator:** Use message only when wait > 3 seconds. Present tense. "Loading datasets..." — never "Please wait."
+
+**Progress indicator:** Label steps with short noun or verb phrase. "Step 2 of 4."
+
+---
+
+## 17. Tags, badges, and status indicators
+
+**Tags:** 1–3 words. Sentence case. Not action triggers.
+
+**Badges:** Single word or short abbreviation. Standard vocabulary: New, Updated, Draft, Published, Deprecated.
+
+---
+
+## 18. Dialogs and confirmations
+
+**Confirmation dialog:** Title = action name ("Delete connection"). Body = 1 sentence on what happens and reversibility. Primary CTA = title verb. Secondary = "Cancel."
+
+**Inline banner:** State issue + what user should do. 1–2 sentences. Include link/action if applicable.
+
+---
+
+## 19. Onboarding
+
+- Lead with what the user can do (not what the product does).
+- Action-oriented CTAs: "Set up your first connection."
+- No marketing language.
+- Step titles: short imperative phrases ("Choose a data source"). No step numbers in title text.
+
+---
+
+## 20. What's new
+
+- Past tense: "Added support for..." / "Fixed an issue where..."
+- Group by category. 1–2 sentences per item.
+- No marketing adjectives ("powerful," "seamless," "game-changing").
+
+---
+
+## 21. Alerts
+
+- 1–2 sentences. Lead with most important information.
+- Severity: informational, success, warning, error.
+- No "Alert:" / "Warning:" prefix — icon conveys severity.
+- Warning/error alerts persist until resolved.
+- Appear at top of affected area.
+
+---
+
+## 22. Combo box
+
+- Placeholder: describes what's being searched ("Search or select a data source"), not "Type to filter."
+- Show "No results found for [query]" — never an empty dropdown.
+- Filter dynamically as user types.
+
+---
+
+## 23. Data tables
+
+**Column headers:** 2–3 word noun phrases, sentence case, no punctuation. Left-align text, right-align numbers.
+
+**Cell content:** Consistent formatting. Empty values = "—" (em dash), not blank, "N/A," or "null."
+
+**Status vocabulary:** Active, Inactive, Draft, Published, Deprecated, Error.
+
+**Bulk actions:** "Delete selected" / "Export." Show count: "3 items selected."
+
+| Use | Avoid |
+|---|---|
+| Last modified | Last Modification Date |
+| Owner | Assigned to / Owned by |
+| Status | Current status |
+
+---
+
+## 24. Grid and spacing
+
+- Avoid wrapping text in narrow columns. Abbreviate predictably or truncate with tooltip.
+- Do not vary density within the same table or list view.
+
+---
+
+## 25. Icons
+
+- Approved Actian icon set only. No decorative icons.
+- Icon-only controls: always pair with tooltip or aria-label. Sentence case. Verb/noun conventions.
+- Decorative icons: `aria-hidden="true"`.
+
+---
+
+## 26. Inline toast
+
+- ≤ 10 words. Present or past tense: "Copied" / "Saved."
+- For localized actions only (copy value, save field inline). Not for global events.
+- Examples: "Copied" / "Saved" / "Tag added" / "Link created"
+
+---
+
+## 27. Lineage-specific UI
+
+**Node labels:** Exact asset name + asset type as secondary label ("Orders" / "Table"). Sentence case.
+
+**Edge labels:** Short verb phrase ("Reads from," "Writes to," "Transforms"). No jargon.
+
+| Term | Definition |
+|---|---|
+| Upstream | Assets that provide data to the selected asset |
+| Downstream | Assets that consume data from the selected asset |
+| Source | The originating system or dataset |
+| Transformation | A processing step that modifies or aggregates data |
+| Impact | The downstream effect of a change to this asset |
+
+---
+
+## 28. Multi-select
+
+- Label = short noun phrase ("Data domains," "Owners").
+- Selected values shown as chips. Chip = item name only.
+- Collapsed count: "3 selected."
+- Use "Select all" and "Clear all."
+
+---
+
+## 29. Object preview panels
+
+- Panel title = exact asset name.
+- Short attribute labels (1–2 words): "Owner," "Last modified," "Type."
+- Include "View full details" link at bottom.
+
+---
+
+## 30. Popover
+
+- Opens on click (not hover). Closes on click outside or Escape.
+- Title: short noun phrase (optional). Body: 2–4 sentences. No bullet lists.
+- Use for explanations too long for tooltip, or small action sets.
+
+---
+
+## 31. Related content panels
+
+- Panel heading = relationship type ("Related datasets," "Used in reports").
+- Asset name as link + 1–2 metadata attributes.
+- Empty state: "No related datasets found."
+
+---
+
+## 32. Stepper
+
+- Step titles: short imperative verb phrases ("Choose a data source"). No step numbers in title.
+- Navigation: "Back" / "Next" / final verb ("Create [object]").
+- Never "Previous," "Finish," "Done," or "Submit" as a final step.
+
+---
+
+## 33. Switch
+
+- Label = feature being controlled, not state. "Email notifications" not "Enable email notifications."
+- For immediate-effect binary settings only. Not for changes requiring a save action.
+
+---
+
+## 34. Tables (general)
+
+- Column headers: short noun phrases, sentence case, no punctuation.
+- Empty cells: "—" (em dash).
+- Dates: ISO 8601 (YYYY-MM-DD) preferred.
+
+---
+
+## 35. Uploads
+
+- Drop zone: "Drag and drop a CSV file, or browse."
+- Browse link: "Browse" or "Choose file" — not "Click here."
+- List accepted formats: "Accepts .csv, .json, and .xlsx files."
+- Error: specific — "data.csv — File exceeds the 50 MB size limit." not "Upload failed."
+
+---
+
+## 36. Validation messages
+
+- Validate on blur (field exit). Not on keystroke. Not before user interaction.
+- Specific: say what is wrong and how to fix it.
+- No "Invalid" standalone. No "Please." No user blame.
+
+| Do | Don't |
+|---|---|
+| Enter a valid email address. | Invalid email. |
+| Connection name is required. | Please fill out this field. |
+| Password must be 8–32 characters. | Password does not meet requirements. |
+| This name is already in use. Choose a different name. | Duplicate entry error. |
+
+---
+
+## 37. Wizards
+
+- Step titles: short imperative phrases, parallel structure across steps.
+- In-step: 2-sentence max explanation at top of each step. Field-level help via popovers.
+- Final step: "Review" or "Review and create" summary with edit links.
+- Navigation: "Back" / "Next" / object-specific final verb ("Create connection").
+
+---
+
+*Full section files with complete Do/Don't examples and subsection detail: `{project_working_directory}/content-guidelines/`*

--- a/plugins/actian-design-system/docs/foundations/content-guidelines.json
+++ b/plugins/actian-design-system/docs/foundations/content-guidelines.json
@@ -1,131 +1,280 @@
 {
   "foundation": "Content guidelines",
   "page_id": "7397:3249",
-  "extracted_at": "2026-03-25T17:00:00Z",
-  "frames": [
-    "Content style and usage",
-    "Content Checklist",
-    "Notes/Feedback"
-  ],
+  "extracted_at": "2026-05-06T00:00:00Z",
+  "source_document": "Actian_Content_Guidelines_Claude3.docx",
+  "source_path": "C:\\Users\\jlevitt\\OneDrive - Actian Software\\Documents\\zeenea\\content guidelines\\Actian_Content_Guidelines_Claude3.docx",
+  "project_files": "{project_working_directory}/content-guidelines/",
+  "live_site": "https://levita99zeenea.github.io/actian-content-guidelines",
+  "index_file": "content-index.md",
   "sections": [
     {
-      "heading": "Content guidelines",
-      "content": []
+      "id": 1,
+      "heading": "Global guidelines",
+      "file": "global-guidelines.md",
+      "subsections": ["Voice and tone", "Writing style", "Capitalization", "Words to avoid", "Punctuation", "Numerical formatting", "Prepositions", "Acronyms", "Plurals", "Abbreviations and articles"],
+      "status": "complete"
     },
     {
-      "heading": "Table of contents\nChecklist\nWords to avoid\r\nCapitalization\r\nWriting style\nNumerical formatting\r\nPunctuation\r\nPrepositions\r\nAcronyms\r\nPlurals\r\nAbbreviations and articles",
-      "content": []
+      "id": 2,
+      "heading": "Buttons",
+      "file": "buttons.md",
+      "subsections": ["When to use", "Style", "Behavior", "Do/Don't", "Terminology for button labeling"],
+      "status": "complete"
     },
     {
-      "heading": "Content guidelines checklist",
-      "content": []
+      "id": 3,
+      "heading": "Links",
+      "file": "links.md",
+      "subsections": ["When to use", "Style", "Behavior", "Clear and descriptive link text", "Consistency"],
+      "status": "complete"
     },
     {
-      "heading": "Use this handy checklist to confirm content is in the right state for reviews. Before meeting with Jeff or Jessie, or asking for review, ensure you’ve fixed any content issues during design and checked them off here.",
-      "content": []
+      "id": 4,
+      "heading": "Checkboxes",
+      "file": "checkboxes.md",
+      "subsections": ["Default format", "Card format"],
+      "status": "complete"
     },
     {
-      "heading": "Words to avoid",
-      "content": []
+      "id": 5,
+      "heading": "Dropdown / Select",
+      "file": "dropdown-select.md",
+      "subsections": ["Behavior", "Style", "Do/Don't"],
+      "status": "complete"
     },
     {
-      "heading": "Guidance on what content works best, including text, imagery, and messaging.",
-      "content": []
+      "id": 6,
+      "heading": "Filters",
+      "file": "filters.md",
+      "subsections": ["When to use", "Style", "Behavior"],
+      "status": "complete"
     },
     {
-      "heading": "Capitalization",
-      "content": []
+      "id": 7,
+      "heading": "Cards",
+      "file": "cards.md",
+      "subsections": ["Card - Item", "Card - Selectable", "Card - Topic"],
+      "status": "complete"
     },
     {
-      "heading": "Don’t overuse capitalization as it makes copy harder to read and de-emphasizes the important content.",
-      "content": []
+      "id": 8,
+      "heading": "Empty and system states",
+      "file": "empty-and-system-states.md",
+      "subsections": ["Empty state", "Error state", "Maintenance state", "Success state"],
+      "status": "complete"
     },
     {
-      "heading": "Writing style",
-      "content": []
+      "id": 9,
+      "heading": "Forms",
+      "file": "forms.md",
+      "subsections": ["General form guidelines", "Input labels and helper text", "Dropdown", "Calendar", "Toggle", "Radio button", "Radio button card format"],
+      "status": "complete"
     },
     {
-      "heading": "Use present, active tense in all possible cases.  In some cases, you can use passive voice, if the focus needs to be on a system instead of a person, for example.",
-      "content": []
+      "id": 10,
+      "heading": "Sticky footer",
+      "file": "sticky-footer.md",
+      "subsections": ["When to use", "Button hierarchy", "Button labels", "Steppers"],
+      "status": "complete"
     },
     {
-      "heading": "Numerical formatting",
-      "content": []
+      "id": 11,
+      "heading": "Modal",
+      "file": "modal.md",
+      "subsections": ["When to use", "Style", "Do/Don't"],
+      "status": "complete"
     },
     {
-      "heading": "---",
-      "content": []
+      "id": 12,
+      "heading": "Search",
+      "file": "search.md",
+      "subsections": ["When to use", "Placeholder text", "Behavior"],
+      "status": "complete"
     },
     {
-      "heading": "Punctuation",
-      "content": []
+      "id": 13,
+      "heading": "Text input",
+      "file": "text-input.md",
+      "subsections": ["Behavior", "Placeholder text", "Do/Don't"],
+      "status": "complete"
     },
     {
-      "heading": "To help readers scan text at a glance, avoid using punctuation in places where it isn't necessary.",
-      "content": []
+      "id": 14,
+      "heading": "Notifications and messaging",
+      "file": "notifications-and-messaging.md",
+      "subsections": ["Notification", "Tooltip", "Toast / Snackbar"],
+      "status": "complete"
     },
     {
-      "heading": "Prepositions",
-      "content": []
+      "id": 15,
+      "heading": "Navigation",
+      "file": "navigation.md",
+      "subsections": ["Global header", "Side nav", "Breadcrumbs", "Tabs", "Pagination"],
+      "status": "complete"
     },
     {
-      "heading": "Prepositions indicate relationships between different elements, actions, or concepts. Proper use of prepositions helps maintain clarity and precision, while misuse can lead to confusion or overly complex sentences. This section provides guidelines for how to effectively and consistently use prepositions across the product.",
-      "content": []
+      "id": 16,
+      "heading": "Loading and progress",
+      "file": "loading-and-progress.md",
+      "subsections": ["Loading indicator", "Progress indicator"],
+      "status": "complete"
     },
     {
-      "heading": "Acronyms",
-      "content": []
+      "id": 17,
+      "heading": "Tags, badges, and status indicators",
+      "file": "tags-badges-status-indicators.md",
+      "subsections": ["Tags", "Badges"],
+      "status": "complete"
     },
     {
-      "heading": "---",
-      "content": []
+      "id": 18,
+      "heading": "Dialogs and confirmations",
+      "file": "dialogs-and-confirmations.md",
+      "subsections": ["Confirmation dialog", "Inline banner"],
+      "status": "complete"
     },
     {
-      "heading": "Plurals",
-      "content": []
+      "id": 19,
+      "heading": "Onboarding",
+      "file": "onboarding.md",
+      "subsections": ["When to use", "Style", "Wizard step titles"],
+      "status": "complete"
     },
     {
-      "heading": "---",
-      "content": []
+      "id": 20,
+      "heading": "What's new",
+      "file": "whats-new.md",
+      "subsections": ["Style", "Do/Don't"],
+      "status": "complete"
     },
     {
-      "heading": "Abbreviations and articles",
-      "content": []
+      "id": 21,
+      "heading": "Alerts",
+      "file": "alerts.md",
+      "subsections": ["When to use", "Style", "Behavior", "Do/Don't"],
+      "status": "complete"
     },
     {
-      "heading": "---",
-      "content": []
+      "id": 22,
+      "heading": "Combo box",
+      "file": "combo-box.md",
+      "subsections": ["When to use", "Style", "Behavior", "Do/Don't"],
+      "status": "complete"
     },
     {
-      "heading": "💬 Backlog",
-      "content": []
+      "id": 23,
+      "heading": "Data tables",
+      "file": "data-tables.md",
+      "subsections": ["When to use", "Column headers", "Cell content", "Bulk actions"],
+      "status": "complete"
     },
     {
-      "heading": "Colors",
-      "content": []
+      "id": 24,
+      "heading": "Grid and spacing",
+      "file": "grid-and-spacing.md",
+      "subsections": ["Content implications", "Density considerations"],
+      "status": "complete"
     },
     {
-      "heading": "[Optional] Important note goes here",
-      "content": []
+      "id": 25,
+      "heading": "Icons",
+      "file": "icons.md",
+      "subsections": ["When to use", "Style", "Accessibility"],
+      "status": "complete"
     },
     {
-      "heading": "[Optional] Objective, use case, requirements, timeline, link to confluence or jira, etc.",
-      "content": []
+      "id": 26,
+      "heading": "Inline toast",
+      "file": "inline-toast.md",
+      "subsections": ["When to use", "Style", "Examples"],
+      "status": "complete"
     },
     {
-      "heading": "[Optional] Add a supporting image",
-      "content": []
+      "id": 27,
+      "heading": "Lineage-specific UI",
+      "file": "lineage-specific-ui.md",
+      "subsections": ["When to use", "Node labels", "Edge and relationship labels", "Terminology"],
+      "status": "complete"
     },
     {
-      "heading": "Content guidelines checklist",
-      "content": []
+      "id": 28,
+      "heading": "Multi-select",
+      "file": "multi-select.md",
+      "subsections": ["When to use", "Style", "Behavior", "Do/Don't"],
+      "status": "complete"
     },
     {
-      "heading": "Use this handy checklist to confirm content is in the right state for reviews. Before meeting with Jeff or Jessie, or asking for review, ensure you’ve fixed any content issues during design and checked them off here.",
-      "content": [
-        "Notes: Kristina/Harrison (Feb/5/26)\n\nDefault 1200 width ✅\nUse whole width for tables ✅\n48px table header default ✅\n\nAsk Jeff:\nFeedback on layout\nShorten descriptions to fit into 2 lines (header)\n10 sub-topics: Can they be grouped into less sections"
-      ]
+      "id": 29,
+      "heading": "Object preview panels",
+      "file": "object-preview-panels.md",
+      "subsections": ["When to use", "Style", "Attribute label examples"],
+      "status": "complete"
+    },
+    {
+      "id": 30,
+      "heading": "Popover",
+      "file": "popover.md",
+      "subsections": ["When to use", "Style", "Behavior"],
+      "status": "complete"
+    },
+    {
+      "id": 31,
+      "heading": "Related content panels",
+      "file": "related-content-panels.md",
+      "subsections": ["When to use", "Style", "Do/Don't"],
+      "status": "complete"
+    },
+    {
+      "id": 32,
+      "heading": "Stepper",
+      "file": "stepper.md",
+      "subsections": ["When to use", "Step titles", "Navigation buttons", "Do/Don't"],
+      "status": "complete"
+    },
+    {
+      "id": 33,
+      "heading": "Switch",
+      "file": "switch.md",
+      "subsections": ["When to use", "Style", "Do/Don't"],
+      "status": "complete"
+    },
+    {
+      "id": 34,
+      "heading": "Tables",
+      "file": "tables.md",
+      "subsections": ["When to use", "Style"],
+      "status": "complete"
+    },
+    {
+      "id": 35,
+      "heading": "Uploads",
+      "file": "uploads.md",
+      "subsections": ["When to use", "Style", "Progress and status", "Do/Don't"],
+      "status": "complete"
+    },
+    {
+      "id": 36,
+      "heading": "Validation messages",
+      "file": "validation-messages.md",
+      "subsections": ["When to use", "Style", "Do/Don't"],
+      "status": "complete"
+    },
+    {
+      "id": 37,
+      "heading": "Wizards",
+      "file": "wizards.md",
+      "subsections": ["When to use", "Step titles", "In-step content", "Confirmation and summary step", "Navigation buttons", "Do/Don't"],
+      "status": "complete"
     }
   ],
-  "text_count": 30
+  "key_rules": {
+    "casing": "Sentence case for all UI text",
+    "style_guide": "IBM Style conventions",
+    "banned_words": ["please", "sorry", "ensure", "execute", "abort", "master", "slave", "blacklist", "whitelist", "sign in", "signin", "CTA", "agnostic", "disabled (as state label)"],
+    "button_formula": "verb + object",
+    "validation_timing": "on blur (field exit), not on keystroke",
+    "empty_cell_value": "— (em dash)",
+    "placeholder_rule": "examples only, never substitute for label"
+  }
 }

--- a/plugins/actian-design-system/references/quality-checklist.md
+++ b/plugins/actian-design-system/references/quality-checklist.md
@@ -85,7 +85,7 @@ Items specific to the `generate-flow` skill, in addition to Universal.
 | 6 | **Missing states flagged** | Empty, error, loading, and confirmation states are included (or explicitly noted as out of scope). |
 | 7 | **Reading order** | Screens flow left-to-right, top-to-bottom. One row per sub-flow, no wrapping. |
 | 8 | **Custom elements follow FM conventions** | `fm-custom-` prefix, `--fm-*` variables, FM spacing/typography, HTML comment explaining purpose. Lo-fi fidelity. |
-| 9 | **Content guidelines applied** | Button labels use action verbs (title case). Form labels are concise (no colons). Error messages explain what + how to fix. |
+| 9 | **Content guidelines applied** | Button labels use action verbs, sentence case ("Save changes", not "Save Changes"). Form labels are concise (no colons). Error messages explain what + how to fix. |
 | 10 | **Accessibility basics** | Interactive elements have focus indicators. Form inputs have labels. No text below 11px. Color is not the only status indicator. |
 
 ---

--- a/plugins/actian-design-system/skills/compare-flows/SKILL.md
+++ b/plugins/actian-design-system/skills/compare-flows/SKILL.md
@@ -22,6 +22,7 @@ Compare two Figma flows or screens and provide structured UX recommendations. Ru
 - **Component usage:** Which FM components in each, components in one but not other, ad-hoc elements that should be library components
 - **Consistency:** Layout patterns, typography, spacing, color token usage between the two flows
 - **Forms layout:** Simple inputs 480px max-width, extended elements full-width, action footer sticky bottom primary right
+- **Copy and labels:** Sentence case, action-verb buttons, error message quality, empty state completeness — reference `../../docs/content-guidelines.md`
 - **UX patterns:** Information hierarchy, progressive disclosure, user effort (fewer steps = better), error recovery
 - **Accessibility:** Contrast, touch targets, focus order
 

--- a/plugins/actian-design-system/skills/convert-to-hifi/SKILL.md
+++ b/plugins/actian-design-system/skills/convert-to-hifi/SKILL.md
@@ -144,6 +144,16 @@ Apply DS spacing tokens and layout rules to every container before pushing:
 - Typography: map FM text sizes to DS text style tokens (body, label, heading tiers)
 - See `references/component-instance-rules.md` for property-setting rules
 
+### Copy polish
+
+Before pushing, audit all visible text against `docs/content-guidelines.md`:
+- Sentence case on all UI text (buttons, labels, headings, column headers, placeholders)
+- Buttons: verb + object ("Save changes", not "Save Changes" and not "Save")
+- No banned words: please, sorry, ensure, execute, abort, sign in, signin, disabled
+- Error messages: state what went wrong + how to fix it (never just "Invalid" or "Error")
+- Empty states: headline + one-sentence body + one CTA button
+- Placeholder text: models expected input — never repeats the field label
+
 ### Push sequence (one small `use_figma` call per step)
 
 1. **Create wrapper frame** — same parent as original, named `"[Original name] — HiFi wrapper"`, `HORIZONTAL` auto layout, gap 32, no fills. This holds the gen card and hifi frame side by side.

--- a/plugins/actian-design-system/skills/create-component/SKILL.md
+++ b/plugins/actian-design-system/skills/create-component/SKILL.md
@@ -69,6 +69,7 @@ After creation, offer: "Want me to generate a component brief?" If accepted, inv
 - Use `primaryAxisAlignItems: "SPACE_BETWEEN"` for push-apart layouts, never Spacer frames
 - Button booleans: `"👁 Leading Icon": false, "👁 Trailing Icon": false` by default
 - Never leave variableScopes as `ALL_SCOPES`
+- **Default text values:** Set all default text properties to guidelines-compliant values per `docs/content-guidelines.md` — sentence case, verb + object for action labels, realistic placeholder text (not "Label", "Text", or "Lorem ipsum")
 
 ## References
 

--- a/plugins/actian-design-system/skills/design-audit/SKILL.md
+++ b/plugins/actian-design-system/skills/design-audit/SKILL.md
@@ -25,6 +25,7 @@ Audit a Figma file or section against the Actian Design System 2026 and/or Fat M
 - **Flow structure:** Dark cover card with Feature/Flow/User, screen naming `[Persona] - [Page] - [State]`, 1440x960 or 1440x700, left-to-right reading order
 - **Forms layout:** Simple inputs 480px max-width, extended elements full-width, action footer sticky bottom with primary right
 - **Missing states:** Empty, error, loading, confirmation states; form validation, disabled, required indicators
+- **Copy and labels:** Check visible text against `../../docs/content-guidelines.md` — sentence case on all UI text, action-verb button labels, error messages that say what went wrong and how to fix it, placeholder text that models input (never repeats the label), no banned words (please, sorry, ensure, execute, abort, sign in, disabled)
 - **Accessibility:** WCAG AA contrast, visible focus states, no text below 11px
 
 ## Output format

--- a/plugins/actian-design-system/skills/generate-flow/SKILL.md
+++ b/plugins/actian-design-system/skills/generate-flow/SKILL.md
@@ -206,6 +206,7 @@ Push-apart row: `{ "type": "FRAME", "name": "Header Row", "layout": { "mode": "H
 - **Feature focus:** Spotlight the feature, placeholder everything else; build sidebar from navItems in flow-data.json
 - **Small direct calls:** Keep each `use_figma` call under 2KB
 - **No contentHtml:** Use structured content[] nodes (FRAME, TEXT, INSTANCE, DIVIDER) only
+- **Copy:** All visible text follows `docs/content-guidelines.md` — sentence case for all UI text, verb + object button labels ("Create data product"), no banned words, placeholder text models input (never repeats the label), empty states include a headline + body + CTA
 
 ## References
 


### PR DESCRIPTION
Wire all skills and agents to the renamed, un-prefixed content guidelines files (global-guidelines.md instead of 01-global-guidelines.md, etc.) and add active copy-quality checks wherever content is generated or audited.

Changes:
- docs/content-guidelines.md: Full rewrite with comprehensive quick-reference checklist and all 37 sections; remove stale format-spec pointer
- docs/foundations/content-guidelines.json: Fix all 37 section file names (remove numeric prefixes); add live_site and index_file fields; expand global-guidelines subsections to reflect new content
- references/quality-checklist.md: Fix factual error — button labels are sentence case, not title case
- skills/design-audit/SKILL.md: Add "Copy and labels" check dimension
- skills/compare-flows/SKILL.md: Add "Copy and labels" comparison dimension
- skills/generate-flow/SKILL.md: Add copy rule to Key rules
- agents/screen-generator.md: Add copy rule to Rules
- skills/convert-to-hifi/SKILL.md: Add copy polish section to Stage 3
- skills/create-component/SKILL.md: Add default text values rule
- agents/card-generator.md: Add content card copy rule