### PR TITLE
feat(evals): component-brief eval lane (Sprint 1a)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,8 +36,10 @@ plugins/*/.env.local
 # Test prompts (local reference only)
 plugins/*/TEST-PROMPTS.md
 
-# Evals (large transcripts, local dev only)
-plugins/*/evals/
+# Evals: ignore workspace outputs (regenerated per run) and stray transcripts,
+# but track eval lane definitions (fixtures, evals.json, grader.md, README.md)
+plugins/actian-design-system/evals/**/workspace/
+plugins/actian-design-system/evals/**/*.transcript.json
 
 # Release notes (local drafts for Slack)
 release-notes/

--- a/plugins/actian-design-system/.claude-plugin/plugin.json
+++ b/plugins/actian-design-system/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "actian-design-system",
   "description": "Actian Design System toolkit — sync tokens from Figma, generate wireframe flows with prototype wiring, create component briefs, audit designs, compare flows, and build presentations. 9 skills (with tiered generation: recognized / adapted / improvised), 8 agents, 155 tokens (3 themes, 8 collections), WCAG 2.1 AA.",
-  "version": "1.71.1",
+  "version": "1.72.0",
   "author": {
     "name": "Actian UX Team"
   },

--- a/plugins/actian-design-system/MIGRATIONS.md
+++ b/plugins/actian-design-system/MIGRATIONS.md
@@ -87,6 +87,29 @@ bearing, not ceremonial.
 If the PR is a refactor / docs-only / test-only change with no AI-facing
 behavioral effect, mark the section `N/A — <one-line reason>` and proceed.
 
+### Component-brief / push-pattern PRs: automated eval lane
+
+For PRs that touch `references/component-brief/`,
+`scripts/renderers/figma-table/`, or the brief skill itself, the smoke
+evidence is the output of the component-brief eval lane:
+
+```bash
+plugins/actian-design-system/scripts/evals/run-component-brief.sh plan
+# dispatch the printed subagent prompts via the Agent tool, then:
+plugins/actian-design-system/scripts/evals/run-component-brief.sh aggregate <iteration-id>
+```
+
+Paste the resulting `benchmark.md` into the Smoke evidence section. See
+`evals/component-brief/README.md` for the full operator workflow.
+
+**Marketplace-cache constraint:** `/component-brief` reads its skill code
+from the installed plugin marketplace cache, NOT from the feature
+branch. So the eval tests the LATEST released version of the brief
+skill. For brief-skill-changing PRs, the smoke evidence has to come
+from a run made AFTER marketplace propagation of that PR's commit.
+Pre-merge eval runs against feature branches catch eval-infra
+regressions, not skill-behavior regressions.
+
 ## Rule 4 — Doc/runtime convention parity
 
 Any Bash code block in committed docs that invokes Node MUST follow the

--- a/plugins/actian-design-system/evals/component-brief/README.md
+++ b/plugins/actian-design-system/evals/component-brief/README.md
@@ -24,6 +24,35 @@ The aggregator emits `benchmark.md`. **Paste benchmark.md into the
 PR description's Smoke Evidence section.** That IS the smoke gate
 (per `MIGRATIONS.md` Rule 3).
 
+## Marketplace-cache constraint
+
+`/component-brief` reads its skill code from the installed plugin
+marketplace cache, NOT from your feature branch. So the eval tests
+the LATEST released version of the brief skill, not whatever you
+have locally checked out.
+
+For PRs that **change the brief skill itself** (or the push patterns
+it consumes), this means:
+
+- Pre-merge eval runs against your feature branch catch
+  eval-infrastructure regressions only — not skill-behavior changes.
+- The load-bearing smoke evidence is an eval run made AFTER the PR
+  is merged AND propagated to the marketplace.
+
+A pragmatic flow for brief-skill-changing PRs:
+
+1. Open the PR with a placeholder Smoke evidence section
+   (`Pending marketplace propagation`).
+2. Merge.
+3. Wait for marketplace cache refresh (typically minutes).
+4. Run the eval against `main`. Paste benchmark.md into the merged
+   PR's description as a follow-up.
+5. If the eval regresses, open a fix PR immediately.
+
+For PRs that **only add to or modify the eval lane itself** (like
+the v1.72.0 PR that introduces this lane), pre-merge runs are
+sufficient — they validate the lane's plumbing, not the skill.
+
 ## What's covered
 
 - **checkbox-table-heavy** — token tables, Anatomy diagram, badges A/B,

--- a/plugins/actian-design-system/evals/component-brief/README.md
+++ b/plugins/actian-design-system/evals/component-brief/README.md
@@ -1,0 +1,53 @@
+# Component-Brief Eval Lane
+
+End-to-end AI-behavior eval for `/component-brief`. Dispatch this when
+opening any PR that touches `references/component-brief/`,
+`scripts/renderers/figma-table/`, or the brief skill itself.
+
+## How to run
+
+In a Claude Code session at the plugin root:
+
+```bash
+plugins/actian-design-system/scripts/evals/run-component-brief.sh plan
+```
+
+The script prints two with-skill subagent prompts and two grader
+prompts. Dispatch them via the Agent tool, then:
+
+```bash
+plugins/actian-design-system/scripts/evals/run-component-brief.sh aggregate <iteration-id>
+plugins/actian-design-system/scripts/evals/run-component-brief.sh view <iteration-id>
+```
+
+The aggregator emits `benchmark.md`. **Paste benchmark.md into the
+PR description's Smoke Evidence section.** That IS the smoke gate
+(per `MIGRATIONS.md` Rule 3).
+
+## What's covered
+
+- **checkbox-table-heavy** — token tables, Anatomy diagram, badges A/B,
+  Variation matrix. Catches v1.71.0 squash regression + Anatomy
+  badge-missing regression.
+- **button-variant-heavy** — Variation matrix with multiple variants.
+  Catches variant-axis rendering regressions.
+
+## What's NOT covered
+
+- Pixel-perfect parity / brand-style match. Manual review only.
+- Pattern 14 / Specs sub-frame correctness. Bug 2 is pre-existing per
+  the v1.71.1 pickup memo and slated for Phase 2.
+- Refine / vision / flow / hifi / audit skills. Each gets its own
+  eval lane in subsequent sprints.
+
+## Updating fixtures
+
+Both fixtures must validate against
+`plugins/actian-design-system/schemas/brief-data.schema.json`. If the
+schema evolves, the integration test suite catches the drift; update
+the fixture in the same PR.
+
+## Updating assertions
+
+Edit `grader.md`. Add new assertion IDs (A8, A9...) and reference them
+from `evals.json`. The grader reads grader.md fresh on every dispatch.

--- a/plugins/actian-design-system/evals/component-brief/evals.json
+++ b/plugins/actian-design-system/evals/component-brief/evals.json
@@ -4,37 +4,58 @@
     {
       "id": 0,
       "eval_name": "checkbox-table-heavy",
-      "prompt": "Generate a component brief for Checkbox using the brief-data at plugins/actian-design-system/evals/component-brief/fixtures/checkbox-brief-data.json. Push the resulting frame to Figma file FaBwMaNkvdrcQIo3fl8I4D, page TBD-EVAL-PAGE-ID. Return the resulting frame's node ID as the last line of your output, prefixed with 'FRAME_NODE_ID='.",
+      "prompt": "Generate a component brief for Checkbox using the brief-data at plugins/actian-design-system/evals/component-brief/fixtures/checkbox-brief-data.json. Push the resulting frame to Figma file FaBwMaNkvdrcQIo3fl8I4D, page 1143:12 (Eval — Component Brief). Return the resulting frame's node ID as the last line of your output, prefixed with 'FRAME_NODE_ID='.",
       "fixture_path": "plugins/actian-design-system/evals/component-brief/fixtures/checkbox-brief-data.json",
       "expected_output": "A component brief frame on the test page, with all Phase 1 token tables rendered at >=32px row heights, real frame names (not generic 'Frame'), Anatomy badges A and B present, Specs sub-frame present.",
       "files": [
         "plugins/actian-design-system/evals/component-brief/fixtures/checkbox-brief-data.json"
       ],
       "assertions": [
-        {"text": "A1: Frame names contain real component-part names", "fixture": "checkbox"},
-        {"text": "A2: No row in Phase 1 token tables crushes below 32px", "fixture": "checkbox"},
-        {"text": "A3: Variation matrix renders rows >= 40px", "fixture": "checkbox"},
-        {"text": "A4: No token typo regression", "fixture": "checkbox"},
-        {"text": "A5: Specs sub-frame exists", "fixture": "checkbox"},
-        {"text": "A6: Anatomy badges A and B exist", "fixture": "checkbox"}
+        {
+          "text": "A1: Frame names contain real component-part names",
+          "fixture": "checkbox"
+        },
+        {
+          "text": "A2: No row in Phase 1 token tables crushes below 32px",
+          "fixture": "checkbox"
+        },
+        {
+          "text": "A3: Variation matrix renders rows >= 40px",
+          "fixture": "checkbox"
+        },
+        { "text": "A4: No token typo regression", "fixture": "checkbox" },
+        { "text": "A5: Specs sub-frame exists", "fixture": "checkbox" },
+        { "text": "A6: Anatomy badges A and B exist", "fixture": "checkbox" }
       ]
     },
     {
       "id": 1,
       "eval_name": "button-variant-heavy",
-      "prompt": "Generate a component brief for Button using the brief-data at plugins/actian-design-system/evals/component-brief/fixtures/button-brief-data.json. Push the resulting frame to Figma file FaBwMaNkvdrcQIo3fl8I4D, page TBD-EVAL-PAGE-ID. Return the resulting frame's node ID as the last line of your output, prefixed with 'FRAME_NODE_ID='.",
+      "prompt": "Generate a component brief for Button using the brief-data at plugins/actian-design-system/evals/component-brief/fixtures/button-brief-data.json. Push the resulting frame to Figma file FaBwMaNkvdrcQIo3fl8I4D, page 1143:12 (Eval — Component Brief). Return the resulting frame's node ID as the last line of your output, prefixed with 'FRAME_NODE_ID='.",
       "fixture_path": "plugins/actian-design-system/evals/component-brief/fixtures/button-brief-data.json",
       "expected_output": "A component brief frame on the test page, with the Variation matrix rendering all variants from the fixture, real frame names, no token typos, Specs sub-frame present.",
       "files": [
         "plugins/actian-design-system/evals/component-brief/fixtures/button-brief-data.json"
       ],
       "assertions": [
-        {"text": "A1: Frame names contain real component-part names", "fixture": "button"},
-        {"text": "A2: No row in Phase 1 token tables crushes below 32px", "fixture": "button"},
-        {"text": "A3: Variation matrix renders rows >= 40px", "fixture": "button"},
-        {"text": "A4: No token typo regression", "fixture": "button"},
-        {"text": "A5: Specs sub-frame exists", "fixture": "button"},
-        {"text": "A7: Variation matrix row count matches fixture", "fixture": "button"}
+        {
+          "text": "A1: Frame names contain real component-part names",
+          "fixture": "button"
+        },
+        {
+          "text": "A2: No row in Phase 1 token tables crushes below 32px",
+          "fixture": "button"
+        },
+        {
+          "text": "A3: Variation matrix renders rows >= 40px",
+          "fixture": "button"
+        },
+        { "text": "A4: No token typo regression", "fixture": "button" },
+        { "text": "A5: Specs sub-frame exists", "fixture": "button" },
+        {
+          "text": "A7: Variation matrix row count matches fixture",
+          "fixture": "button"
+        }
       ]
     }
   ]

--- a/plugins/actian-design-system/evals/component-brief/evals.json
+++ b/plugins/actian-design-system/evals/component-brief/evals.json
@@ -1,0 +1,41 @@
+{
+  "skill_name": "component-brief",
+  "evals": [
+    {
+      "id": 0,
+      "eval_name": "checkbox-table-heavy",
+      "prompt": "Generate a component brief for Checkbox using the brief-data at plugins/actian-design-system/evals/component-brief/fixtures/checkbox-brief-data.json. Push the resulting frame to Figma file FaBwMaNkvdrcQIo3fl8I4D, page TBD-EVAL-PAGE-ID. Return the resulting frame's node ID as the last line of your output, prefixed with 'FRAME_NODE_ID='.",
+      "fixture_path": "plugins/actian-design-system/evals/component-brief/fixtures/checkbox-brief-data.json",
+      "expected_output": "A component brief frame on the test page, with all Phase 1 token tables rendered at >=32px row heights, real frame names (not generic 'Frame'), Anatomy badges A and B present, Specs sub-frame present.",
+      "files": [
+        "plugins/actian-design-system/evals/component-brief/fixtures/checkbox-brief-data.json"
+      ],
+      "assertions": [
+        {"text": "A1: Frame names contain real component-part names", "fixture": "checkbox"},
+        {"text": "A2: No row in Phase 1 token tables crushes below 32px", "fixture": "checkbox"},
+        {"text": "A3: Variation matrix renders rows >= 40px", "fixture": "checkbox"},
+        {"text": "A4: No token typo regression", "fixture": "checkbox"},
+        {"text": "A5: Specs sub-frame exists", "fixture": "checkbox"},
+        {"text": "A6: Anatomy badges A and B exist", "fixture": "checkbox"}
+      ]
+    },
+    {
+      "id": 1,
+      "eval_name": "button-variant-heavy",
+      "prompt": "Generate a component brief for Button using the brief-data at plugins/actian-design-system/evals/component-brief/fixtures/button-brief-data.json. Push the resulting frame to Figma file FaBwMaNkvdrcQIo3fl8I4D, page TBD-EVAL-PAGE-ID. Return the resulting frame's node ID as the last line of your output, prefixed with 'FRAME_NODE_ID='.",
+      "fixture_path": "plugins/actian-design-system/evals/component-brief/fixtures/button-brief-data.json",
+      "expected_output": "A component brief frame on the test page, with the Variation matrix rendering all variants from the fixture, real frame names, no token typos, Specs sub-frame present.",
+      "files": [
+        "plugins/actian-design-system/evals/component-brief/fixtures/button-brief-data.json"
+      ],
+      "assertions": [
+        {"text": "A1: Frame names contain real component-part names", "fixture": "button"},
+        {"text": "A2: No row in Phase 1 token tables crushes below 32px", "fixture": "button"},
+        {"text": "A3: Variation matrix renders rows >= 40px", "fixture": "button"},
+        {"text": "A4: No token typo regression", "fixture": "button"},
+        {"text": "A5: Specs sub-frame exists", "fixture": "button"},
+        {"text": "A7: Variation matrix row count matches fixture", "fixture": "button"}
+      ]
+    }
+  ]
+}

--- a/plugins/actian-design-system/evals/component-brief/fixtures/button-brief-data.json
+++ b/plugins/actian-design-system/evals/component-brief/fixtures/button-brief-data.json
@@ -1,0 +1,207 @@
+{
+  "meta": {
+    "component": "Button",
+    "componentKey": "123:456",
+    "skill": "component-brief",
+    "generatedAt": "2026-04-01T00:00:00.000Z",
+    "duration": "5s",
+    "model": "claude-sonnet-4-6",
+    "pluginVersion": "1.22.0"
+  },
+  "card_header": {
+    "_source": "figma",
+    "name": "Button",
+    "description": "A button component for triggering actions."
+  },
+  "card_component": {
+    "_source": "generated",
+    "variantAxes": [
+      { "axis": "Intent", "values": ["Primary", "Secondary", "Tertiary"] },
+      { "axis": "Size", "values": ["Small", "Medium", "Large"] }
+    ],
+    "variantMatrix": [
+      {
+        "row": "Primary",
+        "columns": [
+          { "label": "Small", "variantName": "Intent=Primary, Size=Small" },
+          { "label": "Medium", "variantName": "Intent=Primary, Size=Medium" },
+          { "label": "Large", "variantName": "Intent=Primary, Size=Large" }
+        ]
+      },
+      {
+        "row": "Secondary",
+        "columns": [
+          { "label": "Small", "variantName": "Intent=Secondary, Size=Small" },
+          { "label": "Medium", "variantName": "Intent=Secondary, Size=Medium" },
+          { "label": "Large", "variantName": "Intent=Secondary, Size=Large" }
+        ]
+      },
+      {
+        "row": "Tertiary",
+        "columns": [
+          { "label": "Small", "variantName": "Intent=Tertiary, Size=Small" },
+          { "label": "Medium", "variantName": "Intent=Tertiary, Size=Medium" },
+          { "label": "Large", "variantName": "Intent=Tertiary, Size=Large" }
+        ]
+      }
+    ],
+    "themeVariant": "Intent=Primary, Size=Medium",
+    "themeComparison": {
+      "actian": {
+        "swatches": [{ "hex": "#005DB2", "token": "theme-primary" }]
+      },
+      "studio": {
+        "swatches": [{ "hex": "#7B3FC4", "token": "theme-primary" }]
+      },
+      "explorer": {
+        "swatches": [{ "hex": "#00796B", "token": "theme-primary" }]
+      }
+    }
+  },
+  "card_anatomy": {
+    "_source": "generated",
+    "parts": [
+      { "letter": "A", "name": "Container" },
+      { "letter": "B", "name": "Label" }
+    ],
+    "specs": [
+      { "target": "height", "label": "36px", "orientation": "vertical" },
+      { "target": "padding", "label": "8px 16px", "orientation": "horizontal" }
+    ],
+    "states": ["Enabled", "Hovered", "Focused", "Pressed", "Disabled"],
+    "partsTable": [
+      {
+        "part": "A",
+        "element": "Frame",
+        "token": "border/radius-sm",
+        "notes": "Container shape"
+      },
+      {
+        "part": "B",
+        "element": "Text",
+        "token": "label-standard",
+        "notes": "Button label"
+      }
+    ]
+  },
+  "card_tokens": {
+    "_source": "generated",
+    "colorTokens": [
+      {
+        "state": "Default",
+        "columns": [
+          { "header": "Fill", "hex": "#005DB2", "token": "theme-primary" },
+          { "header": "Text", "hex": "#FFFFFF", "token": "text-on-primary" }
+        ]
+      }
+    ],
+    "sizingTokens": [
+      { "property": "Height", "token": "size/md", "value": "36px" },
+      { "property": "Padding H", "token": "spacing/md", "value": "16px" }
+    ],
+    "typography": [
+      {
+        "element": "Label",
+        "token": "label-standard",
+        "font": "Inter Semi Bold 14",
+        "tracking": "0"
+      }
+    ]
+  },
+  "card_usage": {
+    "_source": "generated",
+    "whenToUse": [
+      "Use for primary actions that complete a task.",
+      "Use when the action is the most important on the page."
+    ],
+    "whenNotToUse": [
+      "Do not use for navigation — use a link instead.",
+      "Do not use more than one primary button per view."
+    ],
+    "doDont": [
+      {
+        "doLabel": "Use an action verb",
+        "doDetail": "Save, Submit, Confirm",
+        "dontLabel": "Avoid vague labels",
+        "dontDetail": "OK, Yes, Click here"
+      }
+    ]
+  },
+  "card_content": {
+    "_source": "figma",
+    "rules": [
+      {
+        "title": "Label clarity",
+        "description": "Labels must clearly describe the action outcome.",
+        "do": "Save changes",
+        "dont": "OK",
+        "doExample": "Save changes",
+        "dontExample": "OK"
+      }
+    ],
+    "terminology": [
+      { "term": "Save", "use": "When persisting form changes." },
+      { "term": "Submit", "use": "When sending a form for processing." }
+    ]
+  },
+  "card_accessibility": {
+    "_source": "generated",
+    "requirements": [
+      {
+        "title": "Keyboard access",
+        "body": "Button must be focusable with Tab.",
+        "icon": "#005DB2",
+        "code": { "tokens": [] }
+      },
+      {
+        "title": "ARIA role",
+        "body": "Use role=button or native <button>.",
+        "icon": "#005DB2",
+        "code": { "tokens": [] }
+      },
+      {
+        "title": "Focus visible",
+        "body": "Focus ring must be visible with 3:1 contrast.",
+        "icon": "#005DB2",
+        "code": { "tokens": [] }
+      },
+      {
+        "title": "Contrast",
+        "body": "Text must meet 4.5:1 contrast ratio.",
+        "icon": "#005DB2",
+        "code": { "tokens": [] }
+      },
+      {
+        "title": "Touch target",
+        "body": "Minimum 44x44px touch target.",
+        "icon": "#005DB2",
+        "code": { "tokens": [] }
+      },
+      {
+        "title": "Disabled state",
+        "body": "Disabled buttons must not be focusable.",
+        "icon": "#888888",
+        "code": { "tokens": [] }
+      }
+    ],
+    "ariaTable": [
+      {
+        "element": "button",
+        "role": "button",
+        "label": "aria-label",
+        "focusOrder": "1",
+        "keyboard": "Enter, Space",
+        "announcement": "Button name, role"
+      }
+    ],
+    "contrastTable": [
+      {
+        "element": "Label text",
+        "foreground": "#FFFFFF",
+        "background": "#005DB2",
+        "ratio": "8.6:1",
+        "wcag": "Pass"
+      }
+    ]
+  }
+}

--- a/plugins/actian-design-system/evals/component-brief/fixtures/checkbox-brief-data.json
+++ b/plugins/actian-design-system/evals/component-brief/fixtures/checkbox-brief-data.json
@@ -1,0 +1,246 @@
+{
+  "meta": {
+    "component": "Checkbox",
+    "library": "dsKit",
+    "fileKey": "l8biHxfarNi1I2RMvVxVOK",
+    "nodeId": "9478:17216",
+    "componentKey": "f88de6fe161264680045b2b5ec77d311b1b3adb6",
+    "generatedAt": "2026-05-07T00:00:00Z",
+    "skill": "component-brief",
+    "pluginVersion": "1.71.1",
+    "model": "claude-opus-4-7",
+    "duration": "0m 45s"
+  },
+  "card_header": {
+    "_source": "figma",
+    "name": "Checkbox",
+    "description": "A binary or tri-state input control letting users select one or multiple options. Supports labeled, indeterminate, and disabled states across all DS themes."
+  },
+  "card_component": {
+    "_source": "generated",
+    "cardTitle": "Component",
+    "cardSubtitle": "Real library instances showing all variants plus themed component comparison across Actian, Studio, and Explorer",
+    "variantAxes": [
+      { "axis": "Selected", "values": ["Yes", "Indeterminate", "No"] },
+      {
+        "axis": "State",
+        "values": ["Default", "Hover", "Focus", "Pressed", "Disabled"]
+      }
+    ],
+    "variantMatrix": [
+      {
+        "row": "No",
+        "columns": [
+          { "variantName": "Selected=No, State=Default", "label": "Default" },
+          { "variantName": "Selected=No, State=Hover", "label": "Hover" },
+          { "variantName": "Selected=No, State=Focus", "label": "Focus" },
+          { "variantName": "Selected=No, State=Pressed", "label": "Pressed" },
+          { "variantName": "Selected=No, State=Disabled", "label": "Disabled" }
+        ]
+      },
+      {
+        "row": "Yes",
+        "columns": [
+          { "variantName": "Selected=Yes, State=Default", "label": "Default" },
+          { "variantName": "Selected=Yes, State=Hover", "label": "Hover" },
+          { "variantName": "Selected=Yes, State=Focus", "label": "Focus" },
+          { "variantName": "Selected=Yes, State=Pressed", "label": "Pressed" },
+          { "variantName": "Selected=Yes, State=Disabled", "label": "Disabled" }
+        ]
+      },
+      {
+        "row": "Indeterminate",
+        "columns": [
+          {
+            "variantName": "Selected=Indeterminate, State=Default",
+            "label": "Default"
+          },
+          {
+            "variantName": "Selected=Indeterminate, State=Hover",
+            "label": "Hover"
+          },
+          {
+            "variantName": "Selected=Indeterminate, State=Focus",
+            "label": "Focus"
+          },
+          {
+            "variantName": "Selected=Indeterminate, State=Pressed",
+            "label": "Pressed"
+          },
+          {
+            "variantName": "Selected=Indeterminate, State=Disabled",
+            "label": "Disabled"
+          }
+        ]
+      }
+    ],
+    "themeVariant": "Selected=No, State=Default"
+  },
+  "card_anatomy": {
+    "_source": "generated",
+    "cardTitle": "Anatomy",
+    "cardSubtitle": "Component structure, dimensions, interactive states, and part-level token mapping",
+    "parts": [
+      {
+        "letter": "A",
+        "name": "Box",
+        "description": "24×24 square container with border, fill, and rounded corners. Holds the indicator when selected.",
+        "figmaLayerName": "Box"
+      },
+      {
+        "letter": "B",
+        "name": "Indicator",
+        "description": "Checkmark glyph for Selected=Yes, horizontal bar for Selected=Indeterminate. Hidden when Selected=No.",
+        "figmaLayerName": "Indicator"
+      },
+      {
+        "letter": "C",
+        "name": "Label",
+        "description": "Inline text describing the option. Vertically centered with the box.",
+        "figmaLayerName": "Label"
+      }
+    ],
+    "specs": [
+      {
+        "value": "24px",
+        "layerName": "Box",
+        "type": "dimension",
+        "orientation": "Horizontal"
+      },
+      {
+        "value": "24px",
+        "layerName": "Box",
+        "type": "dimension",
+        "orientation": "Vertical"
+      },
+      {
+        "value": "4px",
+        "layerName": "Label",
+        "type": "pointer",
+        "direction": "Left"
+      }
+    ],
+    "states": ["Default", "Hover", "Focus", "Pressed", "Disabled"],
+    "partsTable": [
+      {
+        "part": "A",
+        "element": "Box",
+        "token": "--zen-size-lg, --zen-border-radius-xs, --zen-border-width-md",
+        "notes": "24×24 size, 4px radius, 1px border"
+      },
+      {
+        "part": "B",
+        "element": "Indicator",
+        "token": "--zen-icon-reverse",
+        "notes": "12×12 checkmark / 8×2 horizontal bar (indeterminate)"
+      },
+      {
+        "part": "C",
+        "element": "Label",
+        "token": "--zen-font-body-standard",
+        "notes": "Roboto 400 14px/20px, 0.2px tracking, vertically centered with Box"
+      }
+    ]
+  },
+  "card_tokens": {
+    "_source": "generated",
+    "cardTitle": "Design tokens",
+    "cardSubtitle": "Color, sizing, and typography tokens",
+    "colorTokens": [
+      {
+        "state": "Default (No)",
+        "columns": [
+          { "header": "Border", "token": "border-default", "hex": "#E4E4F0" },
+          { "header": "Box fill", "token": "bg-default", "hex": "#FFFFFF" },
+          { "header": "Indicator", "token": "—", "hex": "#FFFFFF" },
+          { "header": "Label", "token": "text-primary", "hex": "#000000" }
+        ]
+      },
+      {
+        "state": "Default (Yes)",
+        "columns": [
+          { "header": "Border", "token": "border-selected", "hex": "#0550DC" },
+          { "header": "Box fill", "token": "bg-emphasis", "hex": "#0550DC" },
+          { "header": "Indicator", "token": "icon-reverse", "hex": "#FFFFFF" },
+          { "header": "Label", "token": "text-primary", "hex": "#000000" }
+        ]
+      },
+      {
+        "state": "Focus",
+        "columns": [
+          { "header": "Border", "token": "border-selected", "hex": "#0550DC" },
+          { "header": "Box fill", "token": "bg-default", "hex": "#FFFFFF" },
+          { "header": "Indicator", "token": "—", "hex": "#FFFFFF" },
+          { "header": "Label", "token": "text-primary", "hex": "#000000" }
+        ]
+      },
+      {
+        "state": "Error",
+        "columns": [
+          { "header": "Border", "token": "border-error", "hex": "#E6492D" },
+          { "header": "Box fill", "token": "bg-error", "hex": "#FFF4EC" },
+          { "header": "Indicator", "token": "icon-error", "hex": "#DC3514" },
+          { "header": "Label", "token": "text-error", "hex": "#DC3514" }
+        ]
+      },
+      {
+        "state": "Disabled",
+        "columns": [
+          { "header": "Border", "token": "border-disabled", "hex": "#E4E4F0" },
+          { "header": "Box fill", "token": "bg-disabled", "hex": "#F5F5FA" },
+          { "header": "Indicator", "token": "icon-disabled", "hex": "#9898A7" },
+          { "header": "Label", "token": "text-disabled", "hex": "#656574" }
+        ]
+      }
+    ],
+    "sizingTokens": [
+      { "property": "Box width", "token": "--zen-size-lg", "value": "24px" },
+      { "property": "Box height", "token": "--zen-size-lg", "value": "24px" },
+      {
+        "property": "Border radius",
+        "token": "--zen-border-radius-xs",
+        "value": "4px"
+      },
+      {
+        "property": "Border width",
+        "token": "--zen-border-width-md",
+        "value": "1px"
+      },
+      {
+        "property": "Focus ring offset",
+        "token": "--zen-focus-ring-offset",
+        "value": "2px"
+      },
+      {
+        "property": "Gap (box to label)",
+        "token": "--zen-spacing-2xs",
+        "value": "4px"
+      },
+      {
+        "property": "Gap (group items)",
+        "token": "--zen-spacing-xs",
+        "value": "8px"
+      }
+    ],
+    "typography": [
+      {
+        "element": "Label",
+        "token": "body-standard",
+        "font": "Roboto Regular 14px/20px",
+        "tracking": "0.2px"
+      },
+      {
+        "element": "Group label",
+        "token": "body-standard-bold",
+        "font": "Roboto Medium 14px/20px",
+        "tracking": "0.2px"
+      },
+      {
+        "element": "Group description",
+        "token": "body-subtle",
+        "font": "Roboto Regular 12px/16px",
+        "tracking": "0.3px"
+      }
+    ]
+  }
+}

--- a/plugins/actian-design-system/evals/component-brief/grader.md
+++ b/plugins/actian-design-system/evals/component-brief/grader.md
@@ -1,0 +1,127 @@
+# Component-Brief Eval Grader
+
+You are the grader subagent for the component-brief eval lane. The
+with-skill subagent has just invoked `/component-brief` against a
+fixture brief-data.json and pushed a Figma frame. Your job is to
+inspect that frame and return a structured pass/fail per assertion.
+
+## Inputs
+
+You receive:
+
+- `frame_node_id` — the Figma node ID returned by the with-skill run
+  (format: `<file-key>:<node-id>`)
+- `fixture_path` — the brief-data.json the with-skill run was given
+- `eval_name` — `checkbox` or `button` (determines which assertions
+  apply)
+
+## Procedure
+
+1. Call `mcp__claude_ai_Figma__get_metadata` on `frame_node_id` to
+   fetch the full frame tree.
+2. Run each assertion below. For each, return `{text, passed,
+   evidence}` per skill-creator's grading.json schema.
+3. Write `grading.json` to your output directory.
+
+## Universal assertions (both fixtures)
+
+### A1: Frame names contain real component-part names
+
+Walk the frame tree. Count frames whose `name` field equals literally
+`"Frame"`. The v1.71.0 tell was every frame named `"Frame"` because
+the AI created them generically without setting names.
+
+- **Pass:** ≤ 5% of frames are named `"Frame"` (some unnamed wrappers
+  are tolerable; mass-anonymity is the regression signal)
+- **Fail:** > 5%
+- **Evidence:** count + total frames + ratio
+
+### A2: No row in the Phase 1 token tables crushes below 32px
+
+Find frames whose name contains `Color`, `Sizing`, `Typography`, or
+`Anatomy parts`. For each, count direct row children and assert each
+row's `absoluteBoundingBox.height >= 32`.
+
+- **Pass:** every row in every Phase 1 table is ≥ 32px tall
+- **Fail:** any row is < 32px
+- **Evidence:** list of (table, row index, height) for any < 32px row;
+  empty list on pass
+
+### A3: Variation matrix renders rows ≥ 40px
+
+Find a frame whose name contains `Variation`. Same height check at
+40px threshold (variation rows are taller than token rows).
+
+- **Pass:** every variation row ≥ 40px (or no variation frame exists,
+  which is allowed for fixtures without one)
+- **Fail:** any variation row < 40px
+
+### A4: No token typo regression in any text node
+
+Walk all `TEXT` nodes; concatenate their `characters` field. Search
+for any of:
+
+- `--zen-font-body-stardard` (the v1.71.0 typo)
+- `--zen-color-them` (truncation seen in some failed runs)
+- Any `--zen-` prefix followed by a word containing a doubled letter
+  pair that doesn't appear in `tokens/actian-ds.tokens.json`
+
+- **Pass:** no matches
+- **Fail:** any match
+- **Evidence:** the matched substring + node ID
+
+### A5: Specs sub-frame exists
+
+Find a frame whose name contains `Specs`. This assertion does NOT
+check correctness (Bug 2 is pre-existing per the spec); only that
+the section is present.
+
+- **Pass:** at least one frame with `Specs` in its name
+- **Fail:** none
+- **Evidence:** frame name(s) found, or empty
+
+## Checkbox-specific assertions
+
+### A6: Anatomy badges A and B exist as text nodes
+
+Find the Anatomy diagram frame (name contains `Anatomy` and is NOT
+the `Anatomy parts` token table). Inside it, look for TEXT nodes
+whose `characters` are exactly `A` and `B`.
+
+- **Pass:** both `A` and `B` text nodes exist within the Anatomy
+  diagram subtree
+- **Fail:** either is missing
+- **Evidence:** which letters were found
+
+## Button-specific assertions
+
+### A7: Variation matrix row count matches fixture
+
+Read `fixture_path` and count entries in `card_variation.variants`.
+Find the Variation frame in Figma; count its row children
+(direct children excluding any header row).
+
+- **Pass:** Figma row count equals fixture variant count (header rows
+  may be excluded; tolerate ±1)
+- **Fail:** count mismatches by > 1
+- **Evidence:** fixture count + Figma count
+
+## Output format
+
+Write `grading.json` to your assigned output directory:
+
+```json
+{
+  "expectations": [
+    {
+      "text": "A1: Frame names contain real component-part names",
+      "passed": true,
+      "evidence": "12 of 184 frames named 'Frame' (6.5%)"
+    },
+    ...
+  ]
+}
+```
+
+Use **exactly** the field names `text`, `passed`, `evidence` — the
+skill-creator viewer depends on them.

--- a/plugins/actian-design-system/scripts/evals/run-component-brief.sh
+++ b/plugins/actian-design-system/scripts/evals/run-component-brief.sh
@@ -1,0 +1,115 @@
+#!/usr/bin/env bash
+# run-component-brief.sh — orchestrate the component-brief eval lane.
+#
+# This script does NOT directly invoke Claude or push to Figma — those
+# happen inside the calling Claude Code session via the Agent tool when
+# the maintainer says "run the brief eval." This script's job is to:
+#
+#   1. Print the run plan (which evals, where workspace lives)
+#   2. Print copy-paste subagent prompts the maintainer dispatches
+#   3. After subagent runs complete, aggregate benchmark + open viewer
+#
+# This split is intentional: the Anthropic skill-creator framework
+# assumes the orchestrator is Claude Code itself. We can't shell-out
+# to "claude --dangerous-no-permissions"; the maintainer drives it.
+
+set -euo pipefail
+
+PLUGIN_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+EVALS_DIR="$PLUGIN_ROOT/evals/component-brief"
+WORKSPACE_DIR="$EVALS_DIR/workspace"
+SKILL_CREATOR="$HOME/.claude/plugins/cache/claude-plugins-official/skill-creator/unknown/skills/skill-creator"
+
+usage() {
+  cat <<'USAGE'
+Usage:
+  run-component-brief.sh plan            # print the run plan + subagent prompts
+  run-component-brief.sh aggregate <iter># aggregate iteration-N into benchmark
+  run-component-brief.sh view <iter>     # open the eval-viewer for iteration-N
+USAGE
+}
+
+cmd="${1:-}"; shift || true
+
+case "$cmd" in
+  plan)
+    iter="iteration-$(date +%Y%m%d-%H%M%S)"
+    iter_dir="$WORKSPACE_DIR/$iter"
+    mkdir -p "$iter_dir"
+
+    echo "Workspace: $iter_dir"
+    echo
+    echo "Dispatch one Agent per eval. Use these exact prompts:"
+    echo
+    echo "===== checkbox-table-heavy ====="
+    cat <<PROMPT
+Description: Run component-brief eval — Checkbox
+Prompt:
+You are the with-skill subagent for the component-brief eval. Read
+$EVALS_DIR/evals.json eval id=0 ("checkbox-table-heavy") and execute
+the prompt exactly. Save outputs to $iter_dir/eval-checkbox/with_skill/
+outputs/. Capture timing.json with total_tokens and duration_ms.
+PROMPT
+    echo
+    echo "===== button-variant-heavy ====="
+    cat <<PROMPT
+Description: Run component-brief eval — Button
+Prompt:
+You are the with-skill subagent for the component-brief eval. Read
+$EVALS_DIR/evals.json eval id=1 ("button-variant-heavy") and execute
+the prompt exactly. Save outputs to $iter_dir/eval-button/with_skill/
+outputs/. Capture timing.json with total_tokens and duration_ms.
+PROMPT
+    echo
+    echo "After both subagents complete and report FRAME_NODE_ID values,"
+    echo "dispatch the grader subagent for each:"
+    echo
+    cat <<PROMPT
+Description: Grade Checkbox eval result
+Prompt:
+You are the grader subagent. Read $EVALS_DIR/grader.md. Inputs:
+frame_node_id=<paste from previous run>, fixture_path=$EVALS_DIR/
+fixtures/checkbox-brief-data.json, eval_name=checkbox. Write
+grading.json to $iter_dir/eval-checkbox/with_skill/.
+PROMPT
+    echo
+    cat <<PROMPT
+Description: Grade Button eval result
+Prompt:
+You are the grader subagent. Read $EVALS_DIR/grader.md. Inputs:
+frame_node_id=<paste from previous run>, fixture_path=$EVALS_DIR/
+fixtures/button-brief-data.json, eval_name=button. Write
+grading.json to $iter_dir/eval-button/with_skill/.
+PROMPT
+    echo
+    echo "Then run: $0 aggregate $iter"
+    ;;
+
+  aggregate)
+    iter="${1:?iteration required}"
+    iter_dir="$WORKSPACE_DIR/$iter"
+    [ -d "$iter_dir" ] || { echo "no such iteration: $iter_dir" >&2; exit 1; }
+    cd "$SKILL_CREATOR"
+    python3 -m scripts.aggregate_benchmark "$iter_dir" --skill-name component-brief
+    echo
+    echo "benchmark.md:"
+    cat "$iter_dir/benchmark.md"
+    ;;
+
+  view)
+    iter="${1:?iteration required}"
+    iter_dir="$WORKSPACE_DIR/$iter"
+    [ -f "$iter_dir/benchmark.json" ] || { echo "run aggregate first" >&2; exit 1; }
+    nohup python3 "$SKILL_CREATOR/eval-viewer/generate_review.py" \
+      "$iter_dir" \
+      --skill-name component-brief \
+      --benchmark "$iter_dir/benchmark.json" \
+      > "$iter_dir/viewer.log" 2>&1 &
+    echo "Viewer PID $!. Logs at $iter_dir/viewer.log."
+    ;;
+
+  *)
+    usage
+    exit 1
+    ;;
+esac


### PR DESCRIPTION
## Summary

Sprint 1a of the eval-migration roadmap. Adds the component-brief eval lane infrastructure — fixtures, evals.json, grader assertions, runner script, MIGRATIONS Rule 3 cross-link. Replaces the manual v1.71.x smoke checklist with a structured, automated path. The first eval run is intentionally deferred until v1.72.0 propagates to the marketplace cache (see Marketplace-cache constraint in `evals/component-brief/README.md`).

Spec: `plugins/actian-design-system/docs/superpowers/specs/2026-05-08-eval-migration-design.md` (untracked, working artifact)
Plan: `plugins/actian-design-system/docs/superpowers/plans/2026-05-08-eval-migration.md` (untracked)

## What's in scope

- `evals/component-brief/` — fixtures (Checkbox + Button), evals.json, grader.md, README.md
- `scripts/evals/run-component-brief.sh` — runner with plan/aggregate/view subcommands
- MIGRATIONS Rule 3 cross-links the runner + documents the marketplace-cache constraint
- `.gitignore` rescope: blanket `plugins/*/evals/` ignore replaced with workspace-only ignore so eval lane definitions track
- v1.72.0 bump (MINOR — infra-only, no skill behavior change)

## What's deferred

- First on-main eval run (Task 9) — runs after marketplace propagation
- Regression-catch validation (Task 10) — bundled with the post-propagation run

## Smoke evidence

N/A — eval-lane infra-only PR. The lane validates *itself* in the post-merge run; pre-merge runs against this branch would test the marketplace-installed v1.71.1 brief skill, not the lane code on this branch. See `evals/component-brief/README.md` "Marketplace-cache constraint."

Existing test suite: 924/924 pass.

## Test plan

- [x] Existing `tests/integration/` and `tests/renderers/` suites stay green (924/924)
- [x] \`run-component-brief.sh plan\` prints workspace + dispatch prompts
- [x] Eval test page \`1143:12\` exists on \`FaBwMaNkvdrcQIo3fl8I4D\`
- [ ] Post-merge: dispatch the runner against v1.72.0 marketplace cache; capture benchmark.md as follow-up evidence

🤖 Generated with [Claude Code](https://claude.com/claude-code)