### PR TITLE
fix(brief): hash-suffix GenLog property keys in push-patterns docs (v1.72.4)

### DIFF
--- a/plugins/actian-design-system/.claude-plugin/plugin.json
+++ b/plugins/actian-design-system/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "actian-design-system",
   "description": "Actian Design System toolkit — sync tokens from Figma, generate wireframe flows with prototype wiring, create component briefs, audit designs, compare flows, and build presentations. 9 skills (with tiered generation: recognized / adapted / improvised), 8 agents, 155 tokens (3 themes, 8 collections), WCAG 2.1 AA.",
-  "version": "1.72.3",
+  "version": "1.72.4",
   "author": {
     "name": "Actian UX Team"
   },

--- a/plugins/actian-design-system/references/component-brief/push-patterns.md
+++ b/plugins/actian-design-system/references/component-brief/push-patterns.md
@@ -67,6 +67,8 @@ Every brief MUST start with a GenLog card as the first child of the wrapper. Imp
 
 **Source values from `brief-data.json.meta`, never from this example.** The values shown below are placeholders — using them literally produces wrong GenLog content (e.g., a stale plugin version). The data-model values were sourced in Step 2 from authoritative inputs (`plugin.json`, the runtime model name, etc.) — pass them through verbatim.
 
+**CRITICAL — property keys MUST be hash-suffixed.** GenLog's properties are typed as `Skill#3:0`, `Prompt#3:1`, `Date#3:2`, `Duration#3:3`, `Model#3:4`, `Plugin Version#3:5`. Bare keys (`"Skill"`, `"Prompt"`, etc.) silently fail with `setProperties` errors and require a recovery round-trip via `node.componentProperties` introspection. Use the suffixed keys verbatim — they are stable across Meta Kit publishes (tracked in `docs/generated/metakit.json`).
+
 ```js
 // IMPORTANT: read these from your brief-data.json `meta` block, not from the example below.
 const meta = briefData.meta;
@@ -75,12 +77,12 @@ const comp = await figma.importComponentByKeyAsync("a9653f30925367e96dea90093d75
 const inst = comp.createInstance();
 inst.name = "Generation Log";
 inst.setProperties({
-  "Skill": "Skill: " + meta.skill,                         // "component-brief"
-  "Prompt": "Prompt: component-brief " + meta.component,   // "Prompt: component-brief Button"
-  "Date": meta.generatedAt,                                // ISO 8601
-  "Duration": "Duration: " + meta.duration,
-  "Model": meta.model,
-  "Plugin Version": "v" + meta.pluginVersion              // e.g. "v1.57.2" — MUST come from project plugin.json, never invented
+  "Skill#3:0": "Skill: " + meta.skill,                         // "component-brief"
+  "Prompt#3:1": "Prompt: component-brief " + meta.component,   // "Prompt: component-brief Button"
+  "Date#3:2": meta.generatedAt,                                // ISO 8601
+  "Duration#3:3": "Duration: " + meta.duration,
+  "Model#3:4": meta.model,
+  "Plugin Version#3:5": "v" + meta.pluginVersion              // e.g. "v1.57.2" — MUST come from project plugin.json, never invented
 });
 
 const wrapper = await figma.getNodeByIdAsync("<wrapperId>");

--- a/plugins/actian-design-system/references/figma/figma-push-patterns.md
+++ b/plugins/actian-design-system/references/figma/figma-push-patterns.md
@@ -116,10 +116,13 @@ const comp = await figma.importComponentByKeyAsync("a9653f30925367e96dea90093d75
 const inst = comp.createInstance();
 inst.name = "Generation Log";
 
-// Set component properties (text, booleans, instance swaps)
+// Set component properties (text, booleans, instance swaps).
+// IMPORTANT: GenLog property keys are hash-suffixed (`Skill#3:0` etc.).
+// Bare keys silently fail. Look up exact suffixes in `docs/generated/metakit.json`
+// for any imported component before calling setProperties.
 inst.setProperties({
-  "Skill": "Skill: generate-flow",
-  "Date": "2026-04-08T00:00:00Z"
+  "Skill#3:0": "Skill: generate-flow",
+  "Date#3:2": "2026-04-08T00:00:00Z"
 });
 
 return { instanceId: inst.id };


### PR DESCRIPTION
## Summary

- **GenLog snippet bug**: docs showed bare property keys (`"Skill"`, `"Prompt"`, …); actual Meta Kit component requires hash-suffixed keys (`"Skill#3:0"` … `"Plugin Version#3:5"`). Bare keys silently fail in `setProperties`.
- **Evidence**: both v1.72.0 and v1.72.1 with-skill subagents independently hit this in the eval lane and had to recover via `componentProperties` introspection. Captured in `project_v1720_eval_smoke.md`.
- **Fix**: `references/component-brief/push-patterns.md` (full snippet) + `references/figma/figma-push-patterns.md` (Pattern 2's 2-key example) + a CRITICAL callout pointing at `docs/generated/metakit.json` as the source of truth for any imported component's suffixes.
- **Closes Tier 0 #2** from the 2026-05-08 next-session pickup queue.

## Scope

- Doc-only — no recipe / renderer / runtime change. PATCH bump 1.72.2 → 1.72.3.

## Test plan

- [ ] Next eval-lane run uses the suffixed keys verbatim — no introspection round-trip required.
- [ ] CI Tier 1 (test suite + JSON syntax + version-bump) passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)