### PR TITLE
docs(figma): Sprint 1b PR-B — rule codification (v1.74.2)

### DIFF
--- a/plugins/actian-design-system/.claude-plugin/plugin.json
+++ b/plugins/actian-design-system/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "actian-design-system",
   "description": "Actian Design System toolkit — sync tokens from Figma, generate wireframe flows with prototype wiring, create component briefs, audit designs, compare flows, and build presentations. 9 skills (with tiered generation: recognized / adapted / improvised), 8 agents, 155 tokens (3 themes, 8 collections), WCAG 2.1 AA.",
-  "version": "1.74.1",
+  "version": "1.74.2",
   "author": {
     "name": "Actian UX Team"
   },

--- a/plugins/actian-design-system/CLAUDE.md
+++ b/plugins/actian-design-system/CLAUDE.md
@@ -119,6 +119,39 @@ Full checklist: `references/ds-rules/quality-checklist.md`
 
 1. `get_design_context` first. 2. `get_metadata` if response too large. 3. `get_screenshot` for visual ref. 4. Push to Figma using small direct `use_figma` calls (200-2000 bytes each, one operation per call) — see `references/figma/figma-push-patterns.md` for component keys and patterns. Always pass `skillNames: "figma-use"`. 5. Validate against screenshot. See `references/figma/figma-output.md`.
 
+### Critical Plugin API Rules
+
+Every `use_figma` invocation must respect these. Full callouts in
+`references/figma/figma-push-patterns.md` `## Critical Rules`; trap
+catalogue in `references/figma/figma-api-traps.md`.
+
+- **`skillNames: "figma-use"` mandatory** on every call (Figma's
+  official contract).
+- **Never reparent across calls** — `appendChild` on a node from a
+  prior call silently fails; build wrappers first, append in-call.
+- **Return `{ createdNodeIds, mutatedNodeIds }`** from every call
+  (Rule 15) — no single-ID shapes.
+- **Font preload (Rule 8 expansion)** — `await loadFontAsync` for
+  every font in the touched subtree BEFORE `appendChild`/`insertChild`/
+  `setBoundVariable`/`findAll` over text-bearing nodes.
+- **Atomic on error: STOP** — failed scripts roll back fully; do not
+  immediately retry.
+- **`await` every Promise** — `loadFontAsync`, `setCurrentPageAsync`,
+  `importComponentByKeyAsync`, async setters.
+- **Position top-level nodes away from (0,0)** — auto-layout-nested
+  exempt; only page-level needs explicit positioning.
+- **Set `variable.scopes` explicitly** — default `ALL_SCOPES`
+  pollutes property pickers.
+- **Editor Mode**: `use_figma` is design-mode only. Block-list:
+  Sticky, Connector, ShapeWithText, CodeBlock, Slide, SlideRow,
+  Webpage. Use `get_figjam` for FigJam URLs.
+- **DS work**: start at `figma-use/references/working-with-design-systems/wwds.md`.
+- **Use `getSharedPluginData`** — `getPluginData`/`setPluginData` are
+  not supported in `use_figma`.
+
+For the trap catalogue (methods that don't exist, fields that aren't
+bindable, patterns that silently fail), see `references/figma/figma-api-traps.md`.
+
 ---
 
 ## Local Server

--- a/plugins/actian-design-system/references/figma/figma-api-traps.md
+++ b/plugins/actian-design-system/references/figma/figma-api-traps.md
@@ -1,0 +1,89 @@
+# Figma Plugin API Traps
+
+Methods, properties, and patterns that throw, silently fail, or don't
+exist inside `use_figma`. Use this as a checklist when reviewing push
+patterns.
+
+Source: `figma-use/references/api-reference.md` (canonical) + Actian
+Sprint 1b PR-A audits (`docs/superpowers/audits/2026-05-09-pr-a-findings.md`).
+
+---
+
+## Methods that don't exist (throw on call)
+
+| Method | What to use instead |
+|---|---|
+| `figma.getLocalComponents()` | `figma.currentPage.findAll(n => n.type === 'COMPONENT')` |
+| `figma.getLocalComponentsAsync()` | `figma.currentPage.findAll(n => n.type === 'COMPONENT')` |
+| `figma.getLocalComponentSetsAsync()` | `figma.currentPage.findAll(n => n.type === 'COMPONENT_SET')` |
+| `figma.notify(...)` | (no-op — not supported in `use_figma`) |
+| `figma.showUI(...)` | (no-op — `use_figma` has no UI surface) |
+| `figma.openExternal(...)` | (no-op — return URLs in the response instead) |
+| `figma.loadAllPagesAsync()` | Use `setCurrentPageAsync(page)` per page |
+| `figma.variables.extendLibraryCollectionByKeyAsync(...)` | Not supported |
+| `figma.teamLibrary.*` | Not supported in `use_figma` (use `getNodeByIdAsync` + key-based imports) |
+
+## Setters that throw
+
+| Setter | What to use instead |
+|---|---|
+| `figma.currentPage = page` | `await figma.setCurrentPageAsync(page)` |
+
+## Properties that are NOT bindable to variables
+
+`setBoundVariable(field, variable)` silently fails or throws on these
+fields. Set them as direct values resolved from the token registry.
+
+| Field | Why | Workaround |
+|---|---|---|
+| `cornerRadius` | Unified field not bindable | Bind `topLeftRadius`, `topRightRadius`, `bottomLeftRadius`, `bottomRightRadius` individually |
+| `fontSize` | Not in the bindable-fields list | Set as literal: `text.fontSize = 14;` |
+| `fontWeight` | Not in the bindable-fields list | Set as literal via `fontName.style` (e.g. `"Medium"`) |
+| `lineHeight` | Not in the bindable-fields list | Set as literal: `text.lineHeight = { value: 20, unit: 'PIXELS' };` |
+
+## Auto-layout values that throw
+
+| Field | Forbidden value | Reason |
+|---|---|---|
+| `counterAxisAlignItems` | `'STRETCH'` | Not supported (use `'CENTER'`, `'MIN'`, `'MAX'`, `'BASELINE'`) |
+
+## Patterns that silently fail
+
+| Pattern | What happens | Fix |
+|---|---|---|
+| Cross-call `appendChild` | The reparent silently fails; node is orphaned | Build the wrapper first; create+append children IN-CALL via `getNodeByIdAsync(wrapperId)` retrieval |
+| `appendChild` without font preload on text-bearing subtree | Throws or produces garbled text | Preload fonts via `findAll(n => n.type === 'TEXT')` + `Promise.all(loadFontAsync)` BEFORE the append (see Rule 8) |
+| Unawaited `loadFontAsync` / `setCurrentPageAsync` | Subsequent ops fail with "missing font" / wrong page errors | Always `await` Promise-returning APIs |
+| `node.resize()` after setting `primaryAxisSizingMode`/`counterAxisSizingMode` | Resize silently resets sizing modes to FIXED | Call `resize()` first, then set sizing modes; or use `node.set({...})` which auto-orders |
+| Returning `{ briefId: x }` or single-ID shapes | Violates Critical Rule 15 | Always return `{ createdNodeIds: [...], mutatedNodeIds: [...] }` |
+
+## Variable mutation gotchas
+
+`setBoundVariableForPaint(paint, field, variable)`,
+`setBoundVariableForEffect(effect, field, variable)`,
+`setBoundVariableForLayoutGrid(grid, field, variable)` all return NEW
+objects. You MUST capture and reassign:
+
+```js
+// WRONG — original paint is unchanged
+const paint = node.fills[0];
+paint.setBoundVariableForPaint(...);  // returns new paint, discarded
+
+// CORRECT
+const newPaint = paint.setBoundVariableForPaint(...);
+node.fills = [newPaint, ...node.fills.slice(1)];
+```
+
+## Plan-dependent limits
+
+- **Variable collection mode count**: Free-tier files cap at fewer modes
+  than Org-tier. Pattern 14's per-mode binding can throw on Free files.
+- **Variable count per collection**: Plan-dependent; expect up to 1000
+  on Org, fewer on Free.
+
+## See also
+
+- `figma-use/SKILL.md` Critical Rules 1-17 — the canonical rule set
+- `figma-use/references/gotchas.md` — full pitfall catalogue with WRONG/
+  CORRECT examples
+- `references/figma/figma-push-patterns.md` `## Critical Rules` section

--- a/plugins/actian-design-system/references/figma/figma-api-traps.md
+++ b/plugins/actian-design-system/references/figma/figma-api-traps.md
@@ -5,7 +5,8 @@ exist inside `use_figma`. Use this as a checklist when reviewing push
 patterns.
 
 Source: `figma-use/references/api-reference.md` (canonical) + Actian
-Sprint 1b PR-A audits (`docs/superpowers/audits/2026-05-09-pr-a-findings.md`).
+Sprint 1b PR-A audits (commits 98fa34e, 13a087d, a93f28a, 9c0fd71,
+4efc89b on `main`).
 
 ---
 

--- a/plugins/actian-design-system/references/figma/figma-push-patterns.md
+++ b/plugins/actian-design-system/references/figma/figma-push-patterns.md
@@ -40,6 +40,130 @@ Each registry entry contains: `key`, `importMethod` ("set" for `importComponentS
 > Single-ID returns like `{ frameId }` or `{ instanceId }` are a Rule 15 violation.
 > (Source: figma-use/SKILL.md:38)
 
+## Critical Rules
+
+These rules come from `figma-use` SKILL.md (current version, 2026-04-28).
+Skipping any of them produces hard-to-debug failures. The rules in `## 2.
+Core Patterns` above (skillNames mandatory-load, never-reparent, return
+all node IDs) are also Critical Rules and remain in their current position
+for prominence; the rules below are the rest of the canonical set.
+
+> **Rule 3a — `getPluginData`/`setPluginData` are NOT supported in `use_figma`. Use `getSharedPluginData`/`setSharedPluginData` instead.**
+> The shared variant takes a namespace + key and works inside `use_figma`.
+> If you need to persist plugin metadata on a node, always use the shared
+> variant.
+> (Source: figma-use/SKILL.md Rule 3a)
+
+> **Rule 8 — Font preload is mandatory before any operation on text-bearing subtrees.**
+> Per the v2.1.26 expansion (2026-04-27): you MUST `loadFontAsync` before
+> `appendChild`, `insertChild`, `setBoundVariable`, `setExplicitVariableModeForCollection`,
+> `setValueForMode`, AND `findAll` callbacks if any node in the touched
+> subtree contains unloaded fonts. Pre-existing component instances often
+> carry unloaded fonts. Reference fix shape:
+>
+> ```js
+> const fonts = subtree.findAll(n => n.type === 'TEXT')
+>   .map(t => t.fontName)
+>   .filter((fn, i, arr) =>
+>     fn && typeof fn === 'object' &&
+>     arr.findIndex(x => JSON.stringify(x) === JSON.stringify(fn)) === i
+>   );
+> await Promise.all(fonts.map(fn => figma.loadFontAsync(fn)));
+> parent.appendChild(subtree);
+> ```
+>
+> The `typeof fn === 'object'` guard excludes `figma.mixed` (a Symbol) which
+> is truthy but produces `undefined` from `JSON.stringify`. Without the
+> guard, `loadFontAsync(figma.mixed)` throws.
+> (Source: figma-use/SKILL.md Rule 8 — expanded v2.1.26)
+
+> **Rule 13 — Position new top-level nodes away from (0,0).**
+> Top-level nodes (children of `figma.currentPage`) must be positioned at
+> non-(0,0) coordinates — Figma reserves the origin region for collapsed
+> overlay state. Auto-layout-nested nodes (children of frames with
+> `layoutMode = "HORIZONTAL"` or `"VERTICAL"`) are exempt; only page-level
+> nodes need explicit positioning. Pattern 0 (wrapper frame) follows this
+> already by setting `wrapper.x = currentPage.maxY + 200`.
+> (Source: figma-use/SKILL.md Rule 13)
+
+> **Rule 14 — Atomic on error: STOP, do not immediately retry.**
+> A failed `use_figma` script makes ZERO changes — Figma rolls back the
+> entire script. STOP, diagnose the error, then re-issue with the fix.
+> Retrying the same script on transient-looking errors is the wrong move:
+> if the script failed once it will fail again, and silent retries waste
+> tokens. Atomic-on-error is what makes diagnose-then-fix safe.
+> (Source: figma-use/SKILL.md Rule 14)
+
+> **Rule 16 — Always set `variable.scopes` explicitly.**
+> The default `ALL_SCOPES` "pollutes every property picker — almost never
+> what you want." Set scopes per the variable's intended use:
+> - Color tokens: `["FRAME_FILL", "SHAPE_FILL", "TEXT_FILL", "STROKE_COLOR"]`
+> - Spacing tokens: `["GAP", "WIDTH_HEIGHT"]`
+> - Typography tokens: see `figma-use/references/variable-patterns.md` for
+>   the full enumeration.
+> (Source: figma-use/SKILL.md Rule 16)
+
+> **Rule 17 — `await` every Promise.**
+> Unawaited `loadFontAsync`, `setCurrentPageAsync`, `importComponentByKeyAsync`,
+> `setFillStyleIdAsync`, etc. cause silent failures. Use `await` even when
+> you don't read the return value. Promise.all is the right shape when
+> loading many things in parallel; never fire-and-forget.
+> (Source: figma-use/SKILL.md Rule 17)
+
+### Editor Mode
+
+`use_figma` works in **design mode only**. Figma supports multiple editor
+modes (Design, FigJam, Slides, Sites) and our skill cannot author canvas
+content in non-design modes. Specifically blocked node types in design
+mode:
+
+- `STICKY` (FigJam)
+- `CONNECTOR` (FigJam)
+- `SHAPE_WITH_TEXT` (FigJam)
+- `CODE_BLOCK` (FigJam)
+- `SLIDE` (Slides)
+- `SLIDE_ROW` (Slides)
+- `WEBPAGE` (Sites)
+
+If the user sends a `figma.com/board/`, `figma.com/slides/`, `figma.com/make/`,
+or `figma.com/sites/` URL, hand off to the appropriate read-only flow
+(`get_figjam`, `get_design_context` with mode warning) — do not attempt
+`use_figma` writes.
+
+(Source: figma-use/SKILL.md Section 4)
+
+### ToolSearch batch-load
+
+When invoking multiple Figma MCP tools in a single context (e.g.
+`use_figma` + `get_metadata` + `get_screenshot` + `create_new_file`),
+load ALL their schemas in ONE `ToolSearch` call:
+
+```
+ToolSearch query="select:use_figma,get_figjam,get_screenshot,get_metadata,create_new_file"
+```
+
+Loading them one at a time is wasteful and fragments the agent's context
+window. Load all at the start of the work; each schema costs ~1-2K tokens
+once.
+
+(Source: figma-use/SKILL.md v2.1.30)
+
+### Working with Design Systems — start at `wwds.md`
+
+Whenever the work involves an existing DS (which is most of our work —
+DS Kit, FM Kit, Meta Kit), Figma's official entry point is:
+
+```
+figma-use/references/working-with-design-systems/wwds.md
+```
+
+This file routes to per-topic sub-references (creating-with vs using
+components, variables, effect styles, text styles). Read it first when
+starting any DS-touching push task. Our patterns reflect its guidance
+but the upstream is authoritative for any case our patterns don't cover.
+
+(Source: figma-use/SKILL.md line 19)
+
 ## 0. Auto-Layout Defaults
 
 **Any row containing text MUST use `sizing: { horizontal: "FILL" }` with text children at `Hug` sizing.** Never set fixed widths on text-bearing rows.


### PR DESCRIPTION
## Summary

Sprint 1b PR-B. Pure docs PR — codifies the 8 figma-use Critical Rules + Editor Mode boundary + ToolSearch batch-load + DS entry-point pointer that we missed in the 2026-05-07 sweep. Closes the documentation surface gap that PR-A's 4 audits exposed at the runtime level.

PR-A fixed the actual violations; PR-B locks in the rules so future work doesn't reintroduce them.

## What landed

- **`references/figma/figma-push-patterns.md`** — new `## Critical Rules` section. PR-A had already added skillNames mandatory-load (line 5), never-reparent-across-calls (line 30), and Rule 15 return-IDs (line 37). This commit adds the remaining 6 rules + Editor Mode + ToolSearch + DS entry-point pointer.
- **`references/figma/figma-api-traps.md`** — NEW reference file (~89 lines). Consolidates the "What Does NOT Work" table from `figma-use/references/api-reference.md` plus Actian-specific findings from PR-A audits.
- **`CLAUDE.md`** — new `### Critical Plugin API Rules` H3 subsection inside `## Figma MCP Flow`. 11 condensed one-line bullets in always-loaded context, pointing to the deep-dive references for full callouts.

## Codified rules

| Rule | Source | Where it lives now |
|---|---|---|
| 3a — `getPluginData` unsupported, use `getSharedPluginData` | figma-use SKILL.md | push-patterns §Critical Rules + traps |
| 8 — Font preload before `appendChild`/`findAll`/`setBoundVariable`/`setExplicitVariableModeForCollection`/`setValueForMode` (expanded v2.1.26) | figma-use SKILL.md | push-patterns §Critical Rules (with `figma.mixed` Symbol guard from PR-A integration review) |
| 13 — Position top-level nodes away from (0,0); auto-layout-nested exempt | figma-use SKILL.md | push-patterns §Critical Rules |
| 14 — Atomic on error: STOP, do not immediately retry | figma-use SKILL.md | push-patterns §Critical Rules |
| 16 — Always set `variable.scopes` explicitly | figma-use SKILL.md | push-patterns §Critical Rules |
| 17 — `await` every Promise | figma-use SKILL.md | push-patterns §Critical Rules |
| Editor Mode — `use_figma` is design-mode only | figma-use SKILL.md §4 | push-patterns §Critical Rules + CLAUDE.md |
| ToolSearch batch-load (`select:use_figma,...`) | figma-use v2.1.30 | push-patterns §Critical Rules |
| DS entry-point: `working-with-design-systems/wwds.md` | figma-use SKILL.md line 19 | push-patterns §Critical Rules + CLAUDE.md |

## Trap catalogue (figma-api-traps.md)

8 categories:
- Methods that don't exist (`getLocalComponents` family, `figma.notify`, etc.)
- Setters that throw (`figma.currentPage =`)
- Properties not bindable to variables (`cornerRadius`, `fontSize`, `fontWeight`, `lineHeight`)
- Auto-layout forbidden values (`counterAxisAlignItems = 'STRETCH'`)
- Patterns that silently fail (cross-call `appendChild`, `appendChild` without font preload, unawaited Promises, `resize()` after sizing-mode set, single-ID returns)
- Variable mutation gotchas (`setBoundVariableForPaint/Effect/LayoutGrid` return new objects)
- Plan-dependent limits (variable mode count)
- See-also pointers

## Why

Per `memory/project_figma_research_2026_05_09.md`: the figma/mcp-server-guide upstream is frozen 2026-04-28. Everything new = what we missed in the 2026-05-07 sweep. PR-A surfaced 4 of these as actual runtime violations; PR-B codifies the full canonical rule set so future work doesn't reintroduce them.

## Test plan

- [x] `node --test plugins/actian-design-system/tests/` — 948/948 pass throughout (no code changes, no regressions)
- [x] Markdown structure verified — `## Critical Rules` correctly nested between `## 2. Core Patterns` and `## 0. Auto-Layout Defaults`; `### Critical Plugin API Rules` correctly nested under `## Figma MCP Flow` in CLAUDE.md
- [ ] **Live verification (deferred to next eval cycle):** the next brief-skill PR's first eval run uses Protocol 1 (sample-first) over the local grader. Should continue to confirm the PR-A fixes hold + the new docs surface doesn't regress AI behavior.

## Spec / plan

- `plugins/actian-design-system/docs/superpowers/plans/2026-05-09-sprint-1b-pr-b-rule-codification.md` (untracked working artifact)
- `memory/project_figma_research_2026_05_09.md` (research memo this PR derives from)

## What's next in Sprint 1b

- **PR-C** (~3d) — `createAutoLayout` + `node.set` + `node.query` mechanical migration across push patterns. Removes ~150 lines of verbose frame-creation boilerplate.
- **PR-D** (~1d) — cross-harness smoke (Cursor + Copilot VS Code); document harness assumptions matrix in `ARCHITECTURE.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)