### PR TITLE
feat(federation): Phase 0 — llms.txt + AI-agent orientation (v1.76.0)

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 > A design system teammate for the Actian UX team.
 
+> **For AI agents:** Start at [`/llms.txt`](./llms.txt) for the canonical content index.
+
 Built on Claude and connected directly to Figma, the Actian DS Plugin knows the design system — tokens, components, design & content guidelines, and the specific context of our apps. It can act on that knowledge and answer questions about it.
 
 ## The core loop

--- a/llms.txt
+++ b/llms.txt
@@ -1,0 +1,48 @@
+# Actian Design System
+
+> Actian's design system, packaged as a Claude Code plugin. 9 skills for authoring and auditing Figma designs against the Actian DS via the official Figma MCP server. 155 tokens (3 themes, 8 collections), 107 DS Kit components, 33 FM Kit wireframe components, 25 Meta Kit + 3 templates.
+
+The Actian DS is in a federated transition (2026-05-09): knowledge layer is currently bundled with the plugin but moving to a dedicated `actian-ds-knowledge` repo in Phase 1. Until then, this `llms.txt` indexes content at GitHub raw URLs on the `main` branch.
+
+## Docs
+
+- [AI agent orientation](https://raw.githubusercontent.com/volivarii/Actian-DS-Claude-plugin/main/plugins/actian-design-system/docs/llms-overview.md): start here — explains how DS knowledge is organized across tokens, registries, guidelines, and skills
+- [Plugin README](https://raw.githubusercontent.com/volivarii/Actian-DS-Claude-plugin/main/README.md): repo-level overview
+- [Plugin usage guide](https://raw.githubusercontent.com/volivarii/Actian-DS-Claude-plugin/main/USAGE.md): how to invoke the 9 skills
+
+## Knowledge — Foundations
+
+- [Foundations canonical doc](https://raw.githubusercontent.com/volivarii/Actian-DS-Claude-plugin/main/plugins/actian-design-system/docs/foundations.md): MD-as-SoT for spacing, typography, color, motion
+- [Foundations authoring guide](https://raw.githubusercontent.com/volivarii/Actian-DS-Claude-plugin/main/plugins/actian-design-system/docs/foundations-authoring.md): how to update foundations
+- [Tokens (DTCG JSON)](https://raw.githubusercontent.com/volivarii/Actian-DS-Claude-plugin/main/plugins/actian-design-system/tokens/actian-ds.tokens.json): 155 tokens, 3 themes
+- [Tokens (CSS)](https://raw.githubusercontent.com/volivarii/Actian-DS-Claude-plugin/main/plugins/actian-design-system/tokens/actian-ds.tokens.css): CSS custom property form
+
+## Knowledge — Content & Accessibility
+
+- [Content guidelines](https://raw.githubusercontent.com/volivarii/Actian-DS-Claude-plugin/main/plugins/actian-design-system/docs/content-guidelines.md): voice, tone, copy patterns
+- [Accessibility guidelines](https://raw.githubusercontent.com/volivarii/Actian-DS-Claude-plugin/main/plugins/actian-design-system/docs/accessibility-guidelines.md): WCAG 2.1 AA conformance
+
+## Knowledge — Components
+
+- [DS Kit registry](https://raw.githubusercontent.com/volivarii/Actian-DS-Claude-plugin/main/plugins/actian-design-system/docs/generated/dskit.json): 107 design system components with keys, variants, and properties
+- [DS Kit components (MD)](https://raw.githubusercontent.com/volivarii/Actian-DS-Claude-plugin/main/plugins/actian-design-system/docs/generated/dskit-components.md): human-readable mirror with required-override callouts
+- [FM Kit registry](https://raw.githubusercontent.com/volivarii/Actian-DS-Claude-plugin/main/plugins/actian-design-system/docs/generated/fmkit.json): 33 wireframe components
+- [FM Kit components (MD)](https://raw.githubusercontent.com/volivarii/Actian-DS-Claude-plugin/main/plugins/actian-design-system/docs/generated/fm-components.md): human-readable mirror
+- [Meta Kit registry](https://raw.githubusercontent.com/volivarii/Actian-DS-Claude-plugin/main/plugins/actian-design-system/docs/generated/metakit.json): 25 components + 3 templates
+- [App context](https://raw.githubusercontent.com/volivarii/Actian-DS-Claude-plugin/main/plugins/actian-design-system/docs/generated/app-context.json): apps, entities, terminology, patterns
+- [FM↔DS map](https://raw.githubusercontent.com/volivarii/Actian-DS-Claude-plugin/main/plugins/actian-design-system/docs/generated/fm-to-ds-map.json): wireframe-to-DS component mapping
+
+## Knowledge — Push patterns (Figma authoring)
+
+- [Figma push patterns](https://raw.githubusercontent.com/volivarii/Actian-DS-Claude-plugin/main/plugins/actian-design-system/references/figma/figma-push-patterns.md): core Plugin API patterns + Critical Rules + figma-use compliance
+- [Figma API traps](https://raw.githubusercontent.com/volivarii/Actian-DS-Claude-plugin/main/plugins/actian-design-system/references/figma/figma-api-traps.md): catalogue of methods that throw, properties not bindable, silently-fail patterns
+- [Component-brief push patterns](https://raw.githubusercontent.com/volivarii/Actian-DS-Claude-plugin/main/plugins/actian-design-system/references/component-brief/push-patterns.md): brief-specific patterns (Pattern 0-14)
+- [Create-component push patterns](https://raw.githubusercontent.com/volivarii/Actian-DS-Claude-plugin/main/plugins/actian-design-system/references/create-component/push-patterns.md): component authoring patterns
+
+## Optional
+
+- [CLAUDE.md (always-loaded plugin context)](https://raw.githubusercontent.com/volivarii/Actian-DS-Claude-plugin/main/plugins/actian-design-system/CLAUDE.md)
+- [Plugin architecture map](https://raw.githubusercontent.com/volivarii/Actian-DS-Claude-plugin/main/plugins/actian-design-system/ARCHITECTURE.md)
+- [Component guidelines (85 JSON files, 44 curated)](https://github.com/volivarii/Actian-DS-Claude-plugin/tree/main/plugins/actian-design-system/docs/component-guidelines): per-component guideline JSONs
+- [Foundations subtree (8 JSON files)](https://github.com/volivarii/Actian-DS-Claude-plugin/tree/main/plugins/actian-design-system/docs/foundations): per-foundation JSON authored docs
+- [Presentation guide](https://raw.githubusercontent.com/volivarii/Actian-DS-Claude-plugin/main/plugins/actian-design-system/docs/presentation-guide.md): generate-presentation skill content patterns

--- a/plugins/actian-design-system/.claude-plugin/plugin.json
+++ b/plugins/actian-design-system/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "actian-design-system",
   "description": "Actian Design System toolkit — sync tokens from Figma, generate wireframe flows with prototype wiring, create component briefs, audit designs, compare flows, and build presentations. 9 skills (with tiered generation: recognized / adapted / improvised), 8 agents, 155 tokens (3 themes, 8 collections), WCAG 2.1 AA.",
-  "version": "1.75.0",
+  "version": "1.76.0",
   "author": {
     "name": "Actian UX Team"
   },

--- a/plugins/actian-design-system/docs/llms-overview.md
+++ b/plugins/actian-design-system/docs/llms-overview.md
@@ -1,0 +1,55 @@
+# Actian Design System — AI agent orientation
+
+This document orients AI coding agents to the Actian DS plugin's content
+structure. For the canonical entry-point index, see `/llms.txt` at the
+repo root.
+
+## What this plugin is
+
+Actian's federated DS substrate, packaged as a Claude Code plugin. Provides
+9 skills (component-brief, generate-flow, generate-presentation,
+create-component, convert-to-hifi, design-audit, compare-flows, companion,
+sync-design-system) that author and audit Figma designs against the
+Actian DS via the official Figma MCP server.
+
+## How knowledge is structured
+
+| Layer | Location | Format | Purpose |
+|---|---|---|---|
+| Tokens | `tokens/actian-ds.tokens.json` | DTCG JSON | 155 tokens, 3 themes, 8 collections |
+| Component registries | `docs/generated/{fmkit,dskit,metakit}.json` | JSON | Component keys, variants, properties |
+| Component guidelines | `docs/component-guidelines/*.json` | JSON | 85 components (44 curated + 41 stubs) |
+| Foundations | `docs/foundations/*.json` + `docs/foundations.md` | JSON + MD | Spacing, typography, color, motion |
+| Content guidelines | `docs/content-guidelines.md` | MD | Voice, tone, copy patterns |
+| Accessibility | `docs/accessibility-guidelines.md` | MD | WCAG 2.1 AA conformance rules |
+| App context | `docs/generated/app-context.json` | JSON | Apps, entities, terminology, patterns |
+| FM↔DS map | `docs/generated/fm-to-ds-map.json` | JSON | Wireframe-to-DS component mapping |
+| Skill behavior | `plugins/actian-design-system/skills/*/SKILL.md` | MD | Per-skill instructions and references |
+| Push patterns | `references/figma/figma-push-patterns.md` + `references/component-brief/push-patterns.md` | MD | Figma Plugin API patterns |
+
+## Reading order for new AI agents
+
+1. **Start at `/llms.txt`** — the canonical index.
+2. **For Figma write tasks:** read `figma-use` SKILL.md (upstream) → our `references/figma/figma-push-patterns.md` → relevant skill's SKILL.md.
+3. **For DS knowledge questions:** consult tokens + component registries + relevant guideline.
+4. **For brief generation specifically:** see `plugins/actian-design-system/skills/component-brief/SKILL.md`.
+
+## Federation status (2026-05-09)
+
+This plugin is in a transitional state. Phase 0 (this surface) makes
+existing content AI-discoverable via `llms.txt`. Phase 1 (in progress)
+will move the knowledge layer to a separate `actian-ds-knowledge` repo;
+the plugin will then vendor snapshots at release time. URLs in `llms.txt`
+will migrate when Phase 1 lands; AI agents should re-fetch `llms.txt` if
+their cached version is more than ~1 month old.
+
+## Plugin substrate
+
+Built on Anthropic's Claude Code plugin format (SKILL.md, plugin.json,
+hooks, MCP integration). The Figma MCP server (Figma's official plugin
+at `claude plugin install figma@claude-plugins-official`) provides the
+canvas-write surface; our skills layer Actian-specific patterns on top.
+
+## License
+
+UNLICENSED. Internal Actian use.


### PR DESCRIPTION
## Summary

Federation Phase 0 — make Actian DS knowledge AI-discoverable from outside the plugin via two artifacts:

- **`/llms.txt`** at repo root — AI agent index following the emerging open [llms.txt convention](https://llmstxt.org/). Lists 23 canonical entry points (foundations, content, accessibility, tokens, registries, push patterns, skill orientation) in priority order.
- **`plugins/actian-design-system/docs/llms-overview.md`** — concise orientation doc for AI agents. Explains how DS knowledge is organized across tokens, registries, guidelines, and skills, with a recommended reading order for Figma write tasks vs DS knowledge questions vs brief generation.

This is the smallest possible federation ship. Pairs with PR #33 (federation wedge, currently open) — both are open invitations to AI agents to consume Actian DS content from canonical entry points.

## Why MINOR (v1.76.0)

Introduces a new federated-discoverability surface that's observable to AI consumers via `/llms.txt` fetches. Net-positive but observable, hence MINOR rather than PATCH.

## URL strategy

URLs in `llms.txt` are GitHub raw (`raw.githubusercontent.com/volivarii/Actian-DS-Claude-plugin/main/...`) — **explicitly throwaway-by-design**. Phase 1 (`actian-ds-knowledge` repo) will migrate them with a one-line `llms.txt` update when the dedicated repo lands. AI agents fetch live, not cached, so the URL change is atomic with zero stale-cache risk.

Considered alternatives:
- **GitHub Pages**: rejected for Phase 0. ½ day setup for infra we throw away in 3-4 weeks.
- **Defer until Phase 1**: rejected. Loses the immediate AI-agent-discoverability win that pays off before Phase 1 lands.

## What enables this

Any AI agent that follows the `llms.txt` convention (Cursor, Claude.ai, Codex, Copilot, etc.) can now discover Actian DS canonical entry points by fetching `https://raw.githubusercontent.com/volivarii/Actian-DS-Claude-plugin/main/llms.txt`.

## Test plan

- [x] 948/948 tests pass throughout — no code changes
- [x] URL verification: every `raw.githubusercontent.com/...` URL in `llms.txt` maps to an existing file on the branch (the implementer caught one path drift — `docs/fm-to-ds-map.json` was actually at `docs/generated/fm-to-ds-map.json` — and fixed it before commit)
- [x] path-validation test passes (relative `./llms.txt` link in README resolves; orientation MD's relative paths resolve)
- [ ] **Live verification (post-merge):** fetch `https://raw.githubusercontent.com/volivarii/Actian-DS-Claude-plugin/main/llms.txt` and click through 2-3 entry points to confirm content renders cleanly.

## What's NOT in this PR

- No `actian-ds-knowledge` repo standup (Phase 1, ~3-4 weeks).
- No `/sync-design-system` decommission (Phase 1; multi-step parallel-change discipline per MIGRATIONS.md).
- No GitHub Pages setup (deferred — raw URLs are throwaway-by-design).
- No auto-generation pipeline for `.md` views of JSON content (rejected as out-of-scope; AI agents handle JSON natively for self-describing content).
- No Carbon for AI affordance vocabulary integration (separate Tier 2 track).

## Spec / strategy

- `plugins/actian-design-system/docs/superpowers/plans/2026-05-09-federation-phase-0.md` (untracked working artifact)
- `memory/project_federated_substrate.md` (federation strategy memo, 2026-05-07)

## What's next

Federation Phase 1: stand up `actian-ds-knowledge` repo, migrate components + registries + tokens + foundations + content + accessibility, plugin vendoring CI, parallel-change `/sync-design-system` decommission. ~3-4 weeks. Coordinated with Jeff (content fold-in) and Kristina (foundations push access).

🤖 Generated with [Claude Code](https://claude.com/claude-code)