### PR TITLE
fix(brief): Pattern 3 helper HUGs parent row (v1.70.4) — closes recurring 1px table cell crush

### DIFF
--- a/plugins/actian-design-system/.claude-plugin/plugin.json
+++ b/plugins/actian-design-system/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "actian-design-system",
   "description": "Actian Design System toolkit — sync tokens from Figma, generate wireframe flows with prototype wiring, create component briefs, audit designs, compare flows, and build presentations. 9 skills (with tiered generation: recognized / adapted / improvised), 8 agents, 155 tokens (3 themes, 8 collections), WCAG 2.1 AA.",
-  "version": "1.70.3",
+  "version": "1.70.4",
   "author": {
     "name": "Actian UX Team"
   },

--- a/plugins/actian-design-system/references/component-brief/push-patterns.md
+++ b/plugins/actian-design-system/references/component-brief/push-patterns.md
@@ -377,16 +377,31 @@ async function appendTokenTagCell(parentRow, tokenText) {
 
   parentRow.appendChild(labelFrame);
 
-  // HUG-after-append guard (v1.70.0+): table rows with text-cell width
-  // constraints crush child frames to 1px height. Force AUTO sizing on
-  // the labelFrame after append to override inherited FIXED. Phase 2 PR 1
-  // smoke (2026-05-06) showed Checkbox token-tag cells crushed to ~1px
-  // because parent row had FIXED counter-axis sizing.
+  // HUG-after-append guards (v1.70.4+):
+  //   1. labelFrame hugs its own content (intrinsic ~17px tall).
+  //   2. parentRow MUST hug its tallest child too — this is the load-bearing
+  //      fix. Without (2), any row whose cells were sized via cell.resize(w, h)
+  //      ends up with FIXED counter-axis sizing (or short intrinsic height
+  //      from a single-line text node), and parent.clipsContent = true (frame
+  //      default) clips the labelFrame to the row's old ~1px height.
+  //
+  //      v1.70.0/1/2 patches set HUG on labelFrame only — the labelFrame grew
+  //      internally, but the parent row never expanded, so the cell still
+  //      visually rendered as a 1px line (the recurring Checkbox/Variation
+  //      /Tokens/Sizing/Typography squash observed across multiple smokes).
   if (typeof labelFrame.layoutSizingVertical !== "undefined") {
     labelFrame.layoutSizingVertical = "HUG";
   }
   if (typeof labelFrame.layoutSizingHorizontal !== "undefined") {
     labelFrame.layoutSizingHorizontal = "HUG";
+  }
+  if (parentRow.layoutMode === "NONE") {
+    parentRow.layoutMode = "HORIZONTAL";
+  }
+  parentRow.counterAxisSizingMode = "AUTO";
+  parentRow.counterAxisAlignItems = "CENTER";
+  if (typeof parentRow.layoutSizingVertical !== "undefined") {
+    parentRow.layoutSizingVertical = "HUG";
   }
 
   return labelFrame;
@@ -449,9 +464,9 @@ cell.appendChild(textStack);
 
 Regression guard: if the cell or its parent row uses `counterAxisSizingMode = "FIXED"` or sets a hard `cell.resize(_, 20)`, the second line clips. Always Hug.
 
-**Token Tag styling (v1.69.0+, with v1.70.0+ HUG guard):** The token-name text below the swatch dot must use the Token Tag pill style — same construction as Pattern 3's `appendTokenTagCell`. The hex value text below the token name stays as plain monospace text (it's not a token reference). Replace the `// token-name text node` placeholder with a call to `appendTokenTagCell(textStack, tokenName)` or the inline equivalent.
+**Token Tag styling (v1.69.0+, with v1.70.4+ HUG guard):** The token-name text below the swatch dot must use the Token Tag pill style — same construction as Pattern 3's `appendTokenTagCell`. The hex value text below the token name stays as plain monospace text (it's not a token reference). Replace the `// token-name text node` placeholder with a call to `appendTokenTagCell(textStack, tokenName)` or the inline equivalent.
 
-**Regression guard (v1.70.0+):** After appending the labelFrame to the textStack, force `labelFrame.layoutSizingVertical = "HUG"` and `labelFrame.layoutSizingHorizontal = "HUG"` (with `typeof !== "undefined"` defensive check). Without this guard, table rows with text-cell width constraints crush child frames to ~1px height — observed in Phase 2 PR 1 smoke (Checkbox token cells were invisible).
+**Regression guard (v1.70.4+, supersedes v1.70.0):** When inlining the token-tag construction (i.e., not calling `appendTokenTagCell` directly), apply the SAME guards the helper applies — both on the labelFrame (HUG on both axes) AND on the textStack/parentRow (`counterAxisSizingMode = "AUTO"`, `layoutSizingVertical = "HUG"`). v1.70.0–1.70.2 patched only the labelFrame; the parent row stayed at its old ~1px height and clipped the labelFrame visually (the recurring Checkbox/Variation/Tokens/Sizing/Typography squash). The fix MUST hit the parent.
 
 **Table layout:** Build as a header row (state + column names) + data rows. Each data row: state label text + N swatch cells. The data row frame should use `layoutMode = "HORIZONTAL"`, `counterAxisAlignItems = "CENTER"`, and `counterAxisSizingMode = "AUTO"` so it grows to the tallest cell. Batch 2-3 rows per `use_figma` call.
 


### PR DESCRIPTION
## Summary

- Pattern 3 `appendTokenTagCell` HUG-after-append guard now targets `parentRow` (the load-bearing fix), not just `labelFrame`
- Pattern 4 regression-guard comment updated to v1.70.3+ wording — inlined token-tag construction (color swatch grid) applies the SAME guards on `textStack`/`parentRow`
- Plugin bumped 1.70.1 → 1.70.3 (1.70.2 branch abandoned — its single-return refactor was directionally fine but smoke proved non-load-bearing for the actual bugs; revisits naturally during Ring 0.5 Figma skill adoptions)

## Why v1.70.0/1/2 missed it

The v1.70.0 guard set `labelFrame.layoutSizingVertical = "HUG"` after append. labelFrame grew to ~17px internally, **but the parent row's counter-axis sizing stayed short** (often ~1px from `cell.resize(w, h)` calls earlier in the row construction). With `parent.clipsContent = true` (frame default), the labelFrame got visually clipped to the row's height — rendered as a thin horizontal line that read as an em dash.

Three patches across v1.70.0–1.70.2 all targeted the wrong frame.

## What this fixes

Smoke on Checkbox at `FaBwMaNkvdrcQIo3fl8I4D#1067-2614` (2026-05-07) showed token-tag cells crushed to ~1px in:
- Variation matrix (every state×prop cell)
- Tokens table (state×property)
- Sizing sub-table (Token column)
- Typography sub-table (Token column)
- Anatomy parts table (Token column)

All five surfaces use Pattern 3's `appendTokenTagCell` helper or Pattern 4's color-swatch helper that references it. One fix covers all.

## What this does NOT fix

- **Bug 2** (Specs sub-frame improvising a 3-column text table instead of running Pattern 14) — separate root cause (AI sees structured `card_anatomy.specs[]` and emits Pattern 3 instead of Pattern 14). Surgical fix planned next as v1.71.0 B2a (pre-process specs[] in renderer; AI never sees tabular data).

## Test plan

- [ ] Cowork Desktop auto-update to v1.70.3
- [ ] Re-run `/component-brief Checkbox`
- [ ] Acceptance bar: Variation/Tokens/Sizing/Typography tables show full-height token-tag pills (~17–20px tall, no dashes/1px lines)
- [ ] Anatomy parts table Token column also fixed
- [ ] No regression on Section 1 supercard structure (Anatomy/Variation/Tokens/Specs sub-frames still render with dividers)

🤖 Generated with [Claude Code](https://claude.com/claude-code)