### PR TITLE
feat(evals): Protocol 3 programmatic grader + swatch sub-cell naming (v1.74.0)

### DIFF
--- a/plugins/actian-design-system/.claude-plugin/plugin.json
+++ b/plugins/actian-design-system/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "actian-design-system",
   "description": "Actian Design System toolkit — sync tokens from Figma, generate wireframe flows with prototype wiring, create component briefs, audit designs, compare flows, and build presentations. 9 skills (with tiered generation: recognized / adapted / improvised), 8 agents, 155 tokens (3 themes, 8 collections), WCAG 2.1 AA.",
-  "version": "1.73.1",
+  "version": "1.74.0",
   "author": {
     "name": "Actian UX Team"
   },

--- a/plugins/actian-design-system/evals/component-brief/README.md
+++ b/plugins/actian-design-system/evals/component-brief/README.md
@@ -50,6 +50,19 @@ different output. The brief skill's recipe interpretation drifts
 across runs. A doc-level fix probably won't stabilize it; treat as
 harness territory per `project_deterministic_harness_architecture.md`.
 
+## Graders
+
+- **`--grader local` (default, ~0 grader tokens):** runs
+  `scripts/evals/grade-locally.js` per (fixture, run) — one Figma REST call,
+  pure-JS assertions. Requires `FIGMA_PAT` in env. Implements A1–A8.
+- **`--grader subagent` (~100K tokens per grader):** dispatches a grader
+  subagent per (fixture, run) following `grader.md`. Use only when the local
+  grader cannot run.
+
+The default flipped to `local` in v1.74.0 alongside the swatch sub-cell
+naming patch. See `memory/project_eval_lane_cost_economics.md` for the
+cost analysis that motivated this.
+
 ## Marketplace-cache constraint
 
 `/component-brief` reads its skill code from the installed plugin

--- a/plugins/actian-design-system/evals/component-brief/grader.md
+++ b/plugins/actian-design-system/evals/component-brief/grader.md
@@ -5,6 +5,14 @@ with-skill subagent has just invoked `/component-brief` against a
 fixture brief-data.json and pushed a Figma frame. Your job is to
 inspect that frame and return a structured pass/fail per assertion.
 
+> **Default grader is now programmatic** (`scripts/evals/grade-locally.js`).
+> The procedure below is the **fallback subagent grader** retained for cases
+> where the local grader can't run (no `FIGMA_PAT`, REST 4xx, or assertion
+> requires LLM judgment that the local grader doesn't yet implement). All
+> A1–A8 assertions are implemented locally as of v1.74.0. Per
+> `project_eval_lane_cost_economics.md`, the local grader halves eval-cycle
+> cost; reserve subagent dispatch for genuine fallback.
+
 ## Inputs
 
 You receive:
@@ -36,7 +44,7 @@ the AI created them generically without setting names.
 - **Fail:** > 5%
 - **Evidence:** count + total frames + ratio
 
-### A2: No row in the Phase 1 token tables crushes below 32px
+### A2: No row in Phase 1 token tables crushes below 32px
 
 Find frames whose name contains `Color`, `Sizing`, `Typography`, or
 `Anatomy parts`. For each, count direct row children and assert each
@@ -47,7 +55,7 @@ row's `absoluteBoundingBox.height >= 32`.
 - **Evidence:** list of (table, row index, height) for any < 32px row;
   empty list on pass
 
-### A3: Variation matrix renders rows ≥ 40px
+### A3: Variation matrix renders rows >= 40px
 
 Find a frame whose name contains `Variation`. Same height check at
 40px threshold (variation rows are taller than token rows).
@@ -56,7 +64,7 @@ Find a frame whose name contains `Variation`. Same height check at
   which is allowed for fixtures without one)
 - **Fail:** any variation row < 40px
 
-### A4: No token typo regression in any text node
+### A4: No token typo regression
 
 Walk all `TEXT` nodes; concatenate their `characters` field. Search
 for any of:
@@ -80,7 +88,7 @@ the section is present.
 - **Fail:** none
 - **Evidence:** frame name(s) found, or empty
 
-### A8: renderTable invocation rate ≥ 80% (interpreter-named frames)
+### A8: renderTable invocation rate >= 80% (interpreter-named frames)
 
 This assertion measures whether the AI invoked the `renderTable`
 deterministic interpreter (via Bash CLI per
@@ -144,7 +152,7 @@ in `scripts/evals/summarize.js`, NOT in the grader.
 
 ## Checkbox-specific assertions
 
-### A6: Anatomy badges A and B exist as text nodes
+### A6: Anatomy badges A and B exist
 
 Find the Anatomy diagram frame (name contains `Anatomy` and is NOT
 the `Anatomy parts` token table). Inside it, look for TEXT nodes

--- a/plugins/actian-design-system/scripts/evals/grade-locally.js
+++ b/plugins/actian-design-system/scripts/evals/grade-locally.js
@@ -1,0 +1,155 @@
+#!/usr/bin/env node
+"use strict";
+
+// grade-locally.js — programmatic grader for the component-brief eval lane.
+// Replaces the per-run grader subagent with a single Node invocation.
+//
+// Usage:
+//   node grade-locally.js \
+//     --frame-id <file-key>:<node-id> \
+//     --eval-name <checkbox|button> \
+//     --fixture <abs path to brief-data.json> \
+//     --expected-tables <int> \
+//     --out <abs path to output dir>
+//
+// Writes <out>/grading.json in the schema expected by skill-creator's viewer:
+//   { expectations: [{ text, passed, evidence }, ...] }
+//
+// Auth: process.env.FIGMA_PAT (same as figma-rest.js).
+// Cost: ~0 tokens (one REST call); replaces ~100K-token grader subagent.
+
+var fs = require("fs");
+var path = require("path");
+
+var rest = require("../sync/figma-rest.js");
+var A = require("./grading-assertions.js");
+
+function parseArgs(argv) {
+  var out = {};
+  for (var i = 2; i < argv.length; i++) {
+    var arg = argv[i];
+    var m = arg.match(/^--([a-zA-Z0-9-]+)(?:=(.*))?$/);
+    if (!m) continue;
+    var key = m[1];
+    var val = m[2] !== undefined ? m[2] : argv[++i];
+    out[key] = val;
+  }
+  return out;
+}
+
+function fail(msg) {
+  process.stderr.write("grade-locally: " + msg + "\n");
+  process.exit(1);
+}
+
+function splitFrameId(frameId) {
+  // FRAME_NODE_ID format is `<file-key>:<node-id>` where node-id itself
+  // contains colons (e.g. "1357:124"). Split only on the FIRST colon.
+  var firstColon = frameId.indexOf(":");
+  if (firstColon < 0) return null;
+  return {
+    fileKey: frameId.slice(0, firstColon),
+    nodeId: frameId.slice(firstColon + 1),
+  };
+}
+
+function loadFixtureVariantCount(fixturePath) {
+  var raw = fs.readFileSync(fixturePath, "utf8");
+  var parsed = JSON.parse(raw);
+  if (parsed.card_variation && Array.isArray(parsed.card_variation.variants)) {
+    return parsed.card_variation.variants.length;
+  }
+  return null;
+}
+
+async function main() {
+  var args = parseArgs(process.argv);
+  var frameId = args["frame-id"];
+  var evalName = args["eval-name"];
+  var fixturePath = args["fixture"];
+  var expectedTables = args["expected-tables"]
+    ? parseInt(args["expected-tables"], 10)
+    : null;
+  var outDir = args["out"];
+
+  if (!frameId) fail("--frame-id required");
+  if (!evalName) fail("--eval-name required (checkbox|button)");
+  if (!fixturePath) fail("--fixture required");
+  if (expectedTables === null) fail("--expected-tables required");
+  if (!outDir) fail("--out required");
+
+  var split = splitFrameId(frameId);
+  if (!split) fail("--frame-id must be <file-key>:<node-id>");
+
+  var resp = await rest.getNode(split.fileKey, split.nodeId);
+  var nodeEntry = resp.nodes && resp.nodes[split.nodeId];
+  if (!nodeEntry || !nodeEntry.document) {
+    fail("Figma REST returned no document for node " + split.nodeId);
+  }
+  var doc = nodeEntry.document;
+
+  var variantCount = loadFixtureVariantCount(fixturePath);
+
+  var expectations = [];
+  expectations.push(
+    wrap(
+      "A1: Frame names contain real component-part names",
+      A.a1GenericFrameRatio(doc),
+    ),
+  );
+  expectations.push(
+    wrap(
+      "A2: No row in Phase 1 token tables crushes below 32px",
+      A.a2TokenTableRowHeights(doc),
+    ),
+  );
+  expectations.push(
+    wrap(
+      "A3: Variation matrix renders rows >= 40px",
+      A.a3VariationRowHeights(doc),
+    ),
+  );
+  expectations.push(wrap("A4: No token typo regression", A.a4TokenTypos(doc)));
+  expectations.push(wrap("A5: Specs sub-frame exists", A.a5SpecsSubFrame(doc)));
+
+  if (evalName === "checkbox") {
+    expectations.push(
+      wrap("A6: Anatomy badges A and B exist", A.a6AnatomyBadges(doc)),
+    );
+  } else if (evalName === "button") {
+    if (variantCount === null) {
+      fail("button fixture missing card_variation.variants for A7");
+    }
+    expectations.push(
+      wrap(
+        "A7: Variation matrix row count matches fixture",
+        A.a7VariationRowCount(doc, { variantCount: variantCount }),
+      ),
+    );
+  }
+
+  expectations.push(
+    wrap(
+      "A8: renderTable invocation rate >= 80% (interpreter-named frames)",
+      A.a8RenderTableAdoption(doc, {
+        expectedRenderTablesCount: expectedTables,
+      }),
+    ),
+  );
+
+  fs.mkdirSync(outDir, { recursive: true });
+  var outPath = path.join(outDir, "grading.json");
+  fs.writeFileSync(
+    outPath,
+    JSON.stringify({ expectations: expectations }, null, 2) + "\n",
+  );
+  process.stdout.write("wrote " + outPath + "\n");
+}
+
+function wrap(text, result) {
+  return { text: text, passed: result.passed, evidence: result.evidence };
+}
+
+main().catch(function (err) {
+  fail((err && err.stack) || String(err));
+});

--- a/plugins/actian-design-system/scripts/evals/grading-assertions.js
+++ b/plugins/actian-design-system/scripts/evals/grading-assertions.js
@@ -1,0 +1,296 @@
+"use strict";
+
+// Pure assertion functions for the component-brief eval lane.
+// Each function takes a `document` node (the top-level FRAME from a
+// Figma /v1/files/.../nodes?ids=<id> response) and returns
+// { passed: boolean, evidence: string }. No I/O, no side effects.
+//
+// The CLI in grade-locally.js wraps these into the grading.json schema
+// expected by skill-creator's viewer ({expectations: [{text, passed,
+// evidence}]}). Tests live in tests/evals/grading-assertions.test.js
+// and exercise pure-function behavior with synthetic metadata fixtures.
+
+function walkFrames(node, visit) {
+  if (!node) return;
+  if (node.type === "FRAME") visit(node);
+  if (Array.isArray(node.children)) {
+    node.children.forEach(function (c) {
+      walkFrames(c, visit);
+    });
+  }
+}
+
+function a1GenericFrameRatio(document) {
+  var total = 0;
+  var generic = 0;
+  walkFrames(document, function (frame) {
+    total++;
+    if (frame.name === "Frame") generic++;
+  });
+  if (total === 0) {
+    return {
+      passed: true,
+      evidence: "no FRAME nodes in tree (vacuously passes)",
+    };
+  }
+  var ratio = generic / total;
+  var pct = (ratio * 100).toFixed(1);
+  var passed = ratio <= 0.05;
+  return {
+    passed: passed,
+    evidence:
+      generic + " of " + total + " frames named literally 'Frame' (" + pct + "%)",
+  };
+}
+
+var TOKEN_TABLE_NAME_TOKENS = ["Color", "Sizing", "Typography", "Anatomy parts"];
+
+function isTokenTable(name) {
+  if (typeof name !== "string") return false;
+  for (var i = 0; i < TOKEN_TABLE_NAME_TOKENS.length; i++) {
+    if (name.indexOf(TOKEN_TABLE_NAME_TOKENS[i]) >= 0) return true;
+  }
+  return false;
+}
+
+function a2TokenTableRowHeights(document) {
+  var violations = [];
+  walkFrames(document, function (frame) {
+    if (!isTokenTable(frame.name)) return;
+    var rows = Array.isArray(frame.children) ? frame.children : [];
+    rows.forEach(function (row, idx) {
+      var h = row.absoluteBoundingBox ? row.absoluteBoundingBox.height : null;
+      if (h !== null && h < 32) {
+        violations.push({
+          table: frame.name,
+          rowIndex: idx,
+          rowName: row.name,
+          height: h,
+        });
+      }
+    });
+  });
+  if (violations.length === 0) {
+    return {
+      passed: true,
+      evidence: "every row in every Phase 1 token table ≥ 32px",
+    };
+  }
+  return {
+    passed: false,
+    evidence:
+      "rows < 32px: " +
+      violations
+        .map(function (v) {
+          return v.table + "[" + v.rowIndex + "] (" + v.rowName + ", h=" + v.height + ")";
+        })
+        .join("; "),
+  };
+}
+
+function a3VariationRowHeights(document) {
+  var violations = [];
+  var found = false;
+  walkFrames(document, function (frame) {
+    if (typeof frame.name !== "string" || frame.name.indexOf("Variation") < 0) return;
+    found = true;
+    var rows = Array.isArray(frame.children) ? frame.children : [];
+    rows.forEach(function (row, idx) {
+      var h = row.absoluteBoundingBox ? row.absoluteBoundingBox.height : null;
+      if (h !== null && h < 40) {
+        violations.push({
+          frame: frame.name,
+          rowIndex: idx,
+          rowName: row.name,
+          height: h,
+        });
+      }
+    });
+  });
+  if (!found) {
+    return {
+      passed: true,
+      evidence: "no Variation frame in tree (allowed for fixtures without one)",
+    };
+  }
+  if (violations.length === 0) {
+    return { passed: true, evidence: "every variation row ≥ 40px" };
+  }
+  return {
+    passed: false,
+    evidence:
+      "variation rows < 40px: " +
+      violations
+        .map(function (v) {
+          return v.frame + "[" + v.rowIndex + "] (" + v.rowName + ", h=" + v.height + ")";
+        })
+        .join("; "),
+  };
+}
+
+var BANNED_TOKEN_SUBSTRINGS = ["--zen-font-body-stardard", "--zen-color-them"];
+
+function walkText(node, visit) {
+  if (!node) return;
+  if (node.type === "TEXT" && typeof node.characters === "string") {
+    visit(node);
+  }
+  if (Array.isArray(node.children)) {
+    node.children.forEach(function (c) {
+      walkText(c, visit);
+    });
+  }
+}
+
+function a4TokenTypos(document) {
+  var matches = [];
+  walkText(document, function (text) {
+    BANNED_TOKEN_SUBSTRINGS.forEach(function (banned) {
+      if (text.characters.indexOf(banned) >= 0) {
+        matches.push({ id: text.id, banned: banned });
+      }
+    });
+  });
+  if (matches.length === 0) {
+    return { passed: true, evidence: "no banned token typos in any TEXT node" };
+  }
+  return {
+    passed: false,
+    evidence:
+      "banned token strings found: " +
+      matches.map(function (m) {
+        return m.banned + " in " + m.id;
+      }).join("; "),
+  };
+}
+
+function a5SpecsSubFrame(document) {
+  var hits = [];
+  walkFrames(document, function (frame) {
+    if (typeof frame.name === "string" && frame.name.indexOf("Specs") >= 0) {
+      hits.push(frame.name);
+    }
+  });
+  if (hits.length === 0) {
+    return { passed: false, evidence: "no frame name contains 'Specs'" };
+  }
+  return {
+    passed: true,
+    evidence: "Specs frame(s) found: " + hits.join(", "),
+  };
+}
+
+function a6AnatomyBadges(document) {
+  var anatomyDiagram = null;
+  walkFrames(document, function (frame) {
+    if (anatomyDiagram) return;
+    if (typeof frame.name !== "string") return;
+    // Per grader.md: name contains "Anatomy" but is NOT the "Anatomy parts"
+    // token table.
+    if (frame.name.indexOf("Anatomy") < 0) return;
+    if (frame.name.indexOf("Anatomy parts") >= 0) return;
+    anatomyDiagram = frame;
+  });
+  if (!anatomyDiagram) {
+    return { passed: false, evidence: "no Anatomy diagram frame found" };
+  }
+  var foundA = false;
+  var foundB = false;
+  walkText(anatomyDiagram, function (text) {
+    if (text.characters === "A") foundA = true;
+    if (text.characters === "B") foundB = true;
+  });
+  if (foundA && foundB) {
+    return { passed: true, evidence: "both A and B badge TEXT nodes found" };
+  }
+  return {
+    passed: false,
+    evidence:
+      "badges found: A=" + (foundA ? "yes" : "no") + ", B=" + (foundB ? "yes" : "no"),
+  };
+}
+
+function a7VariationRowCount(document, ctx) {
+  var variantCount = ctx && ctx.variantCount;
+  if (typeof variantCount !== "number") {
+    return {
+      passed: false,
+      evidence: "ctx.variantCount missing — pass the fixture's card_variation.variants.length",
+    };
+  }
+  var variationFrame = null;
+  walkFrames(document, function (frame) {
+    if (variationFrame) return;
+    if (typeof frame.name === "string" && frame.name.indexOf("Variation") >= 0) {
+      variationFrame = frame;
+    }
+  });
+  if (!variationFrame) {
+    return { passed: false, evidence: "no Variation frame found" };
+  }
+  var rowChildren = Array.isArray(variationFrame.children)
+    ? variationFrame.children
+    : [];
+  var figmaCount = rowChildren.length;
+  // grader.md tolerates ±1 (header rows may be excluded)
+  var diff = Math.abs(figmaCount - variantCount);
+  if (diff <= 1) {
+    return {
+      passed: true,
+      evidence:
+        "fixture variants: " + variantCount + ", Figma rows: " + figmaCount + " (within ±1)",
+    };
+  }
+  return {
+    passed: false,
+    evidence:
+      "fixture variants: " + variantCount + ", Figma rows: " + figmaCount + " (diff " + diff + ")",
+  };
+}
+
+function a8RenderTableAdoption(document, ctx) {
+  var expected = ctx && ctx.expectedRenderTablesCount;
+  if (typeof expected !== "number") {
+    return {
+      passed: false,
+      evidence:
+        "ctx.expectedRenderTablesCount missing — pass evals.json's expected_render_tables_count",
+    };
+  }
+  var tablesViaInterpreter = 0;
+  var tokenPillFrames = 0;
+  var namedTableFrames = [];
+  walkFrames(document, function (frame) {
+    if (frame.name === "Table (renderTable)") {
+      tablesViaInterpreter++;
+      namedTableFrames.push(frame.name);
+    }
+    if (typeof frame.name === "string" && frame.name.indexOf("Token: --zen-") === 0) {
+      tokenPillFrames++;
+    }
+  });
+  var adoptionRate = expected === 0 ? 0 : tablesViaInterpreter / expected;
+  var passed = adoptionRate >= 0.8;
+  var evidence = JSON.stringify({
+    tables_via_interpreter: tablesViaInterpreter,
+    expected_render_tables_count: expected,
+    adoption_rate: Number(adoptionRate.toFixed(2)),
+    token_pill_frames: tokenPillFrames,
+    named_table_frames: namedTableFrames,
+  });
+  return { passed: passed, evidence: evidence };
+}
+
+module.exports = {
+  walkFrames: walkFrames,
+  walkText: walkText,
+  isTokenTable: isTokenTable,
+  a1GenericFrameRatio: a1GenericFrameRatio,
+  a2TokenTableRowHeights: a2TokenTableRowHeights,
+  a3VariationRowHeights: a3VariationRowHeights,
+  a4TokenTypos: a4TokenTypos,
+  a5SpecsSubFrame: a5SpecsSubFrame,
+  a6AnatomyBadges: a6AnatomyBadges,
+  a7VariationRowCount: a7VariationRowCount,
+  a8RenderTableAdoption: a8RenderTableAdoption,
+};

--- a/plugins/actian-design-system/scripts/evals/run-component-brief.sh
+++ b/plugins/actian-design-system/scripts/evals/run-component-brief.sh
@@ -24,8 +24,10 @@ WORKSPACE_DIR="$EVALS_DIR/workspace"
 usage() {
   cat <<'USAGE'
 Usage:
-  run-component-brief.sh plan [--runs N]   # print run plan + subagent prompts
-                                           # (N defaults to 1; use 3 for variance-aware)
+  run-component-brief.sh plan [--runs N] [--grader local|subagent]
+                                          # N defaults to 1; grader defaults to local
+                                          # local = run scripts/evals/grade-locally.js
+                                          # subagent = dispatch grader subagents (legacy)
   run-component-brief.sh summarize <iter>  # per-assertion pass-rate summary
 USAGE
 }
@@ -44,6 +46,25 @@ $EVALS_DIR/evals.json eval id=$eval_id ("$eval_name") and execute the
 prompt exactly. Save outputs to $out_dir/outputs/. End your final
 response with FRAME_NODE_ID=<file-key>:<node-id> as the LAST line.
 PROMPT
+  echo
+}
+
+# emit_grader_local_command <fixture> <eval_name> <expected_tables> <run_n> <runs_total> <out_dir>
+emit_grader_local_command() {
+  local fixture="$1" eval_name="$2" expected_tables="$3" run_n="$4" runs_total="$5" out_dir="$6"
+  local fixture_capitalized
+  fixture_capitalized="$(echo "${fixture:0:1}" | tr '[:lower:]' '[:upper:]')${fixture:1}"
+  echo "===== Grade $fixture_capitalized (run $run_n/$runs_total) ====="
+  cat <<CMD
+# After with-skill subagent run $run_n returns FRAME_NODE_ID=<file-key>:<node-id>,
+# substitute it into the command below and run it (NO subagent dispatch).
+source "\$CLAUDE_PLUGIN_ROOT/scripts/lib/resolve-node.sh" && "\$NODE_BIN" $PLUGIN_ROOT/scripts/evals/grade-locally.js \\
+  --frame-id=<paste-FRAME_NODE_ID-here> \\
+  --eval-name=$fixture \\
+  --fixture=$EVALS_DIR/fixtures/$fixture-brief-data.json \\
+  --expected-tables=$expected_tables \\
+  --out=$out_dir
+CMD
   echo
 }
 
@@ -67,6 +88,7 @@ cmd="${1:-}"; shift || true
 case "$cmd" in
   plan)
     runs=1
+    grader="local"
     while [ "${1:-}" != "" ]; do
       case "$1" in
         --runs)
@@ -75,6 +97,14 @@ case "$cmd" in
           ;;
         --runs=*)
           runs="${1#--runs=}"
+          shift
+          ;;
+        --grader)
+          grader="${2:?--grader requires a value}"
+          shift 2
+          ;;
+        --grader=*)
+          grader="${1#--grader=}"
           shift
           ;;
         *)
@@ -86,6 +116,10 @@ case "$cmd" in
     done
     if ! [[ "$runs" =~ ^[1-9][0-9]*$ ]]; then
       echo "--runs must be a positive integer (got: $runs)" >&2
+      exit 1
+    fi
+    if [[ "$grader" != "local" && "$grader" != "subagent" ]]; then
+      echo "--grader must be 'local' or 'subagent' (got: $grader)" >&2
       exit 1
     fi
 
@@ -112,16 +146,28 @@ case "$cmd" in
       done
     done
 
-    echo "After ALL with-skill subagents return FRAME_NODE_ID values, dispatch graders:"
+    echo "After ALL with-skill subagents return FRAME_NODE_ID values:"
     echo
-    echo "--- grader subagents ($((runs * 2)) total) ---"
-    echo
-    for fixture in checkbox button; do
-      for n in $(seq 1 "$runs"); do
-        out_dir="$iter_dir/eval-$fixture/run-$n/with_skill"
-        emit_grader_prompt "$fixture" "$n" "$runs" "$out_dir"
+    if [[ "$grader" == "local" ]]; then
+      echo "--- local grader commands ($((runs * 2)) total) ---"
+      echo
+      for fixture in checkbox button; do
+        # expected_render_tables_count is 4 for both fixtures (per evals.json)
+        for n in $(seq 1 "$runs"); do
+          out_dir="$iter_dir/eval-$fixture/run-$n/with_skill"
+          emit_grader_local_command "$fixture" "$fixture" 4 "$n" "$runs" "$out_dir"
+        done
       done
-    done
+    else
+      echo "--- grader subagents ($((runs * 2)) total) ---"
+      echo
+      for fixture in checkbox button; do
+        for n in $(seq 1 "$runs"); do
+          out_dir="$iter_dir/eval-$fixture/run-$n/with_skill"
+          emit_grader_prompt "$fixture" "$n" "$runs" "$out_dir"
+        done
+      done
+    fi
 
     echo "Then run: $0 summarize $iter"
     ;;

--- a/plugins/actian-design-system/scripts/renderers/figma-table/render-figma.js
+++ b/plugins/actian-design-system/scripts/renderers/figma-table/render-figma.js
@@ -773,6 +773,7 @@ function emitColorSwatchCell(lines, cellVar, parentVar, cell) {
   // which would require an importComponentSetByKeyAsync call we control internally).
   var dotVar = cellVar + "_dot";
   lines.push("var " + dotVar + " = figma.createFrame();");
+  lines.push(dotVar + '.name = "Swatch dot";');
   lines.push(dotVar + ".resize(12, 12);");
   lines.push(dotVar + ".cornerRadius = 6;");
   lines.push(
@@ -790,6 +791,7 @@ function emitColorSwatchCell(lines, cellVar, parentVar, cell) {
   // Text stack
   var stackVar = cellVar + "_stack";
   lines.push("var " + stackVar + " = figma.createFrame();");
+  lines.push(stackVar + '.name = "Swatch stack";');
   lines.push(stackVar + ".fills = [];");
   lines.push(stackVar + '.layoutMode = "VERTICAL";');
   lines.push(stackVar + ".itemSpacing = 2;");
@@ -801,6 +803,9 @@ function emitColorSwatchCell(lines, cellVar, parentVar, cell) {
   if (cell.tokenName) {
     var pillVar = cellVar + "_pill";
     lines.push("var " + pillVar + " = figma.createFrame();");
+    lines.push(
+      pillVar + '.name = "Token: " + ' + jsString(cell.tokenName) + ";",
+    );
     lines.push(pillVar + '.layoutMode = "HORIZONTAL";');
     lines.push(pillVar + '.primaryAxisSizingMode = "AUTO";');
     lines.push(pillVar + '.counterAxisSizingMode = "AUTO";');

--- a/plugins/actian-design-system/tests/evals/fixtures/button-passing.json
+++ b/plugins/actian-design-system/tests/evals/fixtures/button-passing.json
@@ -1,0 +1,74 @@
+{
+  "nodes": {
+    "FaBwMaNkvdrcQIo3fl8I4D:1411:1": {
+      "document": {
+        "id": "1411:1",
+        "name": "Component brief — Button",
+        "type": "FRAME",
+        "absoluteBoundingBox": { "x": 0, "y": 0, "width": 1200, "height": 6000 },
+        "children": [
+          {
+            "id": "1411:25",
+            "name": "Specs sub-frame",
+            "type": "FRAME",
+            "absoluteBoundingBox": { "x": 80, "y": 5149, "width": 1108, "height": 255 },
+            "children": []
+          },
+          {
+            "id": "1411:40",
+            "name": "Variation matrix — Button",
+            "type": "FRAME",
+            "absoluteBoundingBox": { "x": 80, "y": 700, "width": 800, "height": 280 },
+            "children": [
+              { "id": "1411:41", "name": "Primary row", "type": "FRAME", "absoluteBoundingBox": { "x": 0, "y": 0, "width": 800, "height": 40 }, "children": [] },
+              { "id": "1411:42", "name": "Secondary row", "type": "FRAME", "absoluteBoundingBox": { "x": 0, "y": 0, "width": 800, "height": 40 }, "children": [] },
+              { "id": "1411:43", "name": "Tertiary row", "type": "FRAME", "absoluteBoundingBox": { "x": 0, "y": 0, "width": 800, "height": 40 }, "children": [] },
+              { "id": "1411:44", "name": "Ghost row", "type": "FRAME", "absoluteBoundingBox": { "x": 0, "y": 0, "width": 800, "height": 40 }, "children": [] },
+              { "id": "1411:45", "name": "Danger row", "type": "FRAME", "absoluteBoundingBox": { "x": 0, "y": 0, "width": 800, "height": 40 }, "children": [] },
+              { "id": "1411:46", "name": "Link row", "type": "FRAME", "absoluteBoundingBox": { "x": 0, "y": 0, "width": 800, "height": 40 }, "children": [] }
+            ]
+          },
+          {
+            "id": "1411:50",
+            "name": "Table (renderTable)",
+            "type": "FRAME",
+            "absoluteBoundingBox": { "x": 80, "y": 900, "width": 800, "height": 200 },
+            "children": [
+              { "id": "1411:51", "name": "Header row", "type": "FRAME", "absoluteBoundingBox": { "x": 0, "y": 0, "width": 800, "height": 32 }, "children": [] }
+            ]
+          },
+          {
+            "id": "1411:60",
+            "name": "Table (renderTable)",
+            "type": "FRAME",
+            "absoluteBoundingBox": { "x": 80, "y": 1100, "width": 800, "height": 200 },
+            "children": [
+              { "id": "1411:61", "name": "Header row", "type": "FRAME", "absoluteBoundingBox": { "x": 0, "y": 0, "width": 800, "height": 32 }, "children": [] }
+            ]
+          },
+          {
+            "id": "1411:70",
+            "name": "Table (renderTable)",
+            "type": "FRAME",
+            "absoluteBoundingBox": { "x": 80, "y": 1300, "width": 800, "height": 200 },
+            "children": [
+              { "id": "1411:71", "name": "Header row", "type": "FRAME", "absoluteBoundingBox": { "x": 0, "y": 0, "width": 800, "height": 32 }, "children": [] }
+            ]
+          },
+          {
+            "id": "1411:80",
+            "name": "Table (renderTable)",
+            "type": "FRAME",
+            "absoluteBoundingBox": { "x": 80, "y": 1500, "width": 800, "height": 200 },
+            "children": [
+              { "id": "1411:81", "name": "Header row", "type": "FRAME", "absoluteBoundingBox": { "x": 0, "y": 0, "width": 800, "height": 32 }, "children": [] }
+            ]
+          }
+        ]
+      },
+      "components": {},
+      "schemaVersion": 0,
+      "styles": {}
+    }
+  }
+}

--- a/plugins/actian-design-system/tests/evals/fixtures/checkbox-failing.json
+++ b/plugins/actian-design-system/tests/evals/fixtures/checkbox-failing.json
@@ -1,0 +1,71 @@
+{
+  "nodes": {
+    "FaBwMaNkvdrcQIo3fl8I4D:9999:1": {
+      "document": {
+        "id": "9999:1",
+        "name": "Component brief — Broken Checkbox",
+        "type": "FRAME",
+        "absoluteBoundingBox": { "x": 0, "y": 0, "width": 1200, "height": 6000 },
+        "children": [
+          { "id": "9999:2", "name": "Frame", "type": "FRAME", "absoluteBoundingBox": { "x": 0, "y": 0, "width": 100, "height": 100 }, "children": [] },
+          { "id": "9999:3", "name": "Frame", "type": "FRAME", "absoluteBoundingBox": { "x": 0, "y": 0, "width": 100, "height": 100 }, "children": [] },
+          { "id": "9999:4", "name": "Frame", "type": "FRAME", "absoluteBoundingBox": { "x": 0, "y": 0, "width": 100, "height": 100 }, "children": [] },
+          { "id": "9999:5", "name": "Frame", "type": "FRAME", "absoluteBoundingBox": { "x": 0, "y": 0, "width": 100, "height": 100 }, "children": [] },
+          {
+            "id": "9999:10",
+            "name": "Color tokens",
+            "type": "FRAME",
+            "absoluteBoundingBox": { "x": 0, "y": 0, "width": 800, "height": 200 },
+            "children": [
+              { "id": "9999:11", "name": "Crushed row", "type": "FRAME", "absoluteBoundingBox": { "x": 0, "y": 0, "width": 800, "height": 20 }, "children": [] }
+            ]
+          },
+          {
+            "id": "9999:20",
+            "name": "Variation matrix — Broken",
+            "type": "FRAME",
+            "absoluteBoundingBox": { "x": 0, "y": 0, "width": 800, "height": 100 },
+            "children": [
+              { "id": "9999:21", "name": "Crushed variation row", "type": "FRAME", "absoluteBoundingBox": { "x": 0, "y": 0, "width": 800, "height": 28 }, "children": [] }
+            ]
+          },
+          {
+            "id": "9999:30",
+            "name": "Anatomy diagram",
+            "type": "FRAME",
+            "absoluteBoundingBox": { "x": 0, "y": 0, "width": 600, "height": 400 },
+            "children": [
+              { "id": "9999:31", "name": "Anatomy badge text A", "type": "TEXT", "characters": "A", "absoluteBoundingBox": { "x": 0, "y": 0, "width": 12, "height": 12 } }
+            ]
+          },
+          {
+            "id": "9999:40",
+            "name": "Token typo holder",
+            "type": "FRAME",
+            "absoluteBoundingBox": { "x": 0, "y": 0, "width": 200, "height": 50 },
+            "children": [
+              { "id": "9999:41", "name": "Token text", "type": "TEXT", "characters": "--zen-font-body-stardard", "absoluteBoundingBox": { "x": 0, "y": 0, "width": 100, "height": 14 } }
+            ]
+          },
+          {
+            "id": "9999:50",
+            "name": "Table (renderTable)",
+            "type": "FRAME",
+            "absoluteBoundingBox": { "x": 0, "y": 0, "width": 800, "height": 200 },
+            "children": []
+          },
+          {
+            "id": "9999:60",
+            "name": "Table (renderTable)",
+            "type": "FRAME",
+            "absoluteBoundingBox": { "x": 0, "y": 0, "width": 800, "height": 200 },
+            "children": []
+          }
+        ]
+      },
+      "components": {},
+      "schemaVersion": 0,
+      "styles": {}
+    }
+  }
+}

--- a/plugins/actian-design-system/tests/evals/fixtures/checkbox-passing.json
+++ b/plugins/actian-design-system/tests/evals/fixtures/checkbox-passing.json
@@ -1,0 +1,332 @@
+{
+  "nodes": {
+    "FaBwMaNkvdrcQIo3fl8I4D:1311:1": {
+      "document": {
+        "id": "1311:1",
+        "name": "Component brief — Checkbox",
+        "type": "FRAME",
+        "absoluteBoundingBox": {
+          "x": 0,
+          "y": 0,
+          "width": 1200,
+          "height": 6000
+        },
+        "children": [
+          {
+            "id": "1311:25",
+            "name": "Specs sub-frame",
+            "type": "FRAME",
+            "absoluteBoundingBox": {
+              "x": 80,
+              "y": 5149,
+              "width": 1108,
+              "height": 255
+            },
+            "children": []
+          },
+          {
+            "id": "1311:30",
+            "name": "Anatomy diagram",
+            "type": "FRAME",
+            "absoluteBoundingBox": {
+              "x": 80,
+              "y": 200,
+              "width": 600,
+              "height": 400
+            },
+            "children": [
+              {
+                "id": "1311:31",
+                "name": "Anatomy badge text A",
+                "type": "TEXT",
+                "characters": "A",
+                "absoluteBoundingBox": {
+                  "x": 0,
+                  "y": 0,
+                  "width": 12,
+                  "height": 12
+                }
+              },
+              {
+                "id": "1311:32",
+                "name": "Anatomy badge text B",
+                "type": "TEXT",
+                "characters": "B",
+                "absoluteBoundingBox": {
+                  "x": 0,
+                  "y": 0,
+                  "width": 12,
+                  "height": 12
+                }
+              }
+            ]
+          },
+          {
+            "id": "1311:40",
+            "name": "Variation matrix — Checkbox 3 selected x 5 states",
+            "type": "FRAME",
+            "absoluteBoundingBox": {
+              "x": 80,
+              "y": 700,
+              "width": 800,
+              "height": 200
+            },
+            "children": [
+              {
+                "id": "1311:41",
+                "name": "Header row",
+                "type": "FRAME",
+                "absoluteBoundingBox": {
+                  "x": 0,
+                  "y": 0,
+                  "width": 800,
+                  "height": 40
+                },
+                "children": []
+              },
+              {
+                "id": "1311:42",
+                "name": "Selected=No row",
+                "type": "FRAME",
+                "absoluteBoundingBox": {
+                  "x": 0,
+                  "y": 0,
+                  "width": 800,
+                  "height": 40
+                },
+                "children": []
+              },
+              {
+                "id": "1311:43",
+                "name": "Selected=Yes row",
+                "type": "FRAME",
+                "absoluteBoundingBox": {
+                  "x": 0,
+                  "y": 0,
+                  "width": 800,
+                  "height": 40
+                },
+                "children": []
+              },
+              {
+                "id": "1311:44",
+                "name": "Selected=Indeterminate row",
+                "type": "FRAME",
+                "absoluteBoundingBox": {
+                  "x": 0,
+                  "y": 0,
+                  "width": 800,
+                  "height": 40
+                },
+                "children": []
+              }
+            ]
+          },
+          {
+            "id": "1311:90",
+            "name": "Color tokens",
+            "type": "FRAME",
+            "absoluteBoundingBox": {
+              "x": 80,
+              "y": 1700,
+              "width": 800,
+              "height": 200
+            },
+            "children": [
+              {
+                "id": "1311:91",
+                "name": "Color row 1",
+                "type": "FRAME",
+                "absoluteBoundingBox": {
+                  "x": 0,
+                  "y": 0,
+                  "width": 800,
+                  "height": 36
+                },
+                "children": []
+              },
+              {
+                "id": "1311:92",
+                "name": "Color row 2",
+                "type": "FRAME",
+                "absoluteBoundingBox": {
+                  "x": 0,
+                  "y": 0,
+                  "width": 800,
+                  "height": 40
+                },
+                "children": []
+              }
+            ]
+          },
+          {
+            "id": "1311:50",
+            "name": "Table (renderTable)",
+            "type": "FRAME",
+            "absoluteBoundingBox": {
+              "x": 80,
+              "y": 900,
+              "width": 800,
+              "height": 200
+            },
+            "children": [
+              {
+                "id": "1311:51",
+                "name": "Header row",
+                "type": "FRAME",
+                "absoluteBoundingBox": {
+                  "x": 0,
+                  "y": 0,
+                  "width": 800,
+                  "height": 32
+                },
+                "children": []
+              },
+              {
+                "id": "1311:52",
+                "name": "Data row",
+                "type": "FRAME",
+                "absoluteBoundingBox": {
+                  "x": 0,
+                  "y": 0,
+                  "width": 800,
+                  "height": 36
+                },
+                "children": [
+                  {
+                    "id": "1311:53",
+                    "name": "Cell — token-pill",
+                    "type": "FRAME",
+                    "absoluteBoundingBox": {
+                      "x": 0,
+                      "y": 0,
+                      "width": 200,
+                      "height": 36
+                    },
+                    "children": [
+                      {
+                        "id": "1311:54",
+                        "name": "Token: --zen-spacing-lg",
+                        "type": "FRAME",
+                        "absoluteBoundingBox": {
+                          "x": 0,
+                          "y": 0,
+                          "width": 100,
+                          "height": 20
+                        },
+                        "children": [
+                          {
+                            "id": "1311:55",
+                            "name": "Token text",
+                            "type": "TEXT",
+                            "characters": "--zen-spacing-lg",
+                            "absoluteBoundingBox": {
+                              "x": 0,
+                              "y": 0,
+                              "width": 100,
+                              "height": 14
+                            }
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "id": "1311:60",
+            "name": "Table (renderTable)",
+            "type": "FRAME",
+            "absoluteBoundingBox": {
+              "x": 80,
+              "y": 1100,
+              "width": 800,
+              "height": 200
+            },
+            "children": [
+              {
+                "id": "1311:61",
+                "name": "Header row",
+                "type": "FRAME",
+                "absoluteBoundingBox": {
+                  "x": 0,
+                  "y": 0,
+                  "width": 800,
+                  "height": 32
+                },
+                "children": []
+              },
+              {
+                "id": "1311:62",
+                "name": "Data row",
+                "type": "FRAME",
+                "absoluteBoundingBox": {
+                  "x": 0,
+                  "y": 0,
+                  "width": 800,
+                  "height": 36
+                },
+                "children": []
+              }
+            ]
+          },
+          {
+            "id": "1311:70",
+            "name": "Table (renderTable)",
+            "type": "FRAME",
+            "absoluteBoundingBox": {
+              "x": 80,
+              "y": 1300,
+              "width": 800,
+              "height": 200
+            },
+            "children": [
+              {
+                "id": "1311:71",
+                "name": "Header row",
+                "type": "FRAME",
+                "absoluteBoundingBox": {
+                  "x": 0,
+                  "y": 0,
+                  "width": 800,
+                  "height": 32
+                },
+                "children": []
+              }
+            ]
+          },
+          {
+            "id": "1311:80",
+            "name": "Table (renderTable)",
+            "type": "FRAME",
+            "absoluteBoundingBox": {
+              "x": 80,
+              "y": 1500,
+              "width": 800,
+              "height": 200
+            },
+            "children": [
+              {
+                "id": "1311:81",
+                "name": "Header row",
+                "type": "FRAME",
+                "absoluteBoundingBox": {
+                  "x": 0,
+                  "y": 0,
+                  "width": 800,
+                  "height": 32
+                },
+                "children": []
+              }
+            ]
+          }
+        ]
+      },
+      "components": {},
+      "schemaVersion": 0,
+      "styles": {}
+    }
+  }
+}

--- a/plugins/actian-design-system/tests/evals/grading-assertions.test.js
+++ b/plugins/actian-design-system/tests/evals/grading-assertions.test.js
@@ -1,0 +1,182 @@
+"use strict";
+
+var { describe, it } = require("node:test");
+var assert = require("node:assert");
+var path = require("path");
+var fs = require("fs");
+
+var assertions = require("../../scripts/evals/grading-assertions.js");
+
+var FIXTURES = path.join(__dirname, "fixtures");
+
+function loadFixture(name) {
+  var raw = fs.readFileSync(path.join(FIXTURES, name + ".json"), "utf8");
+  var parsed = JSON.parse(raw);
+  // Helper: return the single document node for the only key in `nodes`.
+  var ids = Object.keys(parsed.nodes);
+  assert.strictEqual(ids.length, 1, "fixture must have exactly one node entry");
+  return parsed.nodes[ids[0]].document;
+}
+
+describe("A1: generic-Frame ratio", function () {
+  it("passes when ≤5% of frames are named literally 'Frame'", function () {
+    var doc = loadFixture("checkbox-passing");
+    var result = assertions.a1GenericFrameRatio(doc);
+    assert.strictEqual(result.passed, true, result.evidence);
+  });
+
+  it("fails when >5% of frames are named literally 'Frame'", function () {
+    var doc = loadFixture("checkbox-failing");
+    var result = assertions.a1GenericFrameRatio(doc);
+    assert.strictEqual(result.passed, false, result.evidence);
+  });
+});
+
+describe("A2: token-table row heights ≥ 32", function () {
+  it("passes when all rows in tables named Color/Sizing/Typography/Anatomy parts ≥ 32px", function () {
+    var doc = loadFixture("checkbox-passing");
+    var result = assertions.a2TokenTableRowHeights(doc);
+    assert.strictEqual(result.passed, true, result.evidence);
+  });
+
+  it("fails when any row in those tables is < 32px", function () {
+    var doc = loadFixture("checkbox-failing");
+    var result = assertions.a2TokenTableRowHeights(doc);
+    assert.strictEqual(result.passed, false, result.evidence);
+  });
+});
+
+describe("A3: variation matrix row heights ≥ 40", function () {
+  it("passes when all variation rows ≥ 40px", function () {
+    var doc = loadFixture("checkbox-passing");
+    var result = assertions.a3VariationRowHeights(doc);
+    assert.strictEqual(result.passed, true, result.evidence);
+  });
+
+  it("fails when any variation row < 40px", function () {
+    var doc = loadFixture("checkbox-failing");
+    var result = assertions.a3VariationRowHeights(doc);
+    assert.strictEqual(result.passed, false, result.evidence);
+  });
+
+  it("passes vacuously when no Variation frame exists", function () {
+    var doc = { id: "0:1", name: "Empty", type: "FRAME", children: [] };
+    var result = assertions.a3VariationRowHeights(doc);
+    assert.strictEqual(result.passed, true);
+  });
+});
+
+describe("A4: token typo regression", function () {
+  it("passes when no banned token typos appear in any TEXT node", function () {
+    var doc = loadFixture("checkbox-passing");
+    var result = assertions.a4TokenTypos(doc);
+    assert.strictEqual(result.passed, true, result.evidence);
+  });
+
+  it("fails when a TEXT node contains --zen-font-body-stardard", function () {
+    var doc = loadFixture("checkbox-failing");
+    var result = assertions.a4TokenTypos(doc);
+    assert.strictEqual(result.passed, false, result.evidence);
+  });
+});
+
+describe("A5: Specs sub-frame exists", function () {
+  it("passes when a frame whose name contains 'Specs' exists", function () {
+    var doc = loadFixture("checkbox-passing");
+    var result = assertions.a5SpecsSubFrame(doc);
+    assert.strictEqual(result.passed, true, result.evidence);
+  });
+
+  it("fails when no frame name contains 'Specs'", function () {
+    var doc = loadFixture("checkbox-failing");
+    var result = assertions.a5SpecsSubFrame(doc);
+    assert.strictEqual(result.passed, false, result.evidence);
+  });
+});
+
+describe("A6: Anatomy badges A and B", function () {
+  it("passes when both A and B TEXT nodes exist inside Anatomy diagram", function () {
+    var doc = loadFixture("checkbox-passing");
+    var result = assertions.a6AnatomyBadges(doc);
+    assert.strictEqual(result.passed, true, result.evidence);
+  });
+
+  it("fails when badge B is missing", function () {
+    var doc = loadFixture("checkbox-failing");
+    var result = assertions.a6AnatomyBadges(doc);
+    assert.strictEqual(result.passed, false, result.evidence);
+  });
+});
+
+describe("A7: variation row count matches fixture", function () {
+  it("passes when Figma variation row count equals fixture variant count (±1)", function () {
+    var doc = loadFixture("button-passing");
+    var result = assertions.a7VariationRowCount(doc, { variantCount: 6 });
+    assert.strictEqual(result.passed, true, result.evidence);
+  });
+
+  it("fails when counts differ by more than 1", function () {
+    var doc = loadFixture("button-passing");
+    var result = assertions.a7VariationRowCount(doc, { variantCount: 12 });
+    assert.strictEqual(result.passed, false, result.evidence);
+  });
+
+  it("passes when counts differ by exactly 1 (header-row tolerance)", function () {
+    var doc = loadFixture("button-passing");
+    // 6 rows in fixture; 5 variants = diff of 1 — should pass
+    var result = assertions.a7VariationRowCount(doc, { variantCount: 5 });
+    assert.strictEqual(result.passed, true, result.evidence);
+  });
+});
+
+describe("A8: renderTable invocation rate ≥ 80%", function () {
+  it("passes when adoption_rate ≥ 0.80 with strict equality on 'Table (renderTable)'", function () {
+    var doc = loadFixture("checkbox-passing");
+    var result = assertions.a8RenderTableAdoption(doc, {
+      expectedRenderTablesCount: 4,
+    });
+    assert.strictEqual(result.passed, true, result.evidence);
+    var ev = JSON.parse(result.evidence);
+    assert.strictEqual(ev.tables_via_interpreter, 4);
+    assert.strictEqual(ev.adoption_rate, 1);
+  });
+
+  it("fails when fewer than expected tables match exactly", function () {
+    var doc = loadFixture("checkbox-failing");
+    var result = assertions.a8RenderTableAdoption(doc, {
+      expectedRenderTablesCount: 4,
+    });
+    assert.strictEqual(result.passed, false, result.evidence);
+  });
+
+  it("counts only exact 'Table (renderTable)' matches, not suffixed names", function () {
+    var doc = {
+      id: "0:1",
+      name: "Root",
+      type: "FRAME",
+      children: [
+        { id: "0:2", name: "Table (renderTable)", type: "FRAME", children: [] },
+        {
+          id: "0:3",
+          name: "Table (renderTable) — Sizing",
+          type: "FRAME",
+          children: [],
+        },
+        {
+          id: "0:4",
+          name: "Anatomy parts table (renderTable)",
+          type: "FRAME",
+          children: [],
+        },
+        { id: "0:5", name: "Table (renderTable)", type: "FRAME", children: [] },
+      ],
+    };
+    var result = assertions.a8RenderTableAdoption(doc, {
+      expectedRenderTablesCount: 4,
+    });
+    var ev = JSON.parse(result.evidence);
+    // Only 2 strict matches; 4 expected → adoption_rate = 0.50
+    assert.strictEqual(ev.tables_via_interpreter, 2);
+    assert.strictEqual(result.passed, false);
+  });
+});

--- a/plugins/actian-design-system/tests/renderers/diagnostic-names.test.js
+++ b/plugins/actian-design-system/tests/renderers/diagnostic-names.test.js
@@ -105,4 +105,89 @@ describe("render-figma diagnostic names", function () {
       'stdout must contain a `.name = "Token: " + "--zen-…";` concatenation — the eval-lane A8 assertion reads the runtime concatenated value via get_metadata, but the test pins the source emit form.',
     );
   });
+
+  it("emits a named dot frame for color-swatch cells", function () {
+    var spec = {
+      schemaVersion: "2026.05",
+      headers: ["Token", "Color"],
+      rows: [
+        {
+          cells: [
+            { type: "text", value: "Primary" },
+            {
+              type: "color-swatch",
+              color: "#0066ff",
+              hex: "#0066ff",
+              tokenName: "--zen-color-bg-default",
+            },
+          ],
+        },
+      ],
+    };
+    var result = runRendererWithSpec(spec, "0:1");
+    assert.strictEqual(
+      result.status,
+      0,
+      "renderer exited non-zero. stderr=" + result.stderr,
+    );
+    assert.match(
+      result.stdout,
+      /\.name\s*=\s*"Swatch dot";/,
+      'stdout must contain `.name = "Swatch dot";` — A1 grader counts unnamed frames as anonymity, and the swatch dot is one of three sub-frames inside emitColorSwatchCell.',
+    );
+  });
+
+  it("emits a named stack frame for color-swatch cells", function () {
+    var spec = {
+      schemaVersion: "2026.05",
+      headers: ["Token", "Color"],
+      rows: [
+        {
+          cells: [
+            { type: "text", value: "Primary" },
+            {
+              type: "color-swatch",
+              color: "#0066ff",
+              hex: "#0066ff",
+              tokenName: "--zen-color-bg-default",
+            },
+          ],
+        },
+      ],
+    };
+    var result = runRendererWithSpec(spec, "0:1");
+    assert.strictEqual(result.status, 0);
+    assert.match(
+      result.stdout,
+      /\.name\s*=\s*"Swatch stack";/,
+      'stdout must contain `.name = "Swatch stack";` — the vertical text-stack inside emitColorSwatchCell.',
+    );
+  });
+
+  it("emits a Token-named pill frame inside color-swatch cells when tokenName is set", function () {
+    var spec = {
+      schemaVersion: "2026.05",
+      headers: ["Token", "Color"],
+      rows: [
+        {
+          cells: [
+            { type: "text", value: "Primary" },
+            {
+              type: "color-swatch",
+              color: "#0066ff",
+              hex: "#0066ff",
+              tokenName: "--zen-color-bg-default",
+            },
+          ],
+        },
+      ],
+    };
+    var result = runRendererWithSpec(spec, "0:1");
+    assert.strictEqual(result.status, 0);
+    assert.match(
+      result.stdout,
+      /_pill\.name\s*=\s*"Token: "\s*\+\s*"--zen-color-bg-default";/,
+      'stdout must contain `_pill.name = "Token: " + "--zen-color-bg-default";` — keeps the swatch pill consistent with emitTokenPillCell so A8\'s secondary "Token: --zen-…" pill count is uniform.',
+    );
+  });
 });


### PR DESCRIPTION
## Summary

- **Protocol 3 — programmatic grader** replaces 10 grader subagents per cycle (~1M tokens) with one local Node script (~0 tokens). New `scripts/evals/grade-locally.js` reads frame metadata via existing `figma-rest.js` and runs pure-function A1–A8 assertions. Runner gets `--grader local|subagent` flag (default `local`). Halves eval-cycle cost; pays for itself in one cycle.
- **v1.73.2 swatch sub-cell naming** rides along — three `.name` lines in `emitColorSwatchCell` (dot/stack/pill) so the swatch's inner frames don't trip A1's anonymity ratio. Mirrors the v1.73.1 emit-function pattern.

## Why

Per `memory/project_eval_lane_cost_economics.md`, three full `--runs 5` cycles in 48 hours drained ~5h of usage budget. The grader-as-subagent design was overkill from day one — every A1–A8 assertion is a deterministic pattern check against `get_metadata`. Building Protocol 3 was the highest-leverage Tier 1 follow-up.

## What landed

- `scripts/evals/grading-assertions.js` — pure `(document, ctx) → {passed, evidence}` functions, no I/O.
- `scripts/evals/grade-locally.js` — CLI wrapping the assertions; reads metadata via `getNode`; writes `grading.json` matching the subagent grader's schema (so `summarize.js` consumes either output unchanged).
- `scripts/evals/run-component-brief.sh` — `--grader local|subagent` flag. Each emitted local-grader command is self-contained (`source resolve-node.sh && "$NODE_BIN" ...`) per `CLAUDE.md`.
- `tests/evals/grading-assertions.test.js` — 19 tests across 8 describe blocks, exercising pass + fail + boundary cases per assertion.
- `tests/evals/fixtures/{checkbox-passing,checkbox-failing,button-passing}.json` — synthetic Figma metadata fixtures.
- `evals/component-brief/grader.md` — reframed as fallback procedure; canonical assertion text aligned with `evals.json` and the local grader.
- `evals/component-brief/README.md` — new `## Graders` section documenting both modes.
- `scripts/renderers/figma-table/render-figma.js` — 3 `.name` lines added in `emitColorSwatchCell`. Pill uses the same `"Token: " + tokenName` source form as `emitTokenPillCell` so A8's secondary "Token: --zen-…" pill count is uniform.
- `tests/renderers/diagnostic-names.test.js` — 3 new pin assertions.

Subagent grader is retained for fallback (no `FIGMA_PAT`, REST 4xx, or future LLM-judgment assertions).

## Deliberate scope cut

A4's third bullet (auto-detect doubled-letter typos against `tokens/actian-ds.tokens.json`) is intentionally not implemented in this first cut — the two literal banned strings (`--zen-font-body-stardard`, `--zen-color-them`) catch the v1.71.0 regression class. Easy follow-up if a future regression slips through.

## Test plan

- [x] `node --test tests/` from `plugins/actian-design-system/` — 948/948 pass (was 947; +19 grader + 3 swatch pin, with one pre-existing test deduplicated).
- [x] `node --test tests/renderers/diagnostic-names.test.js` — 5/5 pass (2 original + 3 new swatch pins).
- [x] `node --test tests/evals/grading-assertions.test.js` — 19/19 pass.
- [x] Runner smoke `plan --runs 1` — emits 2 with-skill prompts + 2 self-contained local grader commands.
- [x] Runner smoke `plan --grader subagent` — emits 2 legacy grader-subagent prompts.
- [x] Invalid `--grader bogus` — exits 1 with clear stderr.
- [ ] **Live verification:** first eval cycle on this PR will use Protocol 1 (sample-first) per `feedback_eval_lane_cost_discipline.md` — dispatch 1 with-skill subagent per fixture, run the local grader, confirm grading.json matches the subagent grader's schema.

## Spec / plan

`plugins/actian-design-system/docs/superpowers/plans/2026-05-09-protocol-3-grader-and-v1732-swatch-naming.md` (untracked working artifact per `feedback_no_commit_specs.md`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)