### PR TITLE
fix(figma): Sprint 1b PR-A — compliance fixes (v1.74.1)

### DIFF
--- a/plugins/actian-design-system/.claude-plugin/plugin.json
+++ b/plugins/actian-design-system/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "actian-design-system",
   "description": "Actian Design System toolkit — sync tokens from Figma, generate wireframe flows with prototype wiring, create component briefs, audit designs, compare flows, and build presentations. 9 skills (with tiered generation: recognized / adapted / improvised), 8 agents, 155 tokens (3 themes, 8 collections), WCAG 2.1 AA.",
-  "version": "1.74.0",
+  "version": "1.74.1",
   "author": {
     "name": "Actian UX Team"
   },

--- a/plugins/actian-design-system/references/component-brief/push-patterns.md
+++ b/plugins/actian-design-system/references/component-brief/push-patterns.md
@@ -90,7 +90,7 @@ wrapper.setSharedPluginData("ds", "wrapperId", wrapper.id);
 // The fix is at every level — wrapper (here), supercard outer frame
 // (Pattern 1), and content slot (Pattern 1, v1.69.0+).
 
-return { wrapperId: wrapper.id };
+return { createdNodeIds: [wrapper.id], mutatedNodeIds: [] };
 ```
 
 **DO NOT use VERTICAL. Brief cards display in a HORIZONTAL row.**
@@ -124,7 +124,7 @@ inst.setProperties({
 const wrapper = await figma.getNodeByIdAsync("<wrapperId>");
 wrapper.appendChild(inst);
 
-return { genLogId: inst.id };
+return { createdNodeIds: [inst.id], mutatedNodeIds: ["<wrapperId>"] };
 ```
 
 **Fill all 6 properties from `brief-data.json.meta`.** Do NOT skip this card. Do NOT type any value as a literal — every value must originate in the data model.
@@ -227,7 +227,11 @@ if (contentSlot) {
 const wrapper = await figma.getNodeByIdAsync("<wrapperId>");
 wrapper.appendChild(cardFrame);
 
-return { cardId: cardFrame.id, contentSlotId: contentSlot?.id || cardFrame.id };
+return {
+  createdNodeIds: [cardFrame.id],
+  mutatedNodeIds: ["<wrapperId>", ...(contentSlot ? [contentSlot.id] : [])],
+  contentSlotId: contentSlot?.id || cardFrame.id,
+};
 ```
 
 **Card Header stays live after detach.** Use `setProperties` with `Title#140:0`, `Subtitle#140:1`, `Show Subtitle#140:2`. For the Page Header variant (card1), use `"Mode=DS, Type=Page Header"` and set `"Component Name#7:2"` (= `card.name`) and `"Description#7:3"` (= `card.description`) instead. The `cardTitle`/`cardSubtitle` fields still apply but are not surfaced visually on Page Header.
@@ -358,7 +362,7 @@ header.setProperties({
 const parent = await figma.getNodeByIdAsync("<contentSlotId>");
 parent.appendChild(header);
 header.layoutSizingHorizontal = "FILL";
-return { headerId: header.id };
+return { createdNodeIds: [header.id], mutatedNodeIds: ["<contentSlotId>"] };
 ```
 
 **Do NOT detach.** Use `setProperties` with hash-suffixed names. Set `"Show Subtitle#138:0": false` to hide the subtitle, `true` to show it.
@@ -409,7 +413,7 @@ headerRow.layoutSizingHorizontal = "FILL";
 // Data rows — one call per row or batch
 // Each row: same layout, different text content, "Inter:Regular" font
 // REQ/OPT badge: small frame with colored fill + text
-return { tableId: headerRow.id };
+return { createdNodeIds: [headerRow.id], mutatedNodeIds: ["<contentSlotId>"] };
 ```
 
 **Token Tag styling (v1.69.0+, with v1.70.4+ HUG guard restored in v1.71.1):** When a table cell contains a `--zen-*` token name, render the cell as a Token Tag pill instead of plain text. Use the `appendTokenTagCell` helper below — calling it is materially safer than inlining the same construction (smoke history: when the AI inlined the token-tag layout, every variant of the construction crushed cells to 1px; calling the helper directly is the only path that's been smoke-clean).
@@ -495,7 +499,7 @@ const swatch = variant.createInstance();
 // Set fill color — the swatch IS the dot (flat 12×12 instance, NO children)
 swatch.fills = [{ type: "SOLID", color: hexToRgb("#0550DC") }];
 
-return { swatchId: swatch.id };
+return { createdNodeIds: [swatch.id], mutatedNodeIds: [] };
 ```
 
 **CRITICAL:** The Color Swatch component is a flat 12×12 instance with NO children — set `.fills` directly on the swatch instance itself. Do NOT use `findOne` to look for a "Dot" or "Color" child — it will return null and the fill will never be set.
@@ -554,7 +558,7 @@ pair.setProperties({
 const parent = await figma.getNodeByIdAsync("<contentSlotId>");
 parent.appendChild(pair);
 pair.layoutSizingHorizontal = "FILL";
-return { pairId: pair.id };
+return { createdNodeIds: [pair.id], mutatedNodeIds: ["<contentSlotId>"] };
 ```
 
 ---
@@ -605,7 +609,7 @@ for (const req of requirements) {
   t.layoutSizingHorizontal = "FILL";
 }
 
-return { listId: list.id };
+return { createdNodeIds: [list.id], mutatedNodeIds: ["<contentSlotId>"] };
 ```
 
 **No more 6-card grid, no per-card code blocks.** The `code` field on each requirement (still in the data schema for back-compat) is ignored by this pattern. If a requirement genuinely needs a code example, surface it in the body text or move it to the ARIA table — don't bring back the grid.
@@ -653,7 +657,7 @@ parent.appendChild(row);
 row.layoutSizingHorizontal = "FILL";
 
 // For "when NOT to use", use "−" prefix with hexToRgb("#DC2626") (red)
-return { rowId: row.id };
+return { createdNodeIds: [row.id], mutatedNodeIds: ["<contentSlotId>"] };
 ```
 
 ---
@@ -676,7 +680,7 @@ if (targetNode.type === "COMPONENT_SET") {
 const inst = variantComp.createInstance();
 inst.name = "Default variant";
 
-return { instanceId: inst.id };
+return { createdNodeIds: [inst.id], mutatedNodeIds: [] };
 ```
 
 For theme comparison frames, set `variableMode` after creating the frame:
@@ -972,7 +976,8 @@ const parent = await figma.getNodeByIdAsync("<contentSlotId>");
 parent.appendChild(container);
 
 return {
-  diagramId: container.id,
+  createdNodeIds: [container.id],
+  mutatedNodeIds: ["<contentSlotId>"],
   pattern9: {
     scaleApplied: scale,
     scaleSource: scaleOverride !== null ? "override" : "heuristic",
@@ -996,7 +1001,7 @@ if (!badgeVariant) badgeVariant = badgeSet.defaultVariant || badgeSet.children[0
 const badge = badgeVariant.createInstance();
 badge.setProperties({ "Label#44:3": "Pass" });
 
-return { badgeId: badge.id };
+return { createdNodeIds: [badge.id], mutatedNodeIds: [] };
 ```
 
 ---
@@ -1018,7 +1023,7 @@ row.setProperties({
 const parent = await figma.getNodeByIdAsync("<contentSlotId>");
 parent.appendChild(row);
 row.layoutSizingHorizontal = "FILL";
-return { rowId: row.id };
+return { createdNodeIds: [row.id], mutatedNodeIds: ["<contentSlotId>"] };
 ```
 
 **Do NOT detach** — use `setProperties` with hash-suffixed property names. No font loading needed.
@@ -1039,7 +1044,7 @@ block.setProperties({
 const parent = await figma.getNodeByIdAsync("<contentSlotId>");
 parent.appendChild(block);
 block.layoutSizingHorizontal = "FILL";
-return { blockId: block.id };
+return { createdNodeIds: [block.id], mutatedNodeIds: ["<contentSlotId>"] };
 ```
 
 **Do NOT detach** — use `setProperties` with hash-suffixed names. Set `"Show Header#8:0": false` to hide the filename bar. Code text renders monochrome automatically.
@@ -1096,7 +1101,7 @@ const parent = await figma.getNodeByIdAsync("<contentSlotId>");
 parent.appendChild(researchFrame);
 researchFrame.layoutSizingHorizontal = "FILL";
 
-return { researchFrameId: researchFrame.id };
+return { createdNodeIds: [researchFrame.id], mutatedNodeIds: ["<contentSlotId>"] };
 ```
 
 ```js
@@ -1148,7 +1153,9 @@ if (insights.recommendations?.length) {
   rf.layoutSizingHorizontal = "FILL";
 }
 
-return { subsectionsAdded: true };
+// Collect the IDs of sub-section frames actually appended (pf and/or rf may be absent when list is empty).
+const createdSubIds = [...(insights.patterns_observed?.length ? [pf.id] : []), ...(insights.recommendations?.length ? [rf.id] : [])];
+return { createdNodeIds: createdSubIds, mutatedNodeIds: ["<researchFrameId>"] };
 ```
 
 ```js
@@ -1207,7 +1214,8 @@ if (insights.sources?.length) {
   src.layoutSizingHorizontal = "FILL";
 }
 
-return { divergencesAndSourcesDone: true };
+const createdIds = [...(insights._divergences?.length ? [df.id] : []), ...(insights.sources?.length ? [src.id] : [])];
+return { createdNodeIds: createdIds, mutatedNodeIds: ["<researchFrameId>"] };
 ```
 
 ---
@@ -1676,7 +1684,8 @@ const parent = await figma.getNodeByIdAsync("<specsSubFrameId>");
 parent.appendChild(container);
 
 return {
-  redlineId: container.id,
+  createdNodeIds: [container.id],
+  mutatedNodeIds: ["<specsSubFrameId>"],
   pattern14: {
     extractedFrames,
     boundVariables: boundVariablesCount,

--- a/plugins/actian-design-system/references/component-brief/push-patterns.md
+++ b/plugins/actian-design-system/references/component-brief/push-patterns.md
@@ -2,7 +2,8 @@
 
 Direct Figma Plugin API patterns for pushing component briefs. Each pattern is a standalone `use_figma` call. Read your `brief-data.json` and translate each card to these patterns.
 
-All calls MUST include `skillNames: "figma-use"`.
+> **Always pass `skillNames: "figma-use"` on every `mcp__claude_ai_Figma__use_figma` invocation.** This is mandatory per Figma's official contract — the `figma-use` skill carries the load-bearing Plugin API rules (atomic-on-error, color 0–1 range, HUG-after-append, font preload, await-all-promises, page-context-reset, return-all-IDs, explicit `variable.scopes`). Skipping it produces hard-to-debug failures. Every code block in this document assumes `skillNames: "figma-use"` is set on the call wrapping it.
+> (Source: https://help.figma.com/hc/en-us/articles/39287396773399)
 
 ---
 

--- a/plugins/actian-design-system/references/component-brief/push-patterns.md
+++ b/plugins/actian-design-system/references/component-brief/push-patterns.md
@@ -709,7 +709,9 @@ if (colorCol) {
 > ```js
 > const _fonts = instance.findAll(n => n.type === "TEXT")
 >   .map(t => t.fontName)
->   .filter((fn, i, arr) => fn && arr.findIndex(x => JSON.stringify(x) === JSON.stringify(fn)) === i);
+>   .filter((fn, i, arr) =>
+    fn && typeof fn === 'object' &&
+    arr.findIndex(x => JSON.stringify(x) === JSON.stringify(fn)) === i);
 > await Promise.all(_fonts.map(fn => figma.loadFontAsync(fn)));
 > await appendVariationCell(parentRow, instance);
 > ```
@@ -786,7 +788,9 @@ const inst = variantComp.createInstance();
 // the instance (intermittent failures on supercards with pre-existing instances).
 const _instFonts = inst.findAll(n => n.type === "TEXT")
   .map(t => t.fontName)
-  .filter((fn, i, arr) => fn && arr.findIndex(x => JSON.stringify(x) === JSON.stringify(fn)) === i);
+  .filter((fn, i, arr) =>
+    fn && typeof fn === 'object' &&
+    arr.findIndex(x => JSON.stringify(x) === JSON.stringify(fn)) === i);
 await Promise.all(_instFonts.map(fn => figma.loadFontAsync(fn)));
 
 container.appendChild(inst);
@@ -1445,7 +1449,9 @@ const inst = variantComp.createInstance();
 // Collect unique fontNames from inst subtree and preload before appending.
 const _instFonts14 = inst.findAll(n => n.type === "TEXT")
   .map(t => t.fontName)
-  .filter((fn, i, arr) => fn && arr.findIndex(x => JSON.stringify(x) === JSON.stringify(fn)) === i);
+  .filter((fn, i, arr) =>
+    fn && typeof fn === 'object' &&
+    arr.findIndex(x => JSON.stringify(x) === JSON.stringify(fn)) === i);
 await Promise.all(_instFonts14.map(fn => figma.loadFontAsync(fn)));
 
 container.appendChild(inst);

--- a/plugins/actian-design-system/references/component-brief/push-patterns.md
+++ b/plugins/actian-design-system/references/component-brief/push-patterns.md
@@ -697,6 +697,19 @@ if (colorCol) {
 
 **Variation Matrix construction (v1.70.0+):** When building a 2D state matrix for the Section 1 Variation sub-frame (e.g., Checkbox state matrix with rows = No/Yes/Indeterminate × columns = Default/Hover/Focus/Pressed/Disabled), each cell contains a real component instance. Cells are children of HORIZONTAL row frames. The same regression that bit `appendTokenTagCell` bites here: row sizing crushes child instances to 1px.
 
+> **Rule 8 (figma-use v2.1.26):** Font preload is mandatory before `appendChild` on a
+> component instance — the instance carries the component's fonts which may be unloaded.
+> The CALLER of `appendVariationCell` MUST preload the instance's fonts before passing it
+> to this function. Use the pattern:
+> ```js
+> const _fonts = instance.findAll(n => n.type === "TEXT")
+>   .map(t => t.fontName)
+>   .filter((fn, i, arr) => fn && arr.findIndex(x => JSON.stringify(x) === JSON.stringify(fn)) === i);
+> await Promise.all(_fonts.map(fn => figma.loadFontAsync(fn)));
+> await appendVariationCell(parentRow, instance);
+> ```
+> (Source: figma-use/SKILL.md:8)
+
 ```js
 async function appendVariationCell(parentRow, instance) {
   parentRow.appendChild(instance);
@@ -715,6 +728,14 @@ Apply this to every cell in the Variation matrix. Without the guard, Phase 2 PR 
 ---
 
 ## 9. Anatomy Diagram Pattern (Section 1 Anatomy sub-frame, v1.70.0+)
+
+> **Rule 8 (figma-use v2.1.26):** Font preload is mandatory before any of
+> `appendChild`, `insertChild`, `setBoundVariable`, `setExplicitVariableModeForCollection`,
+> `setValueForMode`, or `findAll` callbacks if the touched subtree contains
+> unloaded fonts. Pre-existing component instances often carry unloaded fonts.
+> Pattern 9 creates a component instance from a pre-existing DS component — the
+> font preload block below (before `container.appendChild(inst)`) is load-bearing.
+> (Source: figma-use/SKILL.md:8)
 
 Single ~4-6KB call. Creates component instance, reads bounding boxes, computes badge positions, draws badges + leader lines.
 
@@ -752,6 +773,17 @@ if (targetNode.type === "COMPONENT_SET") {
   variantComp = targetNode;
 }
 const inst = variantComp.createInstance();
+
+// Rule 8 (figma-use v2.1.26): font preload is mandatory before appendChild on a
+// pre-existing component instance — the instance carries the component's fonts which
+// may be unloaded. Collect unique fontNames from the instance subtree and load them
+// all before appending. Without this, Figma silently fails on text operations inside
+// the instance (intermittent failures on supercards with pre-existing instances).
+const _instFonts = inst.findAll(n => n.type === "TEXT")
+  .map(t => t.fontName)
+  .filter((fn, i, arr) => fn && arr.findIndex(x => JSON.stringify(x) === JSON.stringify(fn)) === i);
+await Promise.all(_instFonts.map(fn => figma.loadFontAsync(fn)));
+
 container.appendChild(inst);
 
 // 2a. Pick scale factor — heuristic per pickScale (mirrors scripts/lib/anatomy-scale.js):
@@ -1182,6 +1214,15 @@ return { divergencesAndSourcesDone: true };
 
 ## 14. Specs Redline Pattern (Section 1 Specs sub-frame, v1.70.0+)
 
+> **Rule 8 (figma-use v2.1.26):** Font preload is mandatory before any of
+> `appendChild`, `insertChild`, `setBoundVariable`, `setExplicitVariableModeForCollection`,
+> `setValueForMode`, or `findAll` callbacks if the touched subtree contains
+> unloaded fonts. Pre-existing component instances often carry unloaded fonts.
+> Pattern 14 creates a component instance from a pre-existing DS component — the
+> font preload block below (before `container.appendChild(inst)`) is load-bearing
+> and distinct from the annotation font load earlier in the pattern.
+> (Source: figma-use/SKILL.md:8)
+
 Auto-extracted dimension annotations rendered in a left-gutter ordinate lane. Replaces the v1.69.0 per-edge placement model which produced label-on-component collisions when N > 1 annotations existed on the same surface (Phase 1 + PR 1 smoke).
 
 **Architecture:** all annotations for a surface are routed to a 220px column to the LEFT of the component. Within that column, label pills are stacked vertically, sorted by the Y-coordinate of the edge they annotate. Each entry is `[Token Tag pill] ──── │` (label + horizontal leader + tick at the component's left edge). Top/bottom annotations get an L-shaped leader (horizontal from gutter, vertical witness to the actual edge). Greedy sort-and-stack guarantees zero collisions by construction. Pattern proven by Zeplin redlines, Carbon Design System anatomy pages, Material 3 anatomy diagrams, and CAD ordinate dimensioning.
@@ -1389,6 +1430,15 @@ if (targetNode.type === "COMPONENT_SET") {
   variantComp = targetNode;
 }
 const inst = variantComp.createInstance();
+
+// Rule 8 (figma-use v2.1.26): font preload before appendChild on component instance.
+// The instance carries the target component's fonts which may be unloaded.
+// Collect unique fontNames from inst subtree and preload before appending.
+const _instFonts14 = inst.findAll(n => n.type === "TEXT")
+  .map(t => t.fontName)
+  .filter((fn, i, arr) => fn && arr.findIndex(x => JSON.stringify(x) === JSON.stringify(fn)) === i);
+await Promise.all(_instFonts14.map(fn => figma.loadFontAsync(fn)));
+
 container.appendChild(inst);
 // v1.70.1: shift inst right by (GUTTER_WIDTH + GUTTER_GAP) so the left-gutter
 // has room INSIDE the container at positive x. Without this shift, the gutter

--- a/plugins/actian-design-system/references/create-component/push-patterns.md
+++ b/plugins/actian-design-system/references/create-component/push-patterns.md
@@ -2,7 +2,8 @@
 
 Direct Figma Plugin API patterns for creating components. The agent writes these calls directly instead of using `assembleCall()` + interpreter.
 
-All calls MUST include `skillNames: "figma-use"`.
+> **Always pass `skillNames: "figma-use"` on every `mcp__claude_ai_Figma__use_figma` invocation.** This is mandatory per Figma's official contract — the `figma-use` skill carries the load-bearing Plugin API rules (atomic-on-error, color 0–1 range, HUG-after-append, font preload, await-all-promises, page-context-reset, return-all-IDs, explicit `variable.scopes`). Skipping it produces hard-to-debug failures. Every code block in this document assumes `skillNames: "figma-use"` is set on the call wrapping it.
+> (Source: https://help.figma.com/hc/en-us/articles/39287396773399)
 
 ---
 

--- a/plugins/actian-design-system/references/figma/figma-push-patterns.md
+++ b/plugins/actian-design-system/references/figma/figma-push-patterns.md
@@ -31,6 +31,12 @@ Each registry entry contains: `key`, `importMethod` ("set" for `importComponentS
 > silently fails and produces orphaned frames.
 > (Source: figma-generate-design/SKILL.md:203)
 
+> **Critical Rule 15: return ALL created/mutated node IDs as a structured object.**
+> Every push pattern MUST end with `return { createdNodeIds: [...], mutatedNodeIds: [...] };`.
+> The orchestrating skill uses these IDs to chain subsequent `use_figma` calls.
+> Single-ID returns like `{ frameId }` or `{ instanceId }` are a Rule 15 violation.
+> (Source: figma-use/SKILL.md:38)
+
 ## 0. Auto-Layout Defaults
 
 **Any row containing text MUST use `sizing: { horizontal: "FILL" }` with text children at `Hug` sizing.** Never set fixed widths on text-bearing rows.
@@ -112,7 +118,11 @@ wrapper.y = maxY + 200;
 // Store the wrapper ID so subsequent calls can append to it
 wrapper.setSharedPluginData("ds", "wrapperId", wrapper.id);
 
-return { wrapperId: wrapper.id };
+// Return all created/mutated node IDs per Critical Rule 15
+return {
+  createdNodeIds: [wrapper.id],
+  mutatedNodeIds: [],
+};
 ```
 
 ### Pattern 2: Import single component + create instance
@@ -132,7 +142,11 @@ inst.setProperties({
   "Date#3:2": "2026-04-08T00:00:00Z"
 });
 
-return { instanceId: inst.id };
+// Return all created/mutated node IDs per Critical Rule 15
+return {
+  createdNodeIds: [inst.id],
+  mutatedNodeIds: [],
+};
 ```
 
 ### Pattern 3: Import component set + create variant instance
@@ -151,7 +165,11 @@ if (!variant) variant = set.defaultVariant || set.children[0];
 const inst = variant.createInstance();
 inst.name = "Primary Button";
 
-return { instanceId: inst.id };
+// Return all created/mutated node IDs per Critical Rule 15
+return {
+  createdNodeIds: [inst.id],
+  mutatedNodeIds: [],
+};
 ```
 
 ### Pattern 4: Append new children to a wrapper by ID
@@ -185,7 +203,11 @@ child2.counterAxisSizingMode = "AUTO";
 child2.fills = [];
 parent.appendChild(child2);
 
-return { parentId: parent.id, child1Id: child1.id, child2Id: child2.id };
+// Return all created/mutated node IDs per Critical Rule 15
+return {
+  createdNodeIds: [child1.id, child2.id],
+  mutatedNodeIds: [parent.id],
+};
 ```
 
 **Wrong — DO NOT retrieve nodes by ID and reparent them across calls:**
@@ -214,7 +236,11 @@ text.fills = [{ type: "SOLID", color: { r: 0.1, g: 0.1, b: 0.18 } }];
 // For slides, use Roboto instead:
 // await figma.loadFontAsync({ family: "Roboto", style: "Regular" });
 
-return { textId: text.id };
+// Return all created/mutated node IDs per Critical Rule 15
+return {
+  createdNodeIds: [text.id],
+  mutatedNodeIds: [],
+};
 ```
 
 ### Pattern 6: Create auto-layout frame
@@ -234,7 +260,11 @@ frame.counterAxisSizingMode = "AUTO";
 frame.fills = [{ type: "SOLID", color: { r: 1, g: 1, b: 1 } }];
 frame.cornerRadius = 8;
 
-return { frameId: frame.id };
+// Return all created/mutated node IDs per Critical Rule 15
+return {
+  createdNodeIds: [frame.id],
+  mutatedNodeIds: [],
+};
 ```
 
 ### Pattern 7: Set ALL instance properties (CRITICAL — never leave defaults)
@@ -339,7 +369,7 @@ function hexToRgb(hex) {
 1. **Always pass `skillNames: "figma-use"`** with every `use_figma` call.
 2. **NEVER leave default property values (P0 BLOCKER)** -- scan your data model for banned defaults BEFORE pushing. These strings must NEVER appear in Figma output: `"Page Title"`, `"Description text"`, `"Button label"`, `"Label"` (standalone), `"Nav Item"`, `"Tag"`, `"Header"` (standalone), `"Feature Name"`, `"Flow Description"`, `"User Persona"`. Replace every one with real contextual content. Use `setProperties()` and `findOne()` per Pattern 7.
 3. **One operation per call** -- create a frame OR import components OR populate content. Not all three.
-4. **Return IDs from every call** -- use them in subsequent calls to append children.
+4. **Return `{ createdNodeIds, mutatedNodeIds }` from every call (Critical Rule 15)** -- use the IDs in subsequent calls to append children. Single-ID shapes like `{ frameId }` are violations.
 5. **Keep calls under 2KB** -- if code is longer, split into multiple calls.
 6. **Fonts before text** -- call `loadFontAsync` before setting `.characters`.
 7. **Colors are 0-1 range** -- `{ r: 0.1, g: 0.1, b: 0.18 }` not `{ r: 26, g: 26, b: 46 }`.

--- a/plugins/actian-design-system/references/figma/figma-push-patterns.md
+++ b/plugins/actian-design-system/references/figma/figma-push-patterns.md
@@ -24,6 +24,13 @@ Each registry entry contains: `key`, `importMethod` ("set" for `importComponentS
 
 ## 2. Core Patterns
 
+> **Never reparent across `use_figma` calls.** Build the wrapper first in
+> call N, then build each child node directly inside it in call N+1 by
+> retrieving the wrapper with `getNodeByIdAsync` and appending the NEW node
+> within that same call. Cross-call `appendChild` on a node fetched by ID
+> silently fails and produces orphaned frames.
+> (Source: figma-generate-design/SKILL.md:203)
+
 ## 0. Auto-Layout Defaults
 
 **Any row containing text MUST use `sizing: { horizontal: "FILL" }` with text children at `Hug` sizing.** Never set fixed widths on text-bearing rows.
@@ -147,17 +154,50 @@ inst.name = "Primary Button";
 return { instanceId: inst.id };
 ```
 
-### Pattern 4: Append children to frame by ID
+### Pattern 4: Append new children to a wrapper by ID
+
+> **Never reparent across `use_figma` calls.** Build the wrapper first, then
+> build each section directly inside it. Cross-call `appendChild` silently
+> fails and produces orphaned frames.
+> (Source: figma-generate-design/SKILL.md:203)
+
+**Correct — create new nodes and append them within the same call:**
 
 ```js
-// Append previously-created nodes into a parent frame.
+// Retrieve the wrapper created in the previous call, create new children
+// inside it in this call. child1 and child2 are NEW nodes — never fetched
+// by getNodeByIdAsync from a prior call.
 const parent = await figma.getNodeByIdAsync("1234:5678");
-const child1 = await figma.getNodeByIdAsync("1234:5679");
-const child2 = await figma.getNodeByIdAsync("1234:5680");
+
+const child1 = figma.createFrame();
+child1.name = "Section A";
+child1.layoutMode = "VERTICAL";
+child1.primaryAxisSizingMode = "AUTO";
+child1.counterAxisSizingMode = "AUTO";
+child1.fills = [];
 parent.appendChild(child1);
+
+const child2 = figma.createFrame();
+child2.name = "Section B";
+child2.layoutMode = "VERTICAL";
+child2.primaryAxisSizingMode = "AUTO";
+child2.counterAxisSizingMode = "AUTO";
+child2.fills = [];
 parent.appendChild(child2);
 
-return { parentId: parent.id, childCount: parent.children.length };
+return { parentId: parent.id, child1Id: child1.id, child2Id: child2.id };
+```
+
+**Wrong — DO NOT retrieve nodes by ID and reparent them across calls:**
+
+```js
+// ❌ FORBIDDEN: previously-created nodes fetched by ID then reparented.
+//    appendChild silently fails; both nodes become orphaned frames.
+const parent = await figma.getNodeByIdAsync("1234:5678");
+const child1 = await figma.getNodeByIdAsync("1234:5679");  // ← created in prior call
+const child2 = await figma.getNodeByIdAsync("1234:5680");  // ← created in prior call
+parent.appendChild(child1);  // ← silently fails
+parent.appendChild(child2);  // ← silently fails
 ```
 
 ### Pattern 5: Create text node

--- a/plugins/actian-design-system/references/figma/figma-push-patterns.md
+++ b/plugins/actian-design-system/references/figma/figma-push-patterns.md
@@ -2,6 +2,9 @@
 
 Direct Figma Plugin API patterns for pushing content to Figma. Each pattern is a standalone `use_figma` call (200-2000 bytes). No interpreter, no JSON specs, no Node scripts at push time.
 
+> **Always pass `skillNames: "figma-use"` on every `mcp__claude_ai_Figma__use_figma` invocation.** This is mandatory per Figma's official contract — the `figma-use` skill carries the load-bearing Plugin API rules (atomic-on-error, color 0–1 range, HUG-after-append, font preload, await-all-promises, page-context-reset, return-all-IDs, explicit `variable.scopes`). Skipping it produces hard-to-debug failures. This rule supersedes Push Rule #1 below — every code block in this document assumes `skillNames: "figma-use"` is set on the call wrapping it.
+> (Source: https://help.figma.com/hc/en-us/articles/39287396773399)
+
 ---
 
 ## 1. Component Keys

--- a/plugins/actian-design-system/scripts/renderers/figma-table/render-figma.js
+++ b/plugins/actian-design-system/scripts/renderers/figma-table/render-figma.js
@@ -482,7 +482,11 @@ function emit(spec, parentIdPlaceholder) {
   }
 
   lines.push("");
-  lines.push("return { createdNodeIds: [table.id], mutatedNodeIds: [] };");
+  lines.push(
+    'return { createdNodeIds: [table.id], mutatedNodeIds: ["' +
+      parentId +
+      '"] };',
+  );
 
   return { code: lines.join("\n"), manifest: stats };
 }

--- a/plugins/actian-design-system/scripts/renderers/figma-table/render-figma.js
+++ b/plugins/actian-design-system/scripts/renderers/figma-table/render-figma.js
@@ -482,7 +482,7 @@ function emit(spec, parentIdPlaceholder) {
   }
 
   lines.push("");
-  lines.push("return { tableId: table.id };");
+  lines.push("return { createdNodeIds: [table.id], mutatedNodeIds: [] };");
 
   return { code: lines.join("\n"), manifest: stats };
 }

--- a/plugins/actian-design-system/skills/companion/SKILL.md
+++ b/plugins/actian-design-system/skills/companion/SKILL.md
@@ -8,6 +8,9 @@ argument-hint: "[Figma URL] [prose: instruction, question, or intent]"
 
 Design system teammate on the Actian UX team. Handles anything design-related — from fixing a wrong token to generating a full user flow.
 
+> **Always pass `skillNames: "figma-use"` on every `mcp__claude_ai_Figma__use_figma` invocation.** This is mandatory per Figma's official contract — the `figma-use` skill carries the load-bearing Plugin API rules (atomic-on-error, color 0–1 range, HUG-after-append, font preload, await-all-promises, page-context-reset, return-all-IDs, explicit `variable.scopes`). Skipping it produces hard-to-debug failures.
+> (Source: https://help.figma.com/hc/en-us/articles/39287396773399)
+
 Designers learn three input shapes; the companion does the rest:
 
 1. **Prompt** — "design me X" → routes to a generator skill.

--- a/plugins/actian-design-system/skills/compare-flows/SKILL.md
+++ b/plugins/actian-design-system/skills/compare-flows/SKILL.md
@@ -8,6 +8,9 @@ argument-hint: "[Figma URL 1] [Figma URL 2]"
 
 Compare two Figma flows or screens and provide structured UX recommendations. Runs autonomously — fetch both designs, analyze, output full report. Only pause if user provides just one URL (ask for second).
 
+> **Always pass `skillNames: "figma-use"` on every `mcp__claude_ai_Figma__use_figma` invocation.** This is mandatory per Figma's official contract — the `figma-use` skill carries the load-bearing Plugin API rules (atomic-on-error, color 0–1 range, HUG-after-append, font preload, await-all-promises, page-context-reset, return-all-IDs, explicit `variable.scopes`). Skipping it produces hard-to-debug failures.
+> (Source: https://help.figma.com/hc/en-us/articles/39287396773399)
+
 ## Pipeline
 
 1. Parse each URL per `../../references/figma/figma-output.md` (extract `fileKey`, `nodeId`). Classify each node via `use_figma` (see figma-output.md), route to resolved targets, then get screenshots.

--- a/plugins/actian-design-system/skills/component-brief/SKILL.md
+++ b/plugins/actian-design-system/skills/component-brief/SKILL.md
@@ -8,6 +8,9 @@ argument-hint: "[Figma URL or component name] [generate N,N,N] [research all|<li
 
 Generate a structured component brief with HTML spec page and Figma output. Pipeline: research → data model → present options → push.
 
+> **Always pass `skillNames: "figma-use"` on every `mcp__claude_ai_Figma__use_figma` invocation.** This is mandatory per Figma's official contract — the `figma-use` skill carries the load-bearing Plugin API rules (atomic-on-error, color 0–1 range, HUG-after-append, font preload, await-all-promises, page-context-reset, return-all-IDs, explicit `variable.scopes`). Skipping it produces hard-to-debug failures.
+> (Source: https://help.figma.com/hc/en-us/articles/39287396773399)
+
 ## Mode detection
 
 | Signal | Mode |

--- a/plugins/actian-design-system/skills/convert-to-hifi/SKILL.md
+++ b/plugins/actian-design-system/skills/convert-to-hifi/SKILL.md
@@ -8,6 +8,9 @@ argument-hint: "<figma-url> [--ref <figma-url>[,<figma-url>]] [--no-prompt]"
 
 Upgrade a Fat Marker wireframe to a high-fidelity DS Kit frame. Three-stage pipeline: extract FM tree from Figma → deterministic transform → LLM polish + push. Runs autonomously after Stage 2 confirmation — no other pauses.
 
+> **Always pass `skillNames: "figma-use"` on every `mcp__claude_ai_Figma__use_figma` invocation.** This is mandatory per Figma's official contract — the `figma-use` skill carries the load-bearing Plugin API rules (atomic-on-error, color 0–1 range, HUG-after-append, font preload, await-all-promises, page-context-reset, return-all-IDs, explicit `variable.scopes`). Skipping it produces hard-to-debug failures.
+> (Source: https://help.figma.com/hc/en-us/articles/39287396773399)
+
 ## Flags
 
 | Flag | Type | Default | Behavior |
@@ -55,7 +58,7 @@ Once a value is resolved (from flag or gate), proceed to the pipeline.
 
 ## Stage 1 — Extract FM tree from Figma
 
-Parse the Figma URL per `references/figma/figma-output.md` (convert `-` to `:` in nodeId). Always pass `skillNames: "figma-use"`.
+Parse the Figma URL per `references/figma/figma-output.md` (convert `-` to `:` in nodeId). Always pass `skillNames: "figma-use"` (see top-of-skill callout).
 
 **CRITICAL — large frames overflow the use_figma response limit.** Use the two-pass approach below.
 

--- a/plugins/actian-design-system/skills/create-component/SKILL.md
+++ b/plugins/actian-design-system/skills/create-component/SKILL.md
@@ -8,6 +8,9 @@ argument-hint: "[component description or Figma URL]"
 
 Create a new Figma component (with variants) from a text description or by extending an existing component. Pipeline: understand → check existing → research (optional) → build plan gate → resolve dependencies → build via interpreter → cleanup → parity check.
 
+> **Always pass `skillNames: "figma-use"` on every `mcp__claude_ai_Figma__use_figma` invocation.** This is mandatory per Figma's official contract — the `figma-use` skill carries the load-bearing Plugin API rules (atomic-on-error, color 0–1 range, HUG-after-append, font preload, await-all-promises, page-context-reset, return-all-IDs, explicit `variable.scopes`). Skipping it produces hard-to-debug failures.
+> (Source: https://help.figma.com/hc/en-us/articles/39287396773399)
+
 ## Step 1 — Understand the component
 
 Determine: component name (FM prefix for Fat Marker), library (FM = Inter, DS Kit = Roboto), variants, content, layout, properties. If a Figma URL is provided, parse per `../../references/figma/figma-output.md` — classify node first via `use_figma`, route to the correct target, then `get_design_context` + `get_screenshot`. Infer as much as possible; only ask if the request is too vague to proceed.

--- a/plugins/actian-design-system/skills/design-audit/SKILL.md
+++ b/plugins/actian-design-system/skills/design-audit/SKILL.md
@@ -8,6 +8,9 @@ argument-hint: "[Figma URL] [--scope copy|tokens|a11y|heuristic|all] [--fix <id|
 
 Audit a Figma file or section against the Actian Design System 2026 and/or Fat Marker conventions. Determine which library the file uses (FM = Workflow A, DS Kit = Workflow B), then apply corresponding rules.
 
+> **Always pass `skillNames: "figma-use"` on every `mcp__claude_ai_Figma__use_figma` invocation.** This is mandatory per Figma's official contract — the `figma-use` skill carries the load-bearing Plugin API rules (atomic-on-error, color 0–1 range, HUG-after-append, font preload, await-all-promises, page-context-reset, return-all-IDs, explicit `variable.scopes`). Skipping it produces hard-to-debug failures.
+> (Source: https://help.figma.com/hc/en-us/articles/39287396773399)
+
 ## Flags
 
 | Flag | Type | Default | Behavior |

--- a/plugins/actian-design-system/skills/generate-flow/SKILL.md
+++ b/plugins/actian-design-system/skills/generate-flow/SKILL.md
@@ -8,6 +8,9 @@ argument-hint: "[feature description or Figma URL] [prose instruction] [--hifi -
 
 Build one or more lo-fi screens (n≥1, single-screen output is first-class) and push to Figma. FM components, Inter font, FM palette.
 
+> **Always pass `skillNames: "figma-use"` on every `mcp__claude_ai_Figma__use_figma` invocation.** This is mandatory per Figma's official contract — the `figma-use` skill carries the load-bearing Plugin API rules (atomic-on-error, color 0–1 range, HUG-after-append, font preload, await-all-promises, page-context-reset, return-all-IDs, explicit `variable.scopes`). Skipping it produces hard-to-debug failures.
+> (Source: https://help.figma.com/hc/en-us/articles/39287396773399)
+
 ## Input shapes
 
 The skill accepts three shapes; detection happens before the pipeline runs.

--- a/plugins/actian-design-system/skills/generate-presentation/SKILL.md
+++ b/plugins/actian-design-system/skills/generate-presentation/SKILL.md
@@ -8,6 +8,9 @@ argument-hint: "[topic, file path, Figma URL, or description of content]"
 
 Generate a structured Figma presentation deck using official Actian slide templates. Pipeline: gather content → research gate → outline with gate → build slide-data.json → push to Figma. HTML preview is opt-in ("preview").
 
+> **Always pass `skillNames: "figma-use"` on every `mcp__claude_ai_Figma__use_figma` invocation.** This is mandatory per Figma's official contract — the `figma-use` skill carries the load-bearing Plugin API rules (atomic-on-error, color 0–1 range, HUG-after-append, font preload, await-all-promises, page-context-reset, return-all-IDs, explicit `variable.scopes`). Skipping it produces hard-to-debug failures.
+> (Source: https://help.figma.com/hc/en-us/articles/39287396773399)
+
 Read `../../docs/presentation-guide.md` before generating any slides — primary reference for slide types, typography, colors, sequencing, voice & tone, charts, and review report format.
 
 ## Step 1 — Gather content

--- a/plugins/actian-design-system/skills/sync-design-system/SKILL.md
+++ b/plugins/actian-design-system/skills/sync-design-system/SKILL.md
@@ -9,6 +9,9 @@ argument-hint: "[phase name, component name, 'all', or 'validate']"
 
 Extract design system data directly from Figma libraries via MCP tools. Single-hop: Figma → Plugin (`docs/` + `tokens/`). Read-only on Figma, writes static files locally.
 
+> **Always pass `skillNames: "figma-use"` on every `mcp__claude_ai_Figma__use_figma` invocation.** This is mandatory per Figma's official contract — the `figma-use` skill carries the load-bearing Plugin API rules (atomic-on-error, color 0–1 range, HUG-after-append, font preload, await-all-promises, page-context-reset, return-all-IDs, explicit `variable.scopes`). Skipping it produces hard-to-debug failures.
+> (Source: https://help.figma.com/hc/en-us/articles/39287396773399)
+
 > **Primary purpose: Phase 2 (variables sync) + Phase 4 (token regen).** Phase 2 cannot run in CI because Figma's Variables REST API is gated to Enterprise plans, so this skill is the only path. Run when DS Kit variables change in Figma — typically monthly.
 >
 > **Phases 1 and 3 auto-sync nightly** via `.github/workflows/sync-from-figma.yml` (Sprint 1 v1.59.0). Use the manual phase paths below only as fallback if the workflow is broken or for local debugging.


### PR DESCRIPTION
## Summary

Sprint 1b PR-A. Closes 8 latent Figma-compliance gaps surfaced in the 2026-05-09 research synthesis. **4 audits found issues, 4 came back CLEAN.** Final integration review caught 2 additional correctness gaps in the proposed fixes (one of which would have caused a runtime crash on mixed-font instances).

Headline finding: **Rule 8 font-preload was being violated on every supercard push** — the predicted "intermittent silent failures on supercards with pre-existing instances" from the research memo is now resolved at the source.

## Audits

| Audit | Verdict | Commit |
|---|---|---|
| A1 — `figma-use` skillNames mandatory-load | **ISSUES** — 4 non-conformant skills (companion, compare-flows, design-audit, sync-design-system) had no `skillNames: "figma-use"` mention anywhere. + 5 consistency upgrades + 3 reference docs. | `9c0fd71` |
| A2 — Cross-call appendChild | **ISSUES (1)** — `figma-push-patterns.md` Pattern 4 documented the forbidden cross-call reparent shape verbatim. Every brief or flow run risked silent-orphaned frames. | `98fa34e` |
| A3 — Rule 8 font-preload | **ISSUES (3)** — Patterns 9/14/8 appended DS component instances without preloading their fonts. The figma-use v2.1.26 expansion of Rule 8 made font preload mandatory before `appendChild` on text-bearing subtrees. | `13a087d` |
| A4 — Rule 15 return-IDs | **ISSUES (19)** — every documented push-pattern return shape was non-conformant; renderer's emitted return too. | `a93f28a` |
| A5 — Pattern 9 `resize()` | CLEAN | — |
| A6 — `getLocalComponents()` | CLEAN | — |
| A7 — `cornerRadius` binding | CLEAN | — |
| A8 — `fontSize/fontWeight/lineHeight` binding | CLEAN | — |

## Integration-review fixes

The post-audit integration review caught 2 correctness gaps in the proposed fixes (commit `4efc89b`):

1. **`render-figma.js:485`** emitted `mutatedNodeIds: []` while the script `appendChild`s to the content slot — Rule 15 incomplete. Now interpolates `parentId` into the emitted string literal.
2. **`fn &&` font dedup** didn't exclude `figma.mixed` (a Symbol — truthy but `JSON.stringify` returns `undefined`, so all mixed-font entries dedup to one slot, then `loadFontAsync(figma.mixed)` throws). Added `typeof fn === 'object'` guard at all 3 sites.

## Why

Per `memory/project_figma_research_2026_05_09.md` §"Cross-cutting — composition pattern (LOAD-BEARING FINDING)": Figma's official contract states *"You MUST invoke the figma-use skill before every use_figma call."* The figma-use skill carries the load-bearing Plugin API rules (atomic-on-error, color 0–1 range, HUG-after-append, font preload, await-all-promises, page-context-reset, return-all-IDs, explicit `variable.scopes`). Skipping it produces hard-to-debug failures.

## Test plan

- [x] `node --test plugins/actian-design-system/tests/` — 948/948 pass throughout (no regressions)
- [x] Final integration review caught 2 additional issues; both fixed
- [ ] **Live verification (deferred to next eval cycle):** the next brief-skill PR's first eval run uses Protocol 1 (sample-first) over the local grader. A3 font-preload fix should reduce intermittent A1 anonymity / cell-render failures on supercards.

## Spec / plan

- `plugins/actian-design-system/docs/superpowers/plans/2026-05-09-sprint-1b-pr-a-compliance-fixes.md` (untracked working artifact)
- `plugins/actian-design-system/docs/superpowers/audits/2026-05-09-pr-a-findings.md` (untracked working artifact — full per-audit ledger)
- `memory/project_figma_research_2026_05_09.md` (research memo this PR derives from)

## What's next in Sprint 1b

- **PR-B** (rule codification, ~1d) — expand `references/figma/figma-push-patterns.md` + `CLAUDE.md` with the 8 missed Critical Rules + Editor Mode + ToolSearch batch-load. Docs-only.
- **PR-C** (API adoptions, ~3d) — `createAutoLayout` + `node.set` + `node.query` mechanical migration.
- **PR-D** (cross-harness smoke, ~1d) — test our skills in Cursor + Copilot VS Code; document harness assumptions matrix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)