### PR TITLE
feat(federation): rewrite consumer paths to vendor/ (Phase 1.4b, v1.78.0)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,10 +6,12 @@
 settings.json
 
 # Generated output (teammates create their own via skills)
-components/
-flows/
-presentations/
-prototypes/
+# Anchored to repo root so they don't accidentally match nested
+# directories like plugins/*/vendor/components/.
+/components/
+/flows/
+/presentations/
+/prototypes/
 
 # Annotation files (browser preview artifacts)
 .annotations.json

--- a/llms.txt
+++ b/llms.txt
@@ -2,7 +2,7 @@
 
 > Actian's design system, packaged as a Claude Code plugin. 9 skills for authoring and auditing Figma designs against the Actian DS via the official Figma MCP server. 155 tokens (3 themes, 8 collections), 107 DS Kit components, 33 FM Kit wireframe components, 25 Meta Kit + 3 templates.
 
-The Actian DS is in a federated transition (2026-05-09): knowledge layer is currently bundled with the plugin but moving to a dedicated `actian-ds-knowledge` repo in Phase 1. Until then, this `llms.txt` indexes content at GitHub raw URLs on the `main` branch.
+The Actian DS is in a federated configuration (2026-05-09): the **knowledge layer** lives in [`volivarii/actian-ds-knowledge`](https://github.com/volivarii/actian-ds-knowledge); this plugin vendors a pinned snapshot at release time. The URLs below point AI agents at the canonical knowledge repo. The plugin's own AI orientation, push patterns, and skill code are linked at the bottom under "Plugin meta-docs".
 
 ## Docs
 
@@ -12,27 +12,25 @@ The Actian DS is in a federated transition (2026-05-09): knowledge layer is curr
 
 ## Knowledge — Foundations
 
-- [Foundations canonical doc](https://raw.githubusercontent.com/volivarii/Actian-DS-Claude-plugin/main/plugins/actian-design-system/docs/foundations.md): MD-as-SoT for spacing, typography, color, motion
-- [Foundations authoring guide](https://raw.githubusercontent.com/volivarii/Actian-DS-Claude-plugin/main/plugins/actian-design-system/docs/foundations-authoring.md): how to update foundations
-- [Tokens (DTCG JSON)](https://raw.githubusercontent.com/volivarii/Actian-DS-Claude-plugin/main/plugins/actian-design-system/tokens/actian-ds.tokens.json): 155 tokens, 3 themes
-- [Tokens (CSS)](https://raw.githubusercontent.com/volivarii/Actian-DS-Claude-plugin/main/plugins/actian-design-system/tokens/actian-ds.tokens.css): CSS custom property form
+- [Foundations canonical doc](https://raw.githubusercontent.com/volivarii/actian-ds-knowledge/main/foundations/foundations.md): MD-as-SoT for spacing, typography, color, motion
+- [Foundations authoring guide](https://raw.githubusercontent.com/volivarii/actian-ds-knowledge/main/foundations/AUTHORING.md): how to update foundations
+- [Tokens (DTCG JSON)](https://raw.githubusercontent.com/volivarii/actian-ds-knowledge/main/tokens/tokens.json): 155 tokens, 3 themes
+- [Tokens (CSS)](https://raw.githubusercontent.com/volivarii/actian-ds-knowledge/main/tokens/tokens.css): CSS custom property form
 
 ## Knowledge — Content & Accessibility
 
-- [Content guidelines](https://raw.githubusercontent.com/volivarii/Actian-DS-Claude-plugin/main/plugins/actian-design-system/docs/content-guidelines.md): voice, tone, copy patterns
-- [Accessibility guidelines](https://raw.githubusercontent.com/volivarii/Actian-DS-Claude-plugin/main/plugins/actian-design-system/docs/accessibility-guidelines.md): WCAG 2.1 AA conformance
+- [Content guidelines](https://raw.githubusercontent.com/volivarii/actian-ds-knowledge/main/content/content.md): voice, tone, copy patterns
+- [Accessibility guidelines](https://raw.githubusercontent.com/volivarii/actian-ds-knowledge/main/accessibility/accessibility.md): WCAG 2.1 AA conformance
 
 ## Knowledge — Components
 
-- [DS Kit registry](https://raw.githubusercontent.com/volivarii/Actian-DS-Claude-plugin/main/plugins/actian-design-system/docs/generated/dskit.json): 107 design system components with keys, variants, and properties
-- [DS Kit components (MD)](https://raw.githubusercontent.com/volivarii/Actian-DS-Claude-plugin/main/plugins/actian-design-system/docs/generated/dskit-components.md): human-readable mirror with required-override callouts
-- [FM Kit registry](https://raw.githubusercontent.com/volivarii/Actian-DS-Claude-plugin/main/plugins/actian-design-system/docs/generated/fmkit.json): 33 wireframe components
-- [FM Kit components (MD)](https://raw.githubusercontent.com/volivarii/Actian-DS-Claude-plugin/main/plugins/actian-design-system/docs/generated/fm-components.md): human-readable mirror
-- [Meta Kit registry](https://raw.githubusercontent.com/volivarii/Actian-DS-Claude-plugin/main/plugins/actian-design-system/docs/generated/metakit.json): 25 components + 3 templates
-- [App context](https://raw.githubusercontent.com/volivarii/Actian-DS-Claude-plugin/main/plugins/actian-design-system/docs/generated/app-context.json): apps, entities, terminology, patterns
-- [FM↔DS map](https://raw.githubusercontent.com/volivarii/Actian-DS-Claude-plugin/main/plugins/actian-design-system/docs/generated/fm-to-ds-map.json): wireframe-to-DS component mapping
+- [DS Kit registry](https://raw.githubusercontent.com/volivarii/actian-ds-knowledge/main/components/registries/dskit.json): 107 design system components with keys, variants, and properties
+- [FM Kit registry](https://raw.githubusercontent.com/volivarii/actian-ds-knowledge/main/components/registries/fmkit.json): 33 wireframe components
+- [Meta Kit registry](https://raw.githubusercontent.com/volivarii/actian-ds-knowledge/main/components/registries/metakit.json): 25 components + 3 templates
+- [App context](https://raw.githubusercontent.com/volivarii/actian-ds-knowledge/main/app-context/app-context.json): apps, entities, terminology, patterns
+- [FM↔DS map](https://raw.githubusercontent.com/volivarii/actian-ds-knowledge/main/fm-to-ds-map/fm-to-ds-map.json): wireframe-to-DS component mapping
 
-## Knowledge — Push patterns (Figma authoring)
+## Plugin meta-docs (push patterns + skill code)
 
 - [Figma push patterns](https://raw.githubusercontent.com/volivarii/Actian-DS-Claude-plugin/main/plugins/actian-design-system/references/figma/figma-push-patterns.md): core Plugin API patterns + Critical Rules + figma-use compliance
 - [Figma API traps](https://raw.githubusercontent.com/volivarii/Actian-DS-Claude-plugin/main/plugins/actian-design-system/references/figma/figma-api-traps.md): catalogue of methods that throw, properties not bindable, silently-fail patterns
@@ -43,6 +41,7 @@ The Actian DS is in a federated transition (2026-05-09): knowledge layer is curr
 
 - [CLAUDE.md (always-loaded plugin context)](https://raw.githubusercontent.com/volivarii/Actian-DS-Claude-plugin/main/plugins/actian-design-system/CLAUDE.md)
 - [Plugin architecture map](https://raw.githubusercontent.com/volivarii/Actian-DS-Claude-plugin/main/plugins/actian-design-system/ARCHITECTURE.md)
-- [Component guidelines (85 JSON files, 44 curated)](https://github.com/volivarii/Actian-DS-Claude-plugin/tree/main/plugins/actian-design-system/docs/component-guidelines): per-component guideline JSONs
-- [Foundations subtree (8 JSON files)](https://github.com/volivarii/Actian-DS-Claude-plugin/tree/main/plugins/actian-design-system/docs/foundations): per-foundation JSON authored docs
+- [Knowledge repo README](https://raw.githubusercontent.com/volivarii/actian-ds-knowledge/main/README.md): federation status, repo layout, CI workflows
+- [Component guidelines (85 JSON files, 44 curated)](https://github.com/volivarii/actian-ds-knowledge/tree/main/components/guidelines): per-component guideline JSONs
+- [Foundations subtree (8 JSON files)](https://github.com/volivarii/actian-ds-knowledge/tree/main/foundations): per-foundation JSON files derived from foundations.md
 - [Presentation guide](https://raw.githubusercontent.com/volivarii/Actian-DS-Claude-plugin/main/plugins/actian-design-system/docs/presentation-guide.md): generate-presentation skill content patterns

--- a/plugins/actian-design-system/.claude-plugin/plugin.json
+++ b/plugins/actian-design-system/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "actian-design-system",
   "description": "Actian Design System toolkit — sync tokens from Figma, generate wireframe flows with prototype wiring, create component briefs, audit designs, compare flows, and build presentations. 9 skills (with tiered generation: recognized / adapted / improvised), 8 agents, 155 tokens (3 themes, 8 collections), WCAG 2.1 AA.",
-  "version": "1.77.0",
+  "version": "1.78.0",
   "author": {
     "name": "Actian UX Team"
   },

--- a/plugins/actian-design-system/CLAUDE.md
+++ b/plugins/actian-design-system/CLAUDE.md
@@ -52,11 +52,11 @@ This applies to freelance diagnostics too — if you're tempted to `node -e` som
 Data flows: `Figma -> /sync-design-system (MCP) -> docs/ + tokens/`. JSON is source of truth; Markdown is for human review.
 
 **Key data files** — JSON registries are SoT; `*-components.md` are auto-regenerated mirrors via `/sync-design-system` Phase 1:
-- `docs/component-guidelines/*.json` — 85 component guidelines (44 fully curated + 41 auto-stubs awaiting authoring; stubs carry `_stub: true`)
-- `docs/generated/fmkit.json` / `docs/generated/dskit.json` / `docs/generated/metakit.json` — component registries (keys, variants, properties, defaults)
+- `vendor/components/guidelines/*.json` — 85 component guidelines (44 fully curated + 41 auto-stubs awaiting authoring; stubs carry `_stub: true`)
+- `vendor/components/registries/fmkit.json` / `vendor/components/registries/dskit.json` / `vendor/components/registries/metakit.json` — component registries (keys, variants, properties, defaults)
 - `docs/generated/fm-components.md` / `docs/generated/dskit-components.md` / `docs/generated/meta-kit/components.md` — human-readable mirrors with required-override callouts
-- `docs/generated/app-context.json` — structured app context (apps, entities, terminology, patterns)
-- `tokens/actian-ds.tokens.json` — W3C DTCG tokens (3 themes)
+- `vendor/app-context/app-context.json` — structured app context (apps, entities, terminology, patterns)
+- `vendor/tokens/tokens.json` — W3C DTCG tokens (3 themes)
 
 **Scripts** (utilities — NOT used for Figma push):
 - `scripts/renderers/assemble-preview.js` — generates HTML previews from data models
@@ -94,9 +94,9 @@ Every output includes a generation card (first element) with: skill name, prompt
 
 ## Design System Rules
 
-- **Tokens:** `tokens/actian-ds.tokens.json` (source of truth). For HTML: `var(--zen-color-theme-primary)`, never hardcoded hex.
-- **Content guidelines:** `docs/content-guidelines.md`
-- **Accessibility:** `docs/accessibility-guidelines.md` — WCAG 2.1 AA
+- **Tokens:** `vendor/tokens/tokens.json` (source of truth). For HTML: `var(--zen-color-theme-primary)`, never hardcoded hex.
+- **Content guidelines:** `vendor/content/content.md`
+- **Accessibility:** `vendor/accessibility/accessibility.md` — WCAG 2.1 AA
 - **Never hardcode:** colors, fonts, spacing, radius, shadows, icons. Use tokens. FM outputs use `--fm-*` variables only.
 - **Component instances:** set ALL properties (variants, text, booleans, nested). See `references/ds-rules/component-instance-rules.md`.
 - **Library gaps:** check catalog before custom frames. See `references/ds-rules/library-gap-detection.md`.

--- a/plugins/actian-design-system/docs/llms-overview.md
+++ b/plugins/actian-design-system/docs/llms-overview.md
@@ -14,34 +14,46 @@ Actian DS via the official Figma MCP server.
 
 ## How knowledge is structured
 
-| Layer | Location | Format | Purpose |
-|---|---|---|---|
-| Tokens | `tokens/actian-ds.tokens.json` | DTCG JSON | 155 tokens, 3 themes, 8 collections |
-| Component registries | `docs/generated/{fmkit,dskit,metakit}.json` | JSON | Component keys, variants, properties |
-| Component guidelines | `docs/component-guidelines/*.json` | JSON | 85 components (44 curated + 41 stubs) |
-| Foundations | `docs/foundations/*.json` + `docs/foundations.md` | JSON + MD | Spacing, typography, color, motion |
-| Content guidelines | `docs/content-guidelines.md` | MD | Voice, tone, copy patterns |
-| Accessibility | `docs/accessibility-guidelines.md` | MD | WCAG 2.1 AA conformance rules |
-| App context | `docs/generated/app-context.json` | JSON | Apps, entities, terminology, patterns |
-| FM↔DS map | `docs/generated/fm-to-ds-map.json` | JSON | Wireframe-to-DS component mapping |
-| Skill behavior | `plugins/actian-design-system/skills/*/SKILL.md` | MD | Per-skill instructions and references |
-| Push patterns | `references/figma/figma-push-patterns.md` + `references/component-brief/push-patterns.md` | MD | Figma Plugin API patterns |
+The DS knowledge layer lives in
+[`volivarii/actian-ds-knowledge`](https://github.com/volivarii/actian-ds-knowledge)
+(federated). The plugin vendors a pinned snapshot at release time into
+`vendor/`. AI agents working with the plugin can read either the
+vendored copy or the canonical knowledge repo directly — both are kept
+in sync via the plugin's `vendor-snapshot.yml` workflow.
+
+| Layer | Vendor (in plugin) | Canonical (knowledge repo) | Format | Purpose |
+|---|---|---|---|---|
+| Tokens | `vendor/tokens/tokens.json` + `tokens.css` | `tokens/` | DTCG JSON + CSS | 155 tokens, 3 themes, 8 collections |
+| Component registries | `vendor/components/registries/{fmkit,dskit,metakit}.json` | `components/registries/` | JSON | Component keys, variants, properties |
+| Component guidelines | `vendor/components/guidelines/*.json` | `components/guidelines/` | JSON | 85 components (44 curated + 41 stubs) |
+| Foundations | `vendor/foundations/foundations.md` + `vendor/foundations/*.json` | `foundations/` | MD + JSON | Spacing, typography, color, motion (8 derived) |
+| Content guidelines | `vendor/content/content.md` | `content/` | MD | Voice, tone, copy patterns |
+| Accessibility | `vendor/accessibility/accessibility.md` | `accessibility/` | MD | WCAG 2.1 AA conformance rules |
+| App context | `vendor/app-context/app-context.json` | `app-context/` | JSON | Apps, entities, terminology, patterns |
+| FM↔DS map | `vendor/fm-to-ds-map/fm-to-ds-map.json` | `fm-to-ds-map/` | JSON | Wireframe-to-DS component mapping |
+| Skill behavior | `plugins/actian-design-system/skills/*/SKILL.md` | (plugin only) | MD | Per-skill instructions and references |
+| Push patterns | `references/figma/figma-push-patterns.md` + `references/component-brief/push-patterns.md` | (plugin only) | MD | Figma Plugin API patterns |
 
 ## Reading order for new AI agents
 
-1. **Start at `/llms.txt`** — the canonical index.
+1. **Start at `/llms.txt`** — the canonical index, points at knowledge repo URLs.
 2. **For Figma write tasks:** read `figma-use` SKILL.md (upstream) → our `references/figma/figma-push-patterns.md` → relevant skill's SKILL.md.
-3. **For DS knowledge questions:** consult tokens + component registries + relevant guideline.
+3. **For DS knowledge questions:** consult tokens + component registries + relevant guideline. URLs in `llms.txt` resolve to the knowledge repo; in-plugin code paths read from `vendor/`.
 4. **For brief generation specifically:** see `plugins/actian-design-system/skills/component-brief/SKILL.md`.
 
 ## Federation status (2026-05-09)
 
-This plugin is in a transitional state. Phase 0 (this surface) makes
-existing content AI-discoverable via `llms.txt`. Phase 1 (in progress)
-will move the knowledge layer to a separate `actian-ds-knowledge` repo;
-the plugin will then vendor snapshots at release time. URLs in `llms.txt`
-will migrate when Phase 1 lands; AI agents should re-fetch `llms.txt` if
-their cached version is more than ~1 month old.
+Phase 1 of the federation arc is shipping incrementally:
+
+- ✅ Phase 0 — `llms.txt` index + this orientation doc (v1.76.0)
+- ✅ Phase 1.1 — knowledge repo standup, components/registries + 85 guidelines
+- ✅ Phase 1.2 — foundations migration
+- ✅ Phase 1.3 — tokens + content + accessibility + app-context + fm-to-ds-map
+- ✅ Phase 1.4a — vendoring infrastructure (v1.77.0)
+- ✅ Phase 1.4b — path remap (v1.78.0, plugin code reads from `vendor/`)
+- ⏳ Phase 1.5 — `/sync-design-system` decommission (after Smoke pass #2; multi-week parallel-change discipline)
+
+Knowledge repo CI workflows (sync-from-figma.yml, foundations-derive.yml) keep the content fresh in parallel with the plugin's existing `/sync-design-system` skill until decommission completes.
 
 ## Plugin substrate
 

--- a/plugins/actian-design-system/references/component-brief/data-schema.md
+++ b/plugins/actian-design-system/references/component-brief/data-schema.md
@@ -436,7 +436,7 @@ FM mode uses a simpler 5-card schema. The `meta.library` field is `"fm"` — ren
 
 ## Component-guideline `anatomyScale` field (v1.70.0+)
 
-Optional integer field on `docs/component-guidelines/<slug>.json`. Overrides the Pattern 9 anatomy diagram's automatic scale heuristic. Valid values: 1, 2, 3, or 4.
+Optional integer field on `vendor/components/guidelines/<slug>.json`. Overrides the Pattern 9 anatomy diagram's automatic scale heuristic. Valid values: 1, 2, 3, or 4.
 
 The default heuristic in `scripts/lib/anatomy-scale.js` `pickScale(width, height)` picks the smallest scale where the smaller instance dimension exceeds 80px (e.g., 16×16 Checkbox → 4×, 60×60 → 2×, 200×200 → 1×). The override is useful when the heuristic produces too-small a diagram for a specific component family.
 

--- a/plugins/actian-design-system/references/component-brief/push-patterns.md
+++ b/plugins/actian-design-system/references/component-brief/push-patterns.md
@@ -104,7 +104,7 @@ Every brief MUST start with a GenLog card as the first child of the wrapper. Imp
 
 **Source values from `brief-data.json.meta`, never from this example.** The values shown below are placeholders — using them literally produces wrong GenLog content (e.g., a stale plugin version). The data-model values were sourced in Step 2 from authoritative inputs (`plugin.json`, the runtime model name, etc.) — pass them through verbatim.
 
-**CRITICAL — property keys MUST be hash-suffixed.** GenLog's properties are typed as `Skill#3:0`, `Prompt#3:1`, `Date#3:2`, `Duration#3:3`, `Model#3:4`, `Plugin Version#3:5`. Bare keys (`"Skill"`, `"Prompt"`, etc.) silently fail with `setProperties` errors and require a recovery round-trip via `node.componentProperties` introspection. Use the suffixed keys verbatim — they are stable across Meta Kit publishes (tracked in `docs/generated/metakit.json`).
+**CRITICAL — property keys MUST be hash-suffixed.** GenLog's properties are typed as `Skill#3:0`, `Prompt#3:1`, `Date#3:2`, `Duration#3:3`, `Model#3:4`, `Plugin Version#3:5`. Bare keys (`"Skill"`, `"Prompt"`, etc.) silently fail with `setProperties` errors and require a recovery round-trip via `node.componentProperties` introspection. Use the suffixed keys verbatim — they are stable across Meta Kit publishes (tracked in `vendor/components/registries/metakit.json`).
 
 ```js
 // IMPORTANT: read these from your brief-data.json `meta` block, not from the example below.
@@ -1738,7 +1738,7 @@ Skip if both are unbound (most common case).
 
 1. **Each `use_figma` call creates 1-3 nodes max** — keep calls small (200-2000 bytes typical, up to 6KB for anatomy diagram).
 2. **Return IDs from every call** — use them in subsequent calls to append children.
-3. **Prefer `setProperties` over detach+findOne** — use hash-suffixed property names from `docs/generated/metakit.json`. Only detach when you need to append children into content slots (briefCard, a11yCard). Templates like Swatch Row, A11y Spec Row, Code Block work best as live instances.
+3. **Prefer `setProperties` over detach+findOne** — use hash-suffixed property names from `vendor/components/registries/metakit.json`. Only detach when you need to append children into content slots (briefCard, a11yCard). Templates like Swatch Row, A11y Spec Row, Code Block work best as live instances.
 4. **No interpreter, no codegen scripts** — push directly from data model.
 5. **Detach only when needed** — briefCard and a11yCard must be detached before appending children to content slots. Do NOT detach Swatch Row, A11y Spec Row, Contrast Badge, or Code Block.
-6. **Set ALL properties** — never leave default placeholder text. Check `docs/generated/metakit.json` for exact property names with `#hash` suffixes.
+6. **Set ALL properties** — never leave default placeholder text. Check `vendor/components/registries/metakit.json` for exact property names with `#hash` suffixes.

--- a/plugins/actian-design-system/references/component-brief/render-table-tool.md
+++ b/plugins/actian-design-system/references/component-brief/render-table-tool.md
@@ -75,7 +75,7 @@ Row shape:
 Cell discriminator types (the `type` field always comes first):
 
 - **`text`** — `{ type, value, weight? }` — `weight` is `"regular"` (default) or `"semibold"`.
-- **`token-pill`** — `{ type, value }` — `value` must start with `--zen-` and exists in `tokens/actian-ds.tokens.json`.
+- **`token-pill`** — `{ type, value }` — `value` must start with `--zen-` and exists in `vendor/tokens/tokens.json`.
 - **`code`** — `{ type, value }` — rendered in Fira Code monospace.
 - **`badge`** — `{ type, variant, label? }` — `variant` is `req | opt | draft | stub | canonical`.
 - **`color-swatch`** — `{ type, color, tokenName?, hex? }` — `color` is the swatch dot fill (hex `#RRGGBB`); `tokenName` optionally renders a token-pill above the hex line.
@@ -124,7 +124,7 @@ Before emitting JS, the interpreter validates:
 
 - JSON Schema conformance (shape, required fields, enum values).
 - `additionalProperties: false` on spec root, rows, footnotes, and every cell discriminator.
-- Token names (`token-pill.value`, `color-swatch.tokenName`) against `tokens/actian-ds.tokens.json`.
+- Token names (`token-pill.value`, `color-swatch.tokenName`) against `vendor/tokens/tokens.json`.
 - Cell-count per row matches `headers.length`.
 - Every `row.footnoteRef` resolves to a `footnotes[].ref` entry.
 

--- a/plugins/actian-design-system/references/context/companion-context.md
+++ b/plugins/actian-design-system/references/context/companion-context.md
@@ -55,7 +55,7 @@ Read this on every companion activation. For detailed info, read the full refere
 
 **Theme overrides:** Studio `theme-primary` = `#0283BE`. Explorer `theme-primary` = `#049B98`. Most text/border tokens also differ — always use token names, never hardcode hex.
 
-Full reference: `docs/generated/token-reference.md` | Source of truth: `tokens/actian-ds.tokens.json`
+Full reference: `docs/generated/token-reference.md` | Source of truth: `vendor/tokens/tokens.json`
 
 ## FM Outputs (lo-fi wireframes)
 
@@ -77,7 +77,7 @@ See: `references/ds-rules/fm-css-reference.md`
 | Lists | Oxford comma, parallel structure | Mixed structures |
 | Tone | Professional, clear, helpful | Cute, clever, apologetic |
 
-Full guidelines: `docs/content-guidelines.md`
+Full guidelines: `vendor/content/content.md`
 
 ## Actian Apps
 
@@ -108,7 +108,7 @@ Full context: `references/context/app-context.md`
 | FM Kit | 44 components | Inter | Lo-fi wireframes, FM palette |
 | Meta Kit | 25 components + 3 templates | Inter | Generation output, annotation markers |
 
-Before building custom frames, check: `docs/generated/dskit-components.md`, `docs/generated/fm-components.md`, `docs/component-guidelines/{name}.json`
+Before building custom frames, check: `docs/generated/dskit-components.md`, `docs/generated/fm-components.md`, `vendor/components/guidelines/{name}.json`
 
 **Common FM wireframe components:** fmButton, fmTextInput, fmDropdown, fmSearchInput, fmTableCell, fmCheckbox, fmRadioButton, fmToggle, fmAlert, fmBanner, fmDialog, fmEmptyState, fmPlaceholder, fmTab, fmStepper, fmBadge, fmTag, fmToast, fmPageHeader, fmAppHeader, fmNavItem
 
@@ -131,9 +131,9 @@ All skills push to Figma using direct `use_figma` calls. No codegen scripts at p
 
 | Topic | File |
 |-------|------|
-| Specific component rules | `docs/component-guidelines/{name}.json` |
-| Accessibility standards | `docs/accessibility-guidelines.md` |
-| Foundation (typography, color, etc.) | `docs/foundations/{topic}.json` |
+| Specific component rules | `vendor/components/guidelines/{name}.json` |
+| Accessibility standards | `vendor/accessibility/accessibility.md` |
+| Foundation (typography, color, etc.) | `vendor/foundations/{topic}.json` |
 | FM CSS values (wireframes) | `references/ds-rules/fm-css-reference.md` |
 | UX patterns by flow type | `references/context/ux-patterns.md` |
 | Page layout patterns | `references/ds-rules/layout-patterns.md` |

--- a/plugins/actian-design-system/references/create-component/research-and-dependencies.md
+++ b/plugins/actian-design-system/references/create-component/research-and-dependencies.md
@@ -18,7 +18,7 @@ Use `WebSearch` for 2-3 sources. Focus on component API, not visual styling. Fol
 When the build plan includes nested components (e.g., Card containing Button and Badge):
 
 1. Scan build plan for nested component references
-2. Check `../../docs/generated/fmkit.json` or `../../docs/generated/dskit.json` (fast, local). Fallback: `search_design_system`
+2. Check `../../vendor/components/registries/fmkit.json` or `../../vendor/components/registries/dskit.json` (fast, local). Fallback: `search_design_system`
 3. Classify: **Exists** (import key ready) or **Missing** (build first)
 4. If missing: build leaf-to-root (components with no dependencies first), record keys
 5. Report: "Dependencies resolved: FM Button (exists), FM Icon (exists), Custom Badge (building...)"

--- a/plugins/actian-design-system/references/ds-rules/component-instance-rules.md
+++ b/plugins/actian-design-system/references/ds-rules/component-instance-rules.md
@@ -3,8 +3,8 @@
 ## Token mapping
 
 Per-component token lookups are in the synced JSON files — do NOT hardcode from memory:
-- **Per-component guidelines:** `docs/component-guidelines/*.json` (44 components — content rules, design rules, variants)
-- **All token values:** `tokens/actian-ds.tokens.json` (W3C DTCG, 3 themes) + `docs/generated/token-reference.md`
+- **Per-component guidelines:** `vendor/components/guidelines/*.json` (44 components — content rules, design rules, variants)
+- **All token values:** `vendor/tokens/tokens.json` (W3C DTCG, 3 themes) + `docs/generated/token-reference.md`
 - **Variable keys for Figma binding:** `docs/generated/meta-kit/variables.md` (115 keys)
 - **FM palette:** `references/ds-rules/fm-css-reference.md`
 

--- a/plugins/actian-design-system/references/figma/figma-output.md
+++ b/plugins/actian-design-system/references/figma/figma-output.md
@@ -288,7 +288,7 @@ When Meta Kit template components are available, use clone-and-fill instead of c
 
 ### How it works
 
-1. **Read registry:** Load `../../docs/generated/metakit.json` at the start of the skill (before `use_figma`)
+1. **Read registry:** Load `../../vendor/components/registries/metakit.json` at the start of the skill (before `use_figma`)
 2. **Import template:** `figma.importComponentByKeyAsync(registry.templates['table-header-row'].key)`
 3. **Clone and detach:** `comp.createInstance()` → `instance.detachInstance()` — gives a mutable frame
 4. **Show:** Set `visible = true` on the detached frame (templates are hidden by default)
@@ -323,7 +323,7 @@ function fillSlots(frame, slots) {
 
 Templates are hidden components in the Meta Kit Figma library. Each has stable, semantic layer names (e.g., `label`, `value`, `title`) that serve as the contract between the registry and builder scripts.
 
-Registry location: `../../docs/generated/metakit.json`
+Registry location: `../../vendor/components/registries/metakit.json`
 
 Available templates:
 - `table-header-row` — table header cells (slots: `label`)

--- a/plugins/actian-design-system/references/figma/figma-push-patterns.md
+++ b/plugins/actian-design-system/references/figma/figma-push-patterns.md
@@ -13,9 +13,9 @@ Direct Figma Plugin API patterns for pushing content to Figma. Each pattern is a
 
 | Registry | File | Contents |
 |----------|------|----------|
-| FM Kit | `docs/generated/fmkit.json` | 33 wireframe components with keys, variants, and properties |
-| Meta Kit | `docs/generated/metakit.json` | 25 components + 3 templates |
-| DS Kit | `docs/generated/dskit.json` | 107 design system components with keys, variants, and properties |
+| FM Kit | `vendor/components/registries/fmkit.json` | 33 wireframe components with keys, variants, and properties |
+| Meta Kit | `vendor/components/registries/metakit.json` | 25 components + 3 templates |
+| DS Kit | `vendor/components/registries/dskit.json` | 107 design system components with keys, variants, and properties |
 
 Each registry entry contains: `key`, `importMethod` ("set" for `importComponentSetByKeyAsync`, "single" for `importComponentByKeyAsync`), `variants`, and `properties` (with exact hash-suffixed names for `setProperties()`).
 
@@ -281,7 +281,7 @@ inst.name = "Generation Log";
 
 // Set component properties (text, booleans, instance swaps).
 // IMPORTANT: GenLog property keys are hash-suffixed (`Skill#3:0` etc.).
-// Bare keys silently fail. Look up exact suffixes in `docs/generated/metakit.json`
+// Bare keys silently fail. Look up exact suffixes in `vendor/components/registries/metakit.json`
 // for any imported component before calling setProperties.
 inst.setProperties({
   "Skill#3:0": "Skill: generate-flow",
@@ -449,7 +449,7 @@ const subtitleText = inst.query('TEXT[name="Subtitle"]').first();
 if (subtitleText) subtitleText.characters = "Manage team members and permissions";
 ```
 
-**FM Kit property reference** (exact `#hash` property names are in `docs/generated/fmkit.json` — use `setProperties()`):
+**FM Kit property reference** (exact `#hash` property names are in `vendor/components/registries/fmkit.json` — use `setProperties()`):
 
 - **FM Button** — `"Label#1411:32"`: TEXT (default: "Button label"), `"👁 Leading Icon#1410:3"`: BOOLEAN (default: true → **set false**), `"👁 Trailing Icon#1410:6"`: BOOLEAN (default: true → **set false**). Variants: `Size=md|sm`, `Shape=Regular|Pill`, `Type=Primary|Secondary|Outline|Destructive`, `State=Default|Disabled`
 - **FM Text input field** — `"Input Text#1411:57"`: TEXT (default: "Input text"), `"Show label#176:0"`: BOOLEAN, `"👁 Leading Icon#1411:74"`: BOOLEAN (default: false), `"👁 Trailing Icon#1411:76"`: BOOLEAN (default: false). Variants: `Type=Empty|Placeholder|Default|Disabled`. **Nested FM Input Label** exposes: `"Label Text#1555:11"`, `"Caption Text#1555:12"`, `"Caption#1555:9"`: BOOLEAN, `"Required#1555:10"`: BOOLEAN — set on the INPUT instance, not separately.

--- a/plugins/actian-design-system/references/figma/parity-check.md
+++ b/plugins/actian-design-system/references/figma/parity-check.md
@@ -84,7 +84,7 @@ source "${CLAUDE_PLUGIN_ROOT}/scripts/lib/resolve-node.sh"
 "$NODE_BIN" "${CLAUDE_PLUGIN_ROOT}/scripts/changelog/changelog.js" \
   --previous <manifest-path>/.last-push.json \
   --source <source-data-file> \
-  --tokens "${CLAUDE_PLUGIN_ROOT}/tokens/actian-ds.tokens.json"
+  --tokens "${CLAUDE_PLUGIN_ROOT}/vendor/tokens/tokens.json"
 ```
 
 Report the changelog output to the user. If the previous manifest doesn't exist (first push), the script outputs "First push — no changelog" and exits cleanly.
@@ -159,7 +159,7 @@ omit it fall through to greenfield with a documented warning.
 - `pushedAt` — ISO 8601 timestamp at the moment the manifest is written (e.g. `2026-03-27T14:32:00Z`)
 - `sourceHash` — SHA-256 hex digest of the source data file (e.g., `flow-data.json`, `brief-data.json`) at push time. Enables detecting if source data changed since last push.
 - `componentKeys` — deduplicated array of Figma component keys imported during this push. Enables usage analytics and changelog diffs between pushes.
-- `tokenHash` — SHA-256 hex digest of `tokens/actian-ds.tokens.json` at push time. Enables detecting token drift — if tokens changed since last push, outputs may need regeneration.
+- `tokenHash` — SHA-256 hex digest of `vendor/tokens/tokens.json` at push time. Enables detecting token drift — if tokens changed since last push, outputs may need regeneration.
 - `propertyDefaultsHash` — per-kit SHA-256 hex digests of component property defaults (text/boolean default values) at push time. Computed via `computePropertyDefaultsHashes({ fm, ds, meta })` from `scripts/changelog/changelog.js`. Enables detecting when a designer edits component default values upstream between syncs.
 
 **Manifest locations by skill:**
@@ -193,7 +193,7 @@ Before writing the manifest, compute the enrichment fields:
 ```bash
 source "${CLAUDE_PLUGIN_ROOT}/scripts/lib/resolve-node.sh"
 SOURCE_HASH=$("$NODE_BIN" -e "process.stdout.write(require('crypto').createHash('sha256').update(require('fs').readFileSync('$SOURCE_FILE')).digest('hex'))")
-TOKEN_HASH=$("$NODE_BIN" -e "process.stdout.write(require('crypto').createHash('sha256').update(require('fs').readFileSync('${CLAUDE_PLUGIN_ROOT}/tokens/actian-ds.tokens.json')).digest('hex'))")
+TOKEN_HASH=$("$NODE_BIN" -e "process.stdout.write(require('crypto').createHash('sha256').update(require('fs').readFileSync('${CLAUDE_PLUGIN_ROOT}/vendor/tokens/tokens.json')).digest('hex'))")
 PROPERTY_DEFAULTS_HASH=$("$NODE_BIN" -e "
 var changelog = require('${CLAUDE_PLUGIN_ROOT}/scripts/changelog/changelog.js');
 var path = require('path');

--- a/plugins/actian-design-system/scripts/lib/shared-constants.js
+++ b/plugins/actian-design-system/scripts/lib/shared-constants.js
@@ -4,7 +4,8 @@
  * shared-constants.js — Single source of truth for constants used across codegen scripts.
  *
  * Imported by flow-to-figma.js, brief-to-figma.js, and slide-to-figma.js.
- * Component keys and methods are read from registry JSON files (docs/*.json).
+ * Component keys and methods are read from registry JSON files
+ * (vendor/components/registries/*.json — vendored from actian-ds-knowledge).
  * Only the ref-name → slug mapping is maintained here.
  */
 
@@ -12,7 +13,10 @@ const fs = require("fs");
 const path = require("path");
 
 // ---------------------------------------------------------------------------
-// Registry loader — reads JSON registries from docs/generated/
+// Registry loader — reads JSON registries from vendor/components/registries/
+// (Federation Phase 1.4b: vendored from volivarii/actian-ds-knowledge.
+// See vendored.json for the pinned SHA. Run scripts/vendor/vendor-snapshot.js
+// or trigger the vendor-snapshot.yml workflow to refresh.)
 // ---------------------------------------------------------------------------
 
 const _registryCache = {};
@@ -22,8 +26,9 @@ function loadRegistry(name) {
       __dirname,
       "..",
       "..",
-      "docs",
-      "generated",
+      "vendor",
+      "components",
+      "registries",
       name + ".json",
     );
     _registryCache[name] = JSON.parse(fs.readFileSync(filePath, "utf8"));

--- a/plugins/actian-design-system/scripts/renderers/html-renderers/brief-renderer.js
+++ b/plugins/actian-design-system/scripts/renderers/html-renderers/brief-renderer.js
@@ -1260,9 +1260,11 @@
           "This brief is based on registry data only. The DS team has not yet " +
           "curated content / design / a11y guidelines for this component. " +
           "Briefs will improve once the guideline is fleshed out at " +
-          "<code>docs/component-guidelines/" +
+          "<code>vendor/components/guidelines/" +
           slug +
-          ".json</code>.";
+          ".json</code> (in plugin) / <code>components/guidelines/" +
+          slug +
+          ".json</code> (in actian-ds-knowledge).";
         briefRow.appendChild(footer);
       }
     });

--- a/plugins/actian-design-system/scripts/renderers/render-component-reference.js
+++ b/plugins/actian-design-system/scripts/renderers/render-component-reference.js
@@ -15,12 +15,18 @@ var rules = require(
 );
 
 var KIT_HEADERS = {
-  fm: { title: "Fat Marker Kit", source: "docs/generated/fmkit.json" },
+  fm: {
+    title: "Fat Marker Kit",
+    source: "vendor/components/registries/fmkit.json",
+  },
   ds: {
     title: "Actian Design System 2026",
-    source: "docs/generated/dskit.json",
+    source: "vendor/components/registries/dskit.json",
   },
-  meta: { title: "Meta Kit", source: "docs/generated/metakit.json" },
+  meta: {
+    title: "Meta Kit",
+    source: "vendor/components/registries/metakit.json",
+  },
 };
 
 function formatVariants(variants) {

--- a/plugins/actian-design-system/scripts/validation/component-property-rules.js
+++ b/plugins/actian-design-system/scripts/validation/component-property-rules.js
@@ -175,7 +175,7 @@ if (require.main === module) {
         "Looks up required-override TEXT props and default-true booleans per slug.\n",
       );
       process.stdout.write(
-        "fm* slugs read from docs/generated/fmkit.json; others read from docs/generated/dskit.json.\n",
+        "fm* slugs read from vendor/components/registries/fmkit.json; others read from vendor/components/registries/dskit.json.\n",
       );
       process.exit(0);
     }

--- a/plugins/actian-design-system/scripts/validation/validate-flow-data.js
+++ b/plugins/actian-design-system/scripts/validation/validate-flow-data.js
@@ -1285,9 +1285,11 @@ function validate(data, opts) {
       message:
         "Component '" +
         slug +
-        "' uses a stub guideline. Curated content pending — see docs/component-guidelines/" +
+        "' uses a stub guideline. Curated content pending — see vendor/components/guidelines/" +
         slug +
-        ".json",
+        ".json (in plugin) / components/guidelines/" +
+        slug +
+        ".json (in actian-ds-knowledge)",
     });
   });
 

--- a/plugins/actian-design-system/skills/companion/SKILL.md
+++ b/plugins/actian-design-system/skills/companion/SKILL.md
@@ -111,9 +111,9 @@ All three operate on existing URLs. Pick by prose:
 ## Step 4 — Direct help (no skill needed)
 
 - **Design ops:** List findings (current vs. correct value). Spot fixes (wrong token, spacing, auto-layout): fix via `use_figma`, report what changed. Ambiguous fixes: present options first.
-- **Content designer:** Read text from selection, check against `docs/content-guidelines.md`, suggest rewrites with reasoning.
+- **Content designer:** Read text from selection, check against `vendor/content/content.md`, suggest rewrites with reasoning.
 - **A11y specialist:** Check contrast (4.5:1 normal, 3:1 large), touch targets (44x44px min), focus order. For full audit, recommend `/design-audit`.
 - **UX researcher:** Load `references/context/ux-patterns.md`, search by flow type, optionally web search. Ground recommendations in Actian product context.
 - **System librarian:** Draft guideline in existing format, show draft, user approves before any file edit.
 - **Tier review** (signals: "review tier-3", "show improvised screens", "what got improvised", "show deviations" + Figma URL): Read `.last-push.json` for the URL's flow page; for each `pushedNodes` entry where `tier === "improvised"`, or where `tier === "adapted"` with `matchedRecipe` set and `composition` null, print `label`: `justification`. No skill routing — companion handles directly.
-- **Library lookup** (row 16: "find every empty state", "where do we use X", "show me all Y"): grep registries (`docs/generated/dskit.json`, `docs/generated/fmkit.json`, `docs/generated/metakit.json`) and component guidelines, answer inline. No skill needed.
+- **Library lookup** (row 16: "find every empty state", "where do we use X", "show me all Y"): grep registries (`vendor/components/registries/dskit.json`, `vendor/components/registries/fmkit.json`, `vendor/components/registries/metakit.json`) and component guidelines, answer inline. No skill needed.

--- a/plugins/actian-design-system/skills/compare-flows/SKILL.md
+++ b/plugins/actian-design-system/skills/compare-flows/SKILL.md
@@ -65,5 +65,5 @@ A flow with fewer P0s is generally stronger regardless of P1/P2 counts.
 
 - `references/figma/figma-output.md` — Figma URL parsing
 - `references/ds-rules/quality-checklist.md` — cleanup pass checklist (applied to both flows)
-- `docs/content-guidelines.md` — content guideline checks
-- `docs/accessibility-guidelines.md` — accessibility checks
+- `vendor/content/content.md` — content guideline checks
+- `vendor/accessibility/accessibility.md` — accessibility checks

--- a/plugins/actian-design-system/skills/component-brief/SKILL.md
+++ b/plugins/actian-design-system/skills/component-brief/SKILL.md
@@ -24,7 +24,7 @@ Keywords: `"preview"` → HTML; `"playground"` → explorer.
 
 ## Step 1 — Research (ONE parallel batch)
 
-Parse URL (`fileKey` + `nodeId` per `../../references/figma/figma-output.md`). ONE message: (1) classify-node via `use_figma` (see figma-output.md — returns node type, name, children), (2) `docs/component-guidelines/<slug>.json`, (3) `references/component-brief/data-schema.md`. Then: route based on node type — if PAGE, pick the COMPONENT_SET child from the classification response; if COMPONENT_SET, use directly. Call `get_design_context` on the resolved target. Fallback: `get_screenshot`.
+Parse URL (`fileKey` + `nodeId` per `../../references/figma/figma-output.md`). ONE message: (1) classify-node via `use_figma` (see figma-output.md — returns node type, name, children), (2) `vendor/components/guidelines/<slug>.json`, (3) `references/component-brief/data-schema.md`. Then: route based on node type — if PAGE, pick the COMPONENT_SET child from the classification response; if COMPONENT_SET, use directly. Call `get_design_context` on the resolved target. Fallback: `get_screenshot`.
 
 ## Step 1.5 — Present card selection
 
@@ -93,7 +93,7 @@ If the Step 1.5 response opted in to research (e.g., `research all`, `research u
 2. Dispatch the `brief-researcher` agent with:
    - Component name + slug
    - Scoped cards (intersect requested research with research-applicable cards: card_usage, card_content, card_accessibility)
-   - Existing context inlined: `component-guidelines/<slug>.json`, `docs/foundations.md` (relevant excerpts), `docs/content-guidelines.md`, `docs/accessibility-guidelines.md`
+   - Existing context inlined: `component-guidelines/<slug>.json`, `vendor/foundations/foundations.md` (relevant excerpts), `vendor/content/content.md`, `vendor/accessibility/accessibility.md`
    - Output path: `{project_working_directory}/components/[name]/[name]-research-findings.json`
 3. Wait for the agent's DONE / DONE_WITH_CONCERNS / ERROR signal.
 4. On ERROR: ask the user "Research failed: <reason>. Continue without research? (yes/no)". On `yes`, proceed without `research-findings.json`. On `no`, abort.
@@ -112,7 +112,7 @@ Build `ctx`:
 ctx = {
   component, slug, fileKey, nodeId,
   nodeDescription,        // from dskit.json[slug].description (primary), MCP node.description (fallback)
-  guidelinesJson,         // parsed docs/component-guidelines/<slug>.json
+  guidelinesJson,         // parsed vendor/components/guidelines/<slug>.json
   selectedCards           // ["card_header", "card_tokens", ...]
 }
 ```

--- a/plugins/actian-design-system/skills/convert-to-hifi/SKILL.md
+++ b/plugins/actian-design-system/skills/convert-to-hifi/SKILL.md
@@ -140,7 +140,7 @@ source "${CLAUDE_PLUGIN_ROOT}/scripts/lib/resolve-node.sh" && \
     -o {project_working_directory}/components/hifi/[frame-name]-hifi-data.json
 ```
 
-The script reads `docs/generated/fm-to-ds-map.json` and `docs/generated/dskit.json`, rewrites every FM `ref` to its DS Kit equivalent, preserves variant mappings where defined, and embeds `meta.transformStats` in the output (`total`, `mapped`, `unmapped`).
+The script reads `vendor/fm-to-ds-map/fm-to-ds-map.json` and `vendor/components/registries/dskit.json`, rewrites every FM `ref` to its DS Kit equivalent, preserves variant mappings where defined, and embeds `meta.transformStats` in the output (`total`, `mapped`, `unmapped`).
 
 **Confirmation gate** — present verbatim after the script completes:
 
@@ -167,12 +167,12 @@ After confirmation, build and push uninterrupted. Read `references/figma/figma-p
 ### Handling unmapped nodes
 
 For each node flagged `unmapped: true`:
-1. Read `docs/generated/dskit.json` — scan component descriptions and variant axes
+1. Read `vendor/components/registries/dskit.json` — scan component descriptions and variant axes
 2. Infer the best DS Kit match by shape, purpose, and label text
 3. Substitute with the inferred component; log the substitution in the generation card notes
 
 **Common utility components** (not in FM Kit registry but frequently appear):
-- `Meta / Utility / Card Divider` — import by key from `docs/generated/metakit.json`, use as a DS divider
+- `Meta / Utility / Card Divider` — import by key from `vendor/components/registries/metakit.json`, use as a DS divider
 - Manual rectangles used as dividers — replace with a 1px frame, fill `#E2E7F0`, `FILL` width
 
 If the user chose "skip unmapped", omit those nodes entirely.
@@ -189,7 +189,7 @@ Apply DS spacing tokens and layout rules to every container before pushing:
 ### Push sequence (one small `use_figma` call per step)
 
 1. **Create wrapper frame** — same parent as original, named `"[Original name] — HiFi wrapper"`, `HORIZONTAL` auto layout, gap 32, no fills. This holds the gen card and hifi frame side by side.
-2. **Generation card** — import genLog by key from `docs/generated/metakit.json`, create instance, set props with `mode: "hifi"`, `skill: "convert-to-hifi"`, ISO date, prompt excerpt; append to **wrapper** (NOT inside the hifi frame)
+2. **Generation card** — import genLog by key from `vendor/components/registries/metakit.json`, create instance, set props with `mode: "hifi"`, `skill: "convert-to-hifi"`, ISO date, prompt excerpt; append to **wrapper** (NOT inside the hifi frame)
 3. **Create hifi frame** — named `"[Original name] — HiFi"`, 1440×960, `VERTICAL` auto layout; append to **wrapper**
 4. **For each screen / section in hifi-data.json:**
    a. Import DS Kit components needed for this section (batch per section)
@@ -218,9 +218,9 @@ Apply DS spacing tokens and layout rules to every container before pushing:
 
 ## References
 
-- `docs/generated/fm-to-ds-map.json` — FM component key → DS component mapping table with variant axis maps
-- `docs/generated/dskit.json` — DS Kit component registry (keys, variants, properties, descriptions)
-- `docs/generated/fmkit.json` — FM Kit component registry (keys, variants, properties)
+- `vendor/fm-to-ds-map/fm-to-ds-map.json` — FM component key → DS component mapping table with variant axis maps
+- `vendor/components/registries/dskit.json` — DS Kit component registry (keys, variants, properties, descriptions)
+- `vendor/components/registries/fmkit.json` — FM Kit component registry (keys, variants, properties)
 - `scripts/transformers/fm-tree-to-flow-data.js` — converts raw Figma tree to flow-data format (resolves componentKey → FM ref names via FM_SLUGS)
 - `scripts/transformers/transform-to-hifi.js` — deterministic Stage 2 transform (CLI + module API)
 - `references/figma/figma-push-patterns.md` — component keys, push patterns, Plugin API call templates

--- a/plugins/actian-design-system/skills/create-component/SKILL.md
+++ b/plugins/actian-design-system/skills/create-component/SKILL.md
@@ -17,7 +17,7 @@ Determine: component name (FM prefix for Fat Marker), library (FM = Inter, DS Ki
 
 ## Step 2 — Check existing components
 
-Check `../../docs/generated/dskit-components.md` and `../../docs/generated/fm-components.md`. If it exists, suggest modifying instead. Load `../../docs/component-guidelines/<slug>.json` for content/design guidelines if available.
+Check `../../docs/generated/dskit-components.md` and `../../docs/generated/fm-components.md`. If it exists, suggest modifying instead. Load `../../vendor/components/guidelines/<slug>.json` for content/design guidelines if available.
 
 ## Step 3 — Research (optional)
 

--- a/plugins/actian-design-system/skills/design-audit/SKILL.md
+++ b/plugins/actian-design-system/skills/design-audit/SKILL.md
@@ -67,14 +67,14 @@ Parser:
 
 When `--scope` is set, run only the listed dimensions; otherwise run all.
 
-- **Component guidelines** (scope: `tokens`, `all`): Read `../../docs/component-guidelines/<slug>.json` for per-component content/design rules
+- **Component guidelines** (scope: `tokens`, `all`): Read `../../vendor/components/guidelines/<slug>.json` for per-component content/design rules
 - **Component consistency** (scope: `tokens`, `all`): FM-prefixed components used consistently, no detached instances or ad-hoc recreations, names match catalog (`../../docs/generated/fm-components.md`)
 - **Token usage** (scope: `tokens`, `all`): No hardcoded hex colors, typography uses Inter (FM) or Roboto (DS Kit) text style tokens, spacing on scale (4/8/12/16/24/28/32), border radius uses radius tokens
 - **Flow structure** (scope: `all`): Dark cover card with Feature/Flow/User, screen naming `[Persona] - [Page] - [State]`, 1440x960 or 1440x700, left-to-right reading order
 - **Forms layout** (scope: `all`): Simple inputs 480px max-width, extended elements full-width, action footer sticky bottom with primary right
 - **Missing states** (scope: `heuristic`, `all`): Empty, error, loading, confirmation states; form validation, disabled, required indicators
 - **Accessibility** (scope: `a11y`, `all`): WCAG AA contrast, visible focus states, no text below 11px
-- **Copy review** (scope: `copy`, `all`): Sentence case, action-oriented CTA verbs, no jargon, terminology consistent with `docs/generated/app-context.json` glossary, error messages explain what to do next
+- **Copy review** (scope: `copy`, `all`): Sentence case, action-oriented CTA verbs, no jargon, terminology consistent with `vendor/app-context/app-context.json` glossary, error messages explain what to do next
 - **Heuristic UX** (scope: `heuristic`, `all`) — *placeholder, full impl is engine work*: Surface a section in the report titled "Heuristic findings (preview)" describing IA clarity, task efficiency, and feedback patterns. Findings here are advisory until the engine work lands.
 
 ## Output format

--- a/plugins/actian-design-system/skills/generate-flow/SKILL.md
+++ b/plugins/actian-design-system/skills/generate-flow/SKILL.md
@@ -289,7 +289,7 @@ If any condition fails, fall back per the table below.
 - For each `placeholder-text` finding: replace the placeholder string at the indicated path with the real content (typically derivable from `screens[N].name` or the user prompt).
 - For each `missing-required-override` finding: add the missing prop to the INSTANCE node's `props` object with a real value.
 - For each `unknown-component` finding: correct the `ref` slug (the validator suggests near matches via Levenshtein when applicable).
-- For each `hardcoded-color` finding: replace the hex/rgb/`{r,g,b}` literal at the indicated path with a `var(--zen-…)` or `var(--fm-…)` token reference. **Never push hardcoded colors** — see `tokens/actian-ds.tokens.json` for the available token names.
+- For each `hardcoded-color` finding: replace the hex/rgb/`{r,g,b}` literal at the indicated path with a `var(--zen-…)` or `var(--fm-…)` token reference. **Never push hardcoded colors** — see `vendor/tokens/tokens.json` for the available token names.
 - **Do NOT re-dispatch screen-generator agents.** Patch in-place with Edit, then re-run the validator.
 - **Retry cap:** if the same finding kind on the same path persists across 3 consecutive validator runs, stop and surface the validator output to the user. Do not loop further.
 
@@ -434,7 +434,7 @@ After the screen list is approved, build a `_glossary` object and set it on `met
 }
 ```
 
-**Entity properties lookup:** After building the glossary, slugify the entity name (lowercase, replace spaces with hyphens) and look it up in `docs/generated/app-context.json` → `entities[slug]`. If found, set `_glossary.entityProperties` to the entity's `properties` array. Screen-generators use these for form field labels, table column headers, and detail page content instead of generic placeholders.
+**Entity properties lookup:** After building the glossary, slugify the entity name (lowercase, replace spaces with hyphens) and look it up in `vendor/app-context/app-context.json` → `entities[slug]`. If found, set `_glossary.entityProperties` to the entity's `properties` array. Screen-generators use these for form field labels, table column headers, and detail page content instead of generic placeholders.
 
 Example: entity "Data Product" → slug "data-product" → `entities["data-product"].properties` → `["name", "description", "status", "input ports", "output ports", "datasets", "contacts", "attachments"]`
 
@@ -495,7 +495,7 @@ Read `references/figma/figma-push-patterns.md` for component keys and patterns. 
 
 ### HiFi conversion (if --hifi flag)
 
-After FM push completes, delegate to `/convert-to-hifi`. Pass the pushed flow's Figma URL — the skill reads the FM frame, maps to DS Kit using `docs/generated/fm-to-ds-map.json`, applies layout polish, and pushes a sibling frame named `[Flow name] — HiFi`. Generation card carries `mode: "hifi"`.
+After FM push completes, delegate to `/convert-to-hifi`. Pass the pushed flow's Figma URL — the skill reads the FM frame, maps to DS Kit using `vendor/fm-to-ds-map/fm-to-ds-map.json`, applies layout polish, and pushes a sibling frame named `[Flow name] — HiFi`. Generation card carries `mode: "hifi"`.
 
 If `--audit` is also set, run `/design-audit` on the hifi frame after conversion completes (see Flag interaction matrix).
 

--- a/plugins/actian-design-system/tests/fixtures/render-component-reference/expected-ds.md
+++ b/plugins/actian-design-system/tests/fixtures/render-component-reference/expected-ds.md
@@ -1,6 +1,6 @@
 # Actian Design System 2026 — Component Reference
 
-Auto-generated from `docs/generated/dskit.json` by `scripts/renderers/render-component-reference.js`.
+Auto-generated from `vendor/components/registries/dskit.json` by `scripts/renderers/render-component-reference.js`.
 1 components.
 
 ---

--- a/plugins/actian-design-system/tests/fixtures/render-component-reference/expected-fm.md
+++ b/plugins/actian-design-system/tests/fixtures/render-component-reference/expected-fm.md
@@ -1,6 +1,6 @@
 # Fat Marker Kit — Component Reference
 
-Auto-generated from `docs/generated/fmkit.json` by `scripts/renderers/render-component-reference.js`.
+Auto-generated from `vendor/components/registries/fmkit.json` by `scripts/renderers/render-component-reference.js`.
 3 components.
 
 ---

--- a/plugins/actian-design-system/vendor/components/guidelines/_index.json
+++ b/plugins/actian-design-system/vendor/components/guidelines/_index.json
@@ -1,0 +1,1678 @@
+{
+  "extracted_at": "2026-05-04T14:37:24.649Z",
+  "total_components": 84,
+  "components": [
+    {
+      "slug": "alert-banner",
+      "component": "Alert / banner",
+      "page_id": "9253:21058",
+      "extracted_at": "2026-03-26T00:00:00Z",
+      "has_content_guidelines": false,
+      "has_design_guidelines": true,
+      "has_examples": false,
+      "has_screenshots": false,
+      "has_behavior": false,
+      "frames_found": ["Design guidelines", "Components"],
+      "frames_missing": [
+        "Content guidelines",
+        "ready made examples",
+        "Screenshots of use cases",
+        "Behavior demo"
+      ]
+    },
+    {
+      "slug": "avatar",
+      "component": "Avatar",
+      "page_id": "9253:18762",
+      "extracted_at": "2026-03-26T00:00:00Z",
+      "has_content_guidelines": true,
+      "has_design_guidelines": false,
+      "has_examples": false,
+      "has_screenshots": true,
+      "has_behavior": false,
+      "frames_found": [
+        "Design guidelines",
+        "Content guidelines",
+        "Components",
+        "Screenshots of use cases"
+      ],
+      "frames_missing": ["ready made examples", "Behavior demo"]
+    },
+    {
+      "slug": "badge",
+      "component": "Badge",
+      "page_id": "9253:20900",
+      "extracted_at": "2026-03-26T00:00:00Z",
+      "has_content_guidelines": true,
+      "has_design_guidelines": false,
+      "has_examples": false,
+      "has_screenshots": false,
+      "has_behavior": false,
+      "frames_found": [
+        "Design guidelines",
+        "Content guidelines",
+        "Components",
+        "Ready made examples"
+      ],
+      "frames_missing": ["Screenshots of use cases", "Behavior demo"]
+    },
+    {
+      "slug": "breadcrumbs",
+      "component": "Breadcrumbs",
+      "page_id": "9253:21088",
+      "extracted_at": "2026-03-26T00:00:00Z",
+      "has_content_guidelines": false,
+      "has_design_guidelines": false,
+      "has_examples": false,
+      "has_screenshots": true,
+      "has_behavior": false,
+      "frames_found": ["Screenshots of use cases"],
+      "frames_missing": [
+        "Content guidelines",
+        "design guidelines",
+        "Components",
+        "ready made examples",
+        "Behavior demo"
+      ]
+    },
+    {
+      "slug": "button",
+      "component": "Button",
+      "page_id": "9085:24375",
+      "extracted_at": "2026-03-26T00:00:00Z",
+      "has_content_guidelines": true,
+      "has_design_guidelines": false,
+      "has_examples": false,
+      "has_screenshots": true,
+      "has_behavior": false,
+      "frames_found": [
+        "Content guidelines",
+        "Components",
+        "Screenshots of use cases"
+      ],
+      "frames_missing": [
+        "design guidelines",
+        "ready made examples",
+        "Behavior demo"
+      ]
+    },
+    {
+      "slug": "calendar",
+      "component": "Calendar",
+      "page_id": "12070:77589",
+      "extracted_at": "2026-03-26T00:00:00Z",
+      "has_content_guidelines": true,
+      "has_design_guidelines": false,
+      "has_examples": false,
+      "has_screenshots": false,
+      "has_behavior": false,
+      "frames_found": ["Content guidelines", "Components"],
+      "frames_missing": [
+        "design guidelines",
+        "ready made examples",
+        "Screenshots of use cases",
+        "Behavior demo"
+      ]
+    },
+    {
+      "slug": "card",
+      "component": "Card",
+      "page_id": "9253:21106",
+      "extracted_at": "2026-03-26T00:00:00Z",
+      "has_content_guidelines": true,
+      "has_design_guidelines": false,
+      "has_examples": false,
+      "has_screenshots": true,
+      "has_behavior": false,
+      "frames_found": [
+        "Content guidelines",
+        "Components",
+        "Screenshots of current use cases"
+      ],
+      "frames_missing": [
+        "design guidelines",
+        "ready made examples",
+        "Behavior demo"
+      ]
+    },
+    {
+      "slug": "checkbox",
+      "component": "Checkbox",
+      "page_id": "12070:77593",
+      "extracted_at": "2026-03-26T00:00:00Z",
+      "has_content_guidelines": true,
+      "has_design_guidelines": true,
+      "has_examples": false,
+      "has_screenshots": true,
+      "has_behavior": false,
+      "frames_found": [
+        "Design guidelines",
+        "Content guidelines",
+        "Components",
+        "Screenshots of current use cases"
+      ],
+      "frames_missing": ["ready made examples", "Behavior demo"]
+    },
+    {
+      "slug": "collapse-accordion",
+      "component": "Collapse / Accordion",
+      "page_id": "9253:20890",
+      "extracted_at": "2026-03-26T00:00:00Z",
+      "has_content_guidelines": true,
+      "has_design_guidelines": true,
+      "has_examples": false,
+      "has_screenshots": false,
+      "has_behavior": false,
+      "frames_found": ["Design guidelines", "Content guidelines", "Components"],
+      "frames_missing": [
+        "ready made examples",
+        "Screenshots of use cases",
+        "Behavior demo"
+      ]
+    },
+    {
+      "slug": "data-viz-glossary-item-hierarchy",
+      "component": "Data viz: glossary item hierarchy",
+      "page_id": "14747:29925",
+      "extracted_at": "2026-03-26T00:00:00Z",
+      "has_content_guidelines": false,
+      "has_design_guidelines": false,
+      "has_examples": false,
+      "has_screenshots": true,
+      "has_behavior": false,
+      "frames_found": ["Screenshots of use cases"],
+      "frames_missing": [
+        "Content guidelines",
+        "design guidelines",
+        "Components",
+        "ready made examples",
+        "Behavior demo"
+      ]
+    },
+    {
+      "slug": "data-viz-lineage",
+      "component": "Data viz: lineage",
+      "page_id": "14747:19872",
+      "extracted_at": "2026-03-26T00:00:00Z",
+      "has_content_guidelines": false,
+      "has_design_guidelines": false,
+      "has_examples": false,
+      "has_screenshots": true,
+      "has_behavior": false,
+      "frames_found": ["Components", "Screenshots of use cases"],
+      "frames_missing": [
+        "Content guidelines",
+        "design guidelines",
+        "ready made examples",
+        "Behavior demo"
+      ]
+    },
+    {
+      "slug": "data-viz-metamodel",
+      "component": "Data viz: metamodel",
+      "page_id": "14747:23223",
+      "extracted_at": "2026-03-26T00:00:00Z",
+      "has_content_guidelines": false,
+      "has_design_guidelines": false,
+      "has_examples": false,
+      "has_screenshots": true,
+      "has_behavior": false,
+      "frames_found": ["Components", "Screenshots of use cases"],
+      "frames_missing": [
+        "Content guidelines",
+        "design guidelines",
+        "ready made examples",
+        "Behavior demo"
+      ]
+    },
+    {
+      "slug": "data-viz-progressive-bar",
+      "component": "Data viz: progressive bar",
+      "page_id": "14136:1567",
+      "extracted_at": "2026-03-26T00:00:00Z",
+      "has_content_guidelines": true,
+      "has_design_guidelines": false,
+      "has_examples": false,
+      "has_screenshots": true,
+      "has_behavior": false,
+      "frames_found": [
+        "Content guidelines",
+        "Components",
+        "Screenshots of current use cases"
+      ],
+      "frames_missing": [
+        "design guidelines",
+        "ready made examples",
+        "Behavior demo"
+      ]
+    },
+    {
+      "slug": "data-viz-toolbar",
+      "component": "Data viz: toolbar",
+      "page_id": "8239:5170",
+      "extracted_at": "2026-03-26T00:00:00Z",
+      "has_content_guidelines": false,
+      "has_design_guidelines": false,
+      "has_examples": false,
+      "has_screenshots": true,
+      "has_behavior": false,
+      "frames_found": ["Components", "Screenshots of use cases"],
+      "frames_missing": [
+        "Content guidelines",
+        "design guidelines",
+        "ready made examples",
+        "Behavior demo"
+      ]
+    },
+    {
+      "slug": "data-viz-wip-all-others",
+      "component": "Data viz: WIP all others",
+      "page_id": "14747:33303",
+      "extracted_at": "2026-03-26T00:00:00Z",
+      "has_content_guidelines": false,
+      "has_design_guidelines": false,
+      "has_examples": false,
+      "has_screenshots": true,
+      "has_behavior": false,
+      "frames_found": ["Components", "Screenshots of use cases"],
+      "frames_missing": [
+        "Content guidelines",
+        "design guidelines",
+        "ready made examples",
+        "Behavior demo"
+      ]
+    },
+    {
+      "slug": "digram",
+      "component": "Digram",
+      "page_id": "14007:22442",
+      "extracted_at": "2026-03-26T00:00:00Z",
+      "has_content_guidelines": false,
+      "has_design_guidelines": false,
+      "has_examples": false,
+      "has_screenshots": true,
+      "has_behavior": false,
+      "frames_found": ["Components", "Screenshots of current use cases"],
+      "frames_missing": [
+        "Content guidelines",
+        "design guidelines",
+        "ready made examples",
+        "Behavior demo"
+      ]
+    },
+    {
+      "slug": "drawer",
+      "component": "Drawer / Side panel",
+      "page_id": "12054:49858",
+      "extracted_at": "2026-03-26T00:00:00Z",
+      "has_content_guidelines": false,
+      "has_design_guidelines": false,
+      "has_examples": false,
+      "has_screenshots": true,
+      "has_behavior": true,
+      "frames_found": ["Components", "Screenshots of current use cases"],
+      "frames_missing": [
+        "Content guidelines",
+        "design guidelines",
+        "ready made examples",
+        "Behavior demo"
+      ]
+    },
+    {
+      "slug": "dropdown-select",
+      "component": "Dropdown / Select",
+      "page_id": "12070:77588",
+      "extracted_at": "2026-03-26T00:00:00Z",
+      "has_content_guidelines": true,
+      "has_design_guidelines": false,
+      "has_examples": false,
+      "has_screenshots": true,
+      "has_behavior": false,
+      "frames_found": [
+        "Content guidelines",
+        "Components",
+        "Screenshots of use cases"
+      ],
+      "frames_missing": [
+        "design guidelines",
+        "ready made examples",
+        "Behavior demo"
+      ]
+    },
+    {
+      "slug": "empty-state",
+      "component": "Empty state",
+      "page_id": "7314:3195",
+      "extracted_at": "2026-03-26T00:00:00Z",
+      "has_content_guidelines": true,
+      "has_design_guidelines": true,
+      "has_examples": false,
+      "has_screenshots": false,
+      "has_behavior": false,
+      "frames_found": ["Design guidelines", "Content guidelines", "Components"],
+      "frames_missing": [
+        "ready made examples",
+        "Screenshots of use cases",
+        "Behavior demo"
+      ]
+    },
+    {
+      "slug": "filters",
+      "component": "Filters",
+      "page_id": "9474:8729",
+      "extracted_at": "2026-03-26T00:00:00Z",
+      "has_content_guidelines": true,
+      "has_design_guidelines": false,
+      "has_examples": false,
+      "has_screenshots": true,
+      "has_behavior": false,
+      "frames_found": [
+        "Content guidelines",
+        "Components",
+        "Screenshots of use cases"
+      ],
+      "frames_missing": [
+        "design guidelines",
+        "ready made examples",
+        "Behavior demo"
+      ]
+    },
+    {
+      "slug": "global-header",
+      "component": "Global header",
+      "page_id": "9052:17057",
+      "extracted_at": "2026-03-26T00:00:00Z",
+      "has_content_guidelines": true,
+      "has_design_guidelines": false,
+      "has_examples": false,
+      "has_screenshots": true,
+      "has_behavior": false,
+      "frames_found": [
+        "Content guidelines",
+        "Components",
+        "Screenshots of use cases"
+      ],
+      "frames_missing": [
+        "design guidelines",
+        "ready made examples",
+        "Behavior demo"
+      ]
+    },
+    {
+      "slug": "link",
+      "component": "Link",
+      "page_id": "12054:32076",
+      "extracted_at": "2026-03-26T00:00:00Z",
+      "has_content_guidelines": true,
+      "has_design_guidelines": true,
+      "has_examples": false,
+      "has_screenshots": false,
+      "has_behavior": false,
+      "frames_found": ["Design guidelines", "Content guidelines", "Components"],
+      "frames_missing": [
+        "ready made examples",
+        "Screenshots of use cases",
+        "Behavior demo"
+      ]
+    },
+    {
+      "slug": "loading",
+      "component": "Loading",
+      "page_id": "9253:29118",
+      "extracted_at": "2026-03-26T00:00:00Z",
+      "has_content_guidelines": false,
+      "has_design_guidelines": false,
+      "has_examples": false,
+      "has_screenshots": true,
+      "has_behavior": false,
+      "frames_found": [
+        "Content guidelines",
+        "Components",
+        "Screenshots of current use cases"
+      ],
+      "frames_missing": [
+        "design guidelines",
+        "ready made examples",
+        "Behavior demo"
+      ]
+    },
+    {
+      "slug": "maintenance-banner",
+      "component": "Maintenance banner",
+      "page_id": "13868:11327",
+      "extracted_at": "2026-03-26T00:00:00Z",
+      "has_content_guidelines": false,
+      "has_design_guidelines": false,
+      "has_examples": false,
+      "has_screenshots": true,
+      "has_behavior": false,
+      "frames_found": ["Components", "Screenshots of use cases"],
+      "frames_missing": [
+        "Content guidelines",
+        "design guidelines",
+        "ready made examples",
+        "Behavior demo"
+      ]
+    },
+    {
+      "slug": "modal",
+      "component": "Modal",
+      "page_id": "9253:29287",
+      "extracted_at": "2026-03-26T00:00:00Z",
+      "has_content_guidelines": true,
+      "has_design_guidelines": false,
+      "has_examples": false,
+      "has_screenshots": true,
+      "has_behavior": true,
+      "frames_found": [
+        "Content guidelines",
+        "Components",
+        "Screenshots of current use cases"
+      ],
+      "frames_missing": [
+        "design guidelines",
+        "ready made examples",
+        "Behavior demo"
+      ]
+    },
+    {
+      "slug": "notification-toast",
+      "component": "Notification / Toast",
+      "page_id": "13868:11578",
+      "extracted_at": "2026-03-26T00:00:00Z",
+      "has_content_guidelines": false,
+      "has_design_guidelines": false,
+      "has_examples": false,
+      "has_screenshots": true,
+      "has_behavior": true,
+      "frames_found": ["Components", "Screenshots of use cases"],
+      "frames_missing": [
+        "Content guidelines",
+        "design guidelines",
+        "ready made examples",
+        "Behavior demo"
+      ]
+    },
+    {
+      "slug": "page-header",
+      "component": "Page header",
+      "page_id": "9253:29981",
+      "extracted_at": "2026-03-26T00:00:00Z",
+      "has_content_guidelines": false,
+      "has_design_guidelines": false,
+      "has_examples": false,
+      "has_screenshots": true,
+      "has_behavior": false,
+      "frames_found": ["Components", "Screenshots of current use cases"],
+      "frames_missing": [
+        "Content guidelines",
+        "design guidelines",
+        "ready made examples",
+        "Behavior demo"
+      ]
+    },
+    {
+      "slug": "popover",
+      "component": "Popover",
+      "page_id": "13298:2723",
+      "extracted_at": "2026-03-26T00:00:00Z",
+      "has_content_guidelines": false,
+      "has_design_guidelines": false,
+      "has_examples": false,
+      "has_screenshots": true,
+      "has_behavior": true,
+      "frames_found": ["Components", "Screenshots of current use cases"],
+      "frames_missing": [
+        "Content guidelines",
+        "design guidelines",
+        "ready made examples",
+        "Behavior demo"
+      ]
+    },
+    {
+      "slug": "radio-button",
+      "component": "Radio button",
+      "page_id": "12070:77592",
+      "extracted_at": "2026-03-26T00:00:00Z",
+      "has_content_guidelines": true,
+      "has_design_guidelines": false,
+      "has_examples": false,
+      "has_screenshots": true,
+      "has_behavior": false,
+      "frames_found": [
+        "Content guidelines",
+        "Components",
+        "Screenshots of use cases"
+      ],
+      "frames_missing": [
+        "design guidelines",
+        "ready made examples",
+        "Behavior demo"
+      ]
+    },
+    {
+      "slug": "rich-text",
+      "component": "Rich text (existing)",
+      "page_id": "12070:77590",
+      "extracted_at": "2026-03-26T00:00:00Z",
+      "has_content_guidelines": false,
+      "has_design_guidelines": false,
+      "has_examples": false,
+      "has_screenshots": true,
+      "has_behavior": false,
+      "frames_found": ["Components", "Screenshots of use cases"],
+      "frames_missing": [
+        "Content guidelines",
+        "design guidelines",
+        "ready made examples",
+        "Behavior demo"
+      ]
+    },
+    {
+      "slug": "scroll-bar",
+      "component": "Scroll bar",
+      "page_id": "9253:31918",
+      "extracted_at": "2026-03-26T00:00:00Z",
+      "has_content_guidelines": false,
+      "has_design_guidelines": false,
+      "has_examples": false,
+      "has_screenshots": false,
+      "has_behavior": false,
+      "frames_found": [],
+      "frames_missing": [
+        "Content guidelines",
+        "design guidelines",
+        "Components",
+        "ready made examples",
+        "Screenshots of use cases",
+        "Behavior demo"
+      ]
+    },
+    {
+      "slug": "search-result-card",
+      "component": "Search result card",
+      "page_id": "9253:31959",
+      "extracted_at": "2026-03-26T00:00:00Z",
+      "has_content_guidelines": false,
+      "has_design_guidelines": false,
+      "has_examples": false,
+      "has_screenshots": true,
+      "has_behavior": false,
+      "frames_found": [
+        "Components",
+        "Content guidelines",
+        "Screenshots of current use cases"
+      ],
+      "frames_missing": [
+        "design guidelines",
+        "ready made examples",
+        "Behavior demo"
+      ]
+    },
+    {
+      "slug": "search",
+      "component": "Search",
+      "page_id": "9085:22545",
+      "extracted_at": "2026-03-26T00:00:00Z",
+      "has_content_guidelines": true,
+      "has_design_guidelines": false,
+      "has_examples": false,
+      "has_screenshots": true,
+      "has_behavior": false,
+      "frames_found": [
+        "Content guidelines",
+        "Components",
+        "Screenshots of use cases"
+      ],
+      "frames_missing": [
+        "design guidelines",
+        "ready made examples",
+        "Behavior demo"
+      ]
+    },
+    {
+      "slug": "segmented-control",
+      "component": "Segmented control / Button group",
+      "page_id": "9253:33950",
+      "extracted_at": "2026-03-26T00:00:00Z",
+      "has_content_guidelines": false,
+      "has_design_guidelines": false,
+      "has_examples": false,
+      "has_screenshots": true,
+      "has_behavior": false,
+      "frames_found": ["Components", "Screenshots of use cases"],
+      "frames_missing": [
+        "Content guidelines",
+        "design guidelines",
+        "ready made examples",
+        "Behavior demo"
+      ]
+    },
+    {
+      "slug": "side-nav",
+      "component": "Side nav",
+      "page_id": "13599:19122",
+      "extracted_at": "2026-03-26T00:00:00Z",
+      "has_content_guidelines": false,
+      "has_design_guidelines": false,
+      "has_examples": false,
+      "has_screenshots": false,
+      "has_behavior": true,
+      "frames_found": ["Behavior demo"],
+      "frames_missing": [
+        "Content guidelines",
+        "design guidelines",
+        "Components",
+        "ready made examples",
+        "Screenshots of use cases"
+      ]
+    },
+    {
+      "slug": "stepper",
+      "component": "Stepper",
+      "page_id": "9253:33976",
+      "extracted_at": "2026-03-26T00:00:00Z",
+      "has_content_guidelines": false,
+      "has_design_guidelines": false,
+      "has_examples": false,
+      "has_screenshots": true,
+      "has_behavior": false,
+      "frames_found": ["Components", "Screenshots of current use cases"],
+      "frames_missing": [
+        "Content guidelines",
+        "design guidelines",
+        "ready made examples",
+        "Behavior demo"
+      ]
+    },
+    {
+      "slug": "sticky-footer",
+      "component": "Sticky footer",
+      "page_id": "9253:33986",
+      "extracted_at": "2026-03-26T00:00:00Z",
+      "has_content_guidelines": true,
+      "has_design_guidelines": false,
+      "has_examples": false,
+      "has_screenshots": true,
+      "has_behavior": false,
+      "frames_found": ["Content guidelines", "Screenshots of use cases"],
+      "frames_missing": [
+        "design guidelines",
+        "Components",
+        "ready made examples",
+        "Behavior demo"
+      ]
+    },
+    {
+      "slug": "tab",
+      "component": "Tab",
+      "page_id": "9253:33996",
+      "extracted_at": "2026-03-26T00:00:00Z",
+      "has_content_guidelines": false,
+      "has_design_guidelines": false,
+      "has_examples": false,
+      "has_screenshots": true,
+      "has_behavior": false,
+      "frames_found": ["Components", "Screenshots of current use cases"],
+      "frames_missing": [
+        "Content guidelines",
+        "design guidelines",
+        "ready made examples",
+        "Behavior demo"
+      ]
+    },
+    {
+      "slug": "table",
+      "component": "Table",
+      "page_id": "9253:34015",
+      "extracted_at": "2026-03-26T00:00:00Z",
+      "has_content_guidelines": false,
+      "has_design_guidelines": false,
+      "has_examples": false,
+      "has_screenshots": true,
+      "has_behavior": false,
+      "frames_found": ["Components", "Screenshots of current use cases"],
+      "frames_missing": [
+        "Content guidelines",
+        "design guidelines",
+        "ready made examples",
+        "Behavior demo"
+      ]
+    },
+    {
+      "slug": "tag",
+      "component": "Tag / Identification key",
+      "page_id": "9253:34505",
+      "extracted_at": "2026-03-26T00:00:00Z",
+      "has_content_guidelines": false,
+      "has_design_guidelines": true,
+      "has_examples": false,
+      "has_screenshots": true,
+      "has_behavior": false,
+      "frames_found": [
+        "Design guidelines",
+        "Components",
+        "Content guidelines",
+        "Screenshots of current use cases"
+      ],
+      "frames_missing": ["ready made examples", "Behavior demo"]
+    },
+    {
+      "slug": "text-input",
+      "component": "Text input",
+      "page_id": "12070:77587",
+      "extracted_at": "2026-03-26T00:00:00Z",
+      "has_content_guidelines": true,
+      "has_design_guidelines": false,
+      "has_examples": false,
+      "has_screenshots": true,
+      "has_behavior": false,
+      "frames_found": [
+        "Content guidelines",
+        "Components",
+        "Screenshots of use cases"
+      ],
+      "frames_missing": [
+        "design guidelines",
+        "ready made examples",
+        "Behavior demo"
+      ]
+    },
+    {
+      "slug": "toggle-control",
+      "component": "Toggle control",
+      "page_id": "12070:77591",
+      "extracted_at": "2026-03-26T00:00:00Z",
+      "has_content_guidelines": true,
+      "has_design_guidelines": true,
+      "has_examples": false,
+      "has_screenshots": false,
+      "has_behavior": false,
+      "frames_found": ["Design guidelines", "Content guidelines", "Components"],
+      "frames_missing": [
+        "ready made examples",
+        "Screenshots of use cases",
+        "Behavior demo"
+      ]
+    },
+    {
+      "slug": "tooltip",
+      "component": "Tooltip",
+      "page_id": "9253:37504",
+      "extracted_at": "2026-03-26T00:00:00Z",
+      "has_content_guidelines": false,
+      "has_design_guidelines": true,
+      "has_examples": false,
+      "has_screenshots": true,
+      "has_behavior": true,
+      "frames_found": [
+        "Design guidelines",
+        "Components",
+        "Screenshots of current use cases"
+      ],
+      "frames_missing": [
+        "Content guidelines",
+        "ready made examples",
+        "Behavior demo"
+      ]
+    },
+    {
+      "slug": "traffic-light",
+      "component": "Traffic light",
+      "page_id": "14719:5902",
+      "extracted_at": "2026-03-26T00:00:00Z",
+      "has_content_guidelines": false,
+      "has_design_guidelines": false,
+      "has_examples": false,
+      "has_screenshots": true,
+      "has_behavior": false,
+      "frames_found": ["Components", "Screenshots of current use cases"],
+      "frames_missing": [
+        "Content guidelines",
+        "design guidelines",
+        "ready made examples",
+        "Behavior demo"
+      ]
+    },
+    {
+      "slug": "checkbox-with-label",
+      "component": "Checkbox with label",
+      "page_id": "9478:17216",
+      "extracted_at": "2026-05-04T14:37:24.649Z",
+      "_stub": true,
+      "has_content_guidelines": false,
+      "has_design_guidelines": false,
+      "has_examples": false,
+      "has_screenshots": false,
+      "has_behavior": false,
+      "frames_found": [],
+      "frames_missing": [
+        "Design guidelines",
+        "Content guidelines",
+        "Components",
+        "Screenshots of use cases",
+        "Behavior demo",
+        "ready made examples"
+      ]
+    },
+    {
+      "slug": "lineage-individual-node",
+      "component": "Lineage individual node",
+      "page_id": "14747:19902",
+      "extracted_at": "2026-05-04T14:37:24.649Z",
+      "_stub": true,
+      "has_content_guidelines": false,
+      "has_design_guidelines": false,
+      "has_examples": false,
+      "has_screenshots": false,
+      "has_behavior": false,
+      "frames_found": [],
+      "frames_missing": [
+        "Design guidelines",
+        "Content guidelines",
+        "Components",
+        "Screenshots of use cases",
+        "Behavior demo",
+        "ready made examples"
+      ]
+    },
+    {
+      "slug": "tag-glossary-item-type",
+      "component": "✍️ Tag, Glossary item type",
+      "page_id": "13812:22308",
+      "extracted_at": "2026-05-04T14:37:24.649Z",
+      "_stub": true,
+      "has_content_guidelines": false,
+      "has_design_guidelines": false,
+      "has_examples": false,
+      "has_screenshots": false,
+      "has_behavior": false,
+      "frames_found": [],
+      "frames_missing": [
+        "Design guidelines",
+        "Content guidelines",
+        "Components",
+        "Screenshots of use cases",
+        "Behavior demo",
+        "ready made examples"
+      ]
+    },
+    {
+      "slug": "tag-interactive",
+      "component": "✍️ Tag, Interactive",
+      "page_id": "13845:33759",
+      "extracted_at": "2026-05-04T14:37:24.649Z",
+      "_stub": true,
+      "has_content_guidelines": false,
+      "has_design_guidelines": false,
+      "has_examples": false,
+      "has_screenshots": false,
+      "has_behavior": false,
+      "frames_found": [],
+      "frames_missing": [
+        "Design guidelines",
+        "Content guidelines",
+        "Components",
+        "Screenshots of use cases",
+        "Behavior demo",
+        "ready made examples"
+      ]
+    },
+    {
+      "slug": "notification-dropdown",
+      "component": "Notification dropdown",
+      "page_id": "9114:15379",
+      "extracted_at": "2026-05-04T14:37:24.649Z",
+      "_stub": true,
+      "has_content_guidelines": false,
+      "has_design_guidelines": false,
+      "has_examples": false,
+      "has_screenshots": false,
+      "has_behavior": false,
+      "frames_found": [],
+      "frames_missing": [
+        "Design guidelines",
+        "Content guidelines",
+        "Components",
+        "Screenshots of use cases",
+        "Behavior demo",
+        "ready made examples"
+      ]
+    },
+    {
+      "slug": "whats-new-dropdown",
+      "component": "Whats new dropdown",
+      "page_id": "9114:16794",
+      "extracted_at": "2026-05-04T14:37:24.649Z",
+      "_stub": true,
+      "has_content_guidelines": false,
+      "has_design_guidelines": false,
+      "has_examples": false,
+      "has_screenshots": false,
+      "has_behavior": false,
+      "frames_found": [],
+      "frames_missing": [
+        "Design guidelines",
+        "Content guidelines",
+        "Components",
+        "Screenshots of use cases",
+        "Behavior demo",
+        "ready made examples"
+      ]
+    },
+    {
+      "slug": "tag-default",
+      "component": "✍️ Tag, Default",
+      "page_id": "7257:3037",
+      "extracted_at": "2026-05-04T14:37:24.649Z",
+      "_stub": true,
+      "has_content_guidelines": false,
+      "has_design_guidelines": false,
+      "has_examples": false,
+      "has_screenshots": false,
+      "has_behavior": false,
+      "frames_found": [],
+      "frames_missing": [
+        "Design guidelines",
+        "Content guidelines",
+        "Components",
+        "Screenshots of use cases",
+        "Behavior demo",
+        "ready made examples"
+      ]
+    },
+    {
+      "slug": "notification",
+      "component": "Notification",
+      "page_id": "13868:11595",
+      "extracted_at": "2026-05-04T14:37:24.649Z",
+      "_stub": true,
+      "has_content_guidelines": false,
+      "has_design_guidelines": false,
+      "has_examples": false,
+      "has_screenshots": false,
+      "has_behavior": false,
+      "frames_found": [],
+      "frames_missing": [
+        "Design guidelines",
+        "Content guidelines",
+        "Components",
+        "Screenshots of use cases",
+        "Behavior demo",
+        "ready made examples"
+      ]
+    },
+    {
+      "slug": "metamodel-widget",
+      "component": "Metamodel widget",
+      "page_id": "14747:23588",
+      "extracted_at": "2026-05-04T14:37:24.649Z",
+      "_stub": true,
+      "has_content_guidelines": false,
+      "has_design_guidelines": false,
+      "has_examples": false,
+      "has_screenshots": false,
+      "has_behavior": false,
+      "frames_found": [],
+      "frames_missing": [
+        "Design guidelines",
+        "Content guidelines",
+        "Components",
+        "Screenshots of use cases",
+        "Behavior demo",
+        "ready made examples"
+      ]
+    },
+    {
+      "slug": "line-graph",
+      "component": "⛔️ Line graph",
+      "page_id": "15473:49490",
+      "extracted_at": "2026-05-04T14:37:24.649Z",
+      "_stub": true,
+      "has_content_guidelines": false,
+      "has_design_guidelines": false,
+      "has_examples": false,
+      "has_screenshots": false,
+      "has_behavior": false,
+      "frames_found": [],
+      "frames_missing": [
+        "Design guidelines",
+        "Content guidelines",
+        "Components",
+        "Screenshots of use cases",
+        "Behavior demo",
+        "ready made examples"
+      ]
+    },
+    {
+      "slug": "glossary-item-hierarchy-diagram",
+      "component": "Glossary item hierarchy diagram",
+      "page_id": "14747:30242",
+      "extracted_at": "2026-05-04T14:37:24.649Z",
+      "_stub": true,
+      "has_content_guidelines": false,
+      "has_design_guidelines": false,
+      "has_examples": false,
+      "has_screenshots": false,
+      "has_behavior": false,
+      "frames_found": [],
+      "frames_missing": [
+        "Design guidelines",
+        "Content guidelines",
+        "Components",
+        "Screenshots of use cases",
+        "Behavior demo",
+        "ready made examples"
+      ]
+    },
+    {
+      "slug": "chat-with-ai-steward",
+      "component": "Chat with AI Steward",
+      "page_id": "15464:24509",
+      "extracted_at": "2026-05-04T14:37:24.649Z",
+      "_stub": true,
+      "has_content_guidelines": false,
+      "has_design_guidelines": false,
+      "has_examples": false,
+      "has_screenshots": false,
+      "has_behavior": false,
+      "frames_found": [],
+      "frames_missing": [
+        "Design guidelines",
+        "Content guidelines",
+        "Components",
+        "Screenshots of use cases",
+        "Behavior demo",
+        "ready made examples"
+      ]
+    },
+    {
+      "slug": "digram-item-types",
+      "component": "Digram, Item types",
+      "page_id": "14007:23209",
+      "extracted_at": "2026-05-04T14:37:24.649Z",
+      "_stub": true,
+      "has_content_guidelines": false,
+      "has_design_guidelines": false,
+      "has_examples": false,
+      "has_screenshots": false,
+      "has_behavior": false,
+      "frames_found": [],
+      "frames_missing": [
+        "Design guidelines",
+        "Content guidelines",
+        "Components",
+        "Screenshots of use cases",
+        "Behavior demo",
+        "ready made examples"
+      ]
+    },
+    {
+      "slug": "progress-bar-small",
+      "component": "Progress bar small",
+      "page_id": "14136:1615",
+      "extracted_at": "2026-05-04T14:37:24.649Z",
+      "_stub": true,
+      "has_content_guidelines": false,
+      "has_design_guidelines": false,
+      "has_examples": false,
+      "has_screenshots": false,
+      "has_behavior": false,
+      "frames_found": [],
+      "frames_missing": [
+        "Design guidelines",
+        "Content guidelines",
+        "Components",
+        "Screenshots of use cases",
+        "Behavior demo",
+        "ready made examples"
+      ]
+    },
+    {
+      "slug": "confirmation",
+      "component": "Confirmation",
+      "page_id": "13871:32310",
+      "extracted_at": "2026-05-04T14:37:24.649Z",
+      "_stub": true,
+      "has_content_guidelines": false,
+      "has_design_guidelines": false,
+      "has_examples": false,
+      "has_screenshots": false,
+      "has_behavior": false,
+      "frames_found": [],
+      "frames_missing": [
+        "Design guidelines",
+        "Content guidelines",
+        "Components",
+        "Screenshots of use cases",
+        "Behavior demo",
+        "ready made examples"
+      ]
+    },
+    {
+      "slug": "error-state",
+      "component": "Error state",
+      "page_id": "13087:34544",
+      "extracted_at": "2026-05-04T14:37:24.649Z",
+      "_stub": true,
+      "has_content_guidelines": false,
+      "has_design_guidelines": false,
+      "has_examples": false,
+      "has_screenshots": false,
+      "has_behavior": false,
+      "frames_found": [],
+      "frames_missing": [
+        "Design guidelines",
+        "Content guidelines",
+        "Components",
+        "Screenshots of use cases",
+        "Behavior demo",
+        "ready made examples"
+      ]
+    },
+    {
+      "slug": "tag-catalog-item-type",
+      "component": "✍️ Tag, Catalog item type",
+      "page_id": "11300:8312",
+      "extracted_at": "2026-05-04T14:37:24.649Z",
+      "_stub": true,
+      "has_content_guidelines": false,
+      "has_design_guidelines": false,
+      "has_examples": false,
+      "has_screenshots": false,
+      "has_behavior": false,
+      "frames_found": [],
+      "frames_missing": [
+        "Design guidelines",
+        "Content guidelines",
+        "Components",
+        "Screenshots of use cases",
+        "Behavior demo",
+        "ready made examples"
+      ]
+    },
+    {
+      "slug": "identification-key",
+      "component": "Identification key",
+      "page_id": "14349:15323",
+      "extracted_at": "2026-05-04T14:37:24.649Z",
+      "_stub": true,
+      "has_content_guidelines": false,
+      "has_design_guidelines": false,
+      "has_examples": false,
+      "has_screenshots": false,
+      "has_behavior": false,
+      "frames_found": [],
+      "frames_missing": [
+        "Design guidelines",
+        "Content guidelines",
+        "Components",
+        "Screenshots of use cases",
+        "Behavior demo",
+        "ready made examples"
+      ]
+    },
+    {
+      "slug": "loading-skeleton",
+      "component": "Loading skeleton",
+      "page_id": "14294:8086",
+      "extracted_at": "2026-05-04T14:37:24.649Z",
+      "_stub": true,
+      "has_content_guidelines": false,
+      "has_design_guidelines": false,
+      "has_examples": false,
+      "has_screenshots": false,
+      "has_behavior": true,
+      "frames_found": [],
+      "frames_missing": [
+        "Design guidelines",
+        "Content guidelines",
+        "Components",
+        "Screenshots of use cases",
+        "Behavior demo",
+        "ready made examples"
+      ]
+    },
+    {
+      "slug": "tabs",
+      "component": "Tabs",
+      "page_id": "14747:14818",
+      "extracted_at": "2026-05-04T14:37:24.649Z",
+      "_stub": true,
+      "has_content_guidelines": false,
+      "has_design_guidelines": false,
+      "has_examples": false,
+      "has_screenshots": false,
+      "has_behavior": false,
+      "frames_found": [],
+      "frames_missing": [
+        "Design guidelines",
+        "Content guidelines",
+        "Components",
+        "Screenshots of use cases",
+        "Behavior demo",
+        "ready made examples"
+      ]
+    },
+    {
+      "slug": "tag-catalog",
+      "component": "✍️ Tag, Catalog",
+      "page_id": "13812:22309",
+      "extracted_at": "2026-05-04T14:37:24.649Z",
+      "_stub": true,
+      "has_content_guidelines": false,
+      "has_design_guidelines": false,
+      "has_examples": false,
+      "has_screenshots": false,
+      "has_behavior": false,
+      "frames_found": [],
+      "frames_missing": [
+        "Design guidelines",
+        "Content guidelines",
+        "Components",
+        "Screenshots of use cases",
+        "Behavior demo",
+        "ready made examples"
+      ]
+    },
+    {
+      "slug": "tag-status",
+      "component": "✍️ Tag, Status",
+      "page_id": "7257:3705",
+      "extracted_at": "2026-05-04T14:37:24.649Z",
+      "_stub": true,
+      "has_content_guidelines": false,
+      "has_design_guidelines": false,
+      "has_examples": false,
+      "has_screenshots": false,
+      "has_behavior": false,
+      "frames_found": [],
+      "frames_missing": [
+        "Design guidelines",
+        "Content guidelines",
+        "Components",
+        "Screenshots of use cases",
+        "Behavior demo",
+        "ready made examples"
+      ]
+    },
+    {
+      "slug": "input",
+      "component": "Input",
+      "page_id": "7238:2487",
+      "extracted_at": "2026-05-04T14:37:24.649Z",
+      "_stub": true,
+      "has_content_guidelines": false,
+      "has_design_guidelines": false,
+      "has_examples": false,
+      "has_screenshots": false,
+      "has_behavior": false,
+      "frames_found": [],
+      "frames_missing": [
+        "Design guidelines",
+        "Content guidelines",
+        "Components",
+        "Screenshots of use cases",
+        "Behavior demo",
+        "ready made examples"
+      ]
+    },
+    {
+      "slug": "perimeter-card",
+      "component": "Perimeter card",
+      "page_id": "14783:7565",
+      "extracted_at": "2026-05-04T14:37:24.649Z",
+      "_stub": true,
+      "has_content_guidelines": false,
+      "has_design_guidelines": false,
+      "has_examples": false,
+      "has_screenshots": false,
+      "has_behavior": false,
+      "frames_found": [],
+      "frames_missing": [
+        "Design guidelines",
+        "Content guidelines",
+        "Components",
+        "Screenshots of use cases",
+        "Behavior demo",
+        "ready made examples"
+      ]
+    },
+    {
+      "slug": "drawer-side-panel",
+      "component": "Drawer, side panel",
+      "page_id": "14294:5758",
+      "extracted_at": "2026-05-04T14:37:24.649Z",
+      "_stub": true,
+      "has_content_guidelines": false,
+      "has_design_guidelines": false,
+      "has_examples": false,
+      "has_screenshots": false,
+      "has_behavior": true,
+      "frames_found": [],
+      "frames_missing": [
+        "Design guidelines",
+        "Content guidelines",
+        "Components",
+        "Screenshots of use cases",
+        "Behavior demo",
+        "ready made examples"
+      ]
+    },
+    {
+      "slug": "input-date",
+      "component": "Input, date",
+      "page_id": "8194:7305",
+      "extracted_at": "2026-05-04T14:37:24.649Z",
+      "_stub": true,
+      "has_content_guidelines": false,
+      "has_design_guidelines": false,
+      "has_examples": false,
+      "has_screenshots": false,
+      "has_behavior": false,
+      "frames_found": [],
+      "frames_missing": [
+        "Design guidelines",
+        "Content guidelines",
+        "Components",
+        "Screenshots of use cases",
+        "Behavior demo",
+        "ready made examples"
+      ]
+    },
+    {
+      "slug": "bar-graph",
+      "component": "⛔️ Bar graph",
+      "page_id": "15473:49489",
+      "extracted_at": "2026-05-04T14:37:24.649Z",
+      "_stub": true,
+      "has_content_guidelines": false,
+      "has_design_guidelines": false,
+      "has_examples": false,
+      "has_screenshots": false,
+      "has_behavior": false,
+      "frames_found": [],
+      "frames_missing": [
+        "Design guidelines",
+        "Content guidelines",
+        "Components",
+        "Screenshots of use cases",
+        "Behavior demo",
+        "ready made examples"
+      ]
+    },
+    {
+      "slug": "dropdown-select-default",
+      "component": "Dropdown, Select, default",
+      "page_id": "13972:708",
+      "extracted_at": "2026-05-04T14:37:24.649Z",
+      "_stub": true,
+      "has_content_guidelines": false,
+      "has_design_guidelines": false,
+      "has_examples": false,
+      "has_screenshots": false,
+      "has_behavior": false,
+      "frames_found": [],
+      "frames_missing": [
+        "Design guidelines",
+        "Content guidelines",
+        "Components",
+        "Screenshots of use cases",
+        "Behavior demo",
+        "ready made examples"
+      ]
+    },
+    {
+      "slug": "lineage-connecting-line",
+      "component": "Lineage connecting line",
+      "page_id": "14747:20085",
+      "extracted_at": "2026-05-04T14:37:24.649Z",
+      "_stub": true,
+      "has_content_guidelines": false,
+      "has_design_guidelines": false,
+      "has_examples": false,
+      "has_screenshots": false,
+      "has_behavior": false,
+      "frames_found": [],
+      "frames_missing": [
+        "Design guidelines",
+        "Content guidelines",
+        "Components",
+        "Screenshots of use cases",
+        "Behavior demo",
+        "ready made examples"
+      ]
+    },
+    {
+      "slug": "search-filters",
+      "component": "Search filters",
+      "page_id": "9660:49637",
+      "extracted_at": "2026-05-04T14:37:24.649Z",
+      "_stub": true,
+      "has_content_guidelines": false,
+      "has_design_guidelines": false,
+      "has_examples": false,
+      "has_screenshots": false,
+      "has_behavior": false,
+      "frames_found": [],
+      "frames_missing": [
+        "Design guidelines",
+        "Content guidelines",
+        "Components",
+        "Screenshots of use cases",
+        "Behavior demo",
+        "ready made examples"
+      ]
+    },
+    {
+      "slug": "search-dropdown-menu",
+      "component": "Search dropdown menu",
+      "page_id": "8756:9994",
+      "extracted_at": "2026-05-04T14:37:24.649Z",
+      "_stub": true,
+      "has_content_guidelines": false,
+      "has_design_guidelines": false,
+      "has_examples": false,
+      "has_screenshots": false,
+      "has_behavior": false,
+      "frames_found": [],
+      "frames_missing": [
+        "Design guidelines",
+        "Content guidelines",
+        "Components",
+        "Screenshots of use cases",
+        "Behavior demo",
+        "ready made examples"
+      ]
+    },
+    {
+      "slug": "digram-topic",
+      "component": "Digram, Topic",
+      "page_id": "14128:3800",
+      "extracted_at": "2026-05-04T14:37:24.649Z",
+      "_stub": true,
+      "has_content_guidelines": false,
+      "has_design_guidelines": false,
+      "has_examples": false,
+      "has_screenshots": false,
+      "has_behavior": false,
+      "frames_found": [],
+      "frames_missing": [
+        "Design guidelines",
+        "Content guidelines",
+        "Components",
+        "Screenshots of use cases",
+        "Behavior demo",
+        "ready made examples"
+      ]
+    },
+    {
+      "slug": "tag-stage",
+      "component": "✍️ Tag, Stage",
+      "page_id": "8655:10279",
+      "extracted_at": "2026-05-04T14:37:24.649Z",
+      "_stub": true,
+      "has_content_guidelines": false,
+      "has_design_guidelines": false,
+      "has_examples": false,
+      "has_screenshots": false,
+      "has_behavior": false,
+      "frames_found": [],
+      "frames_missing": [
+        "Design guidelines",
+        "Content guidelines",
+        "Components",
+        "Screenshots of use cases",
+        "Behavior demo",
+        "ready made examples"
+      ]
+    },
+    {
+      "slug": "maintenance-state",
+      "component": "Maintenance state",
+      "page_id": "13871:32311",
+      "extracted_at": "2026-05-04T14:37:24.649Z",
+      "_stub": true,
+      "has_content_guidelines": false,
+      "has_design_guidelines": false,
+      "has_examples": false,
+      "has_screenshots": false,
+      "has_behavior": false,
+      "frames_found": [],
+      "frames_missing": [
+        "Design guidelines",
+        "Content guidelines",
+        "Components",
+        "Screenshots of use cases",
+        "Behavior demo",
+        "ready made examples"
+      ]
+    },
+    {
+      "slug": "tag-updated",
+      "component": "✍️ Tag, Updated",
+      "page_id": "13812:22307",
+      "extracted_at": "2026-05-04T14:37:24.649Z",
+      "_stub": true,
+      "has_content_guidelines": false,
+      "has_design_guidelines": false,
+      "has_examples": false,
+      "has_screenshots": false,
+      "has_behavior": false,
+      "frames_found": [],
+      "frames_missing": [
+        "Design guidelines",
+        "Content guidelines",
+        "Components",
+        "Screenshots of use cases",
+        "Behavior demo",
+        "ready made examples"
+      ]
+    },
+    {
+      "slug": "toolbar",
+      "component": "Toolbar",
+      "page_id": "14335:16907",
+      "extracted_at": "2026-05-04T14:37:24.649Z",
+      "_stub": true,
+      "has_content_guidelines": false,
+      "has_design_guidelines": false,
+      "has_examples": false,
+      "has_screenshots": false,
+      "has_behavior": false,
+      "frames_found": [],
+      "frames_missing": [
+        "Design guidelines",
+        "Content guidelines",
+        "Components",
+        "Screenshots of use cases",
+        "Behavior demo",
+        "ready made examples"
+      ]
+    },
+    {
+      "slug": "lineage-grouped-node",
+      "component": "Lineage grouped node",
+      "page_id": "15634:17895",
+      "extracted_at": "2026-05-04T14:37:24.649Z",
+      "_stub": true,
+      "has_content_guidelines": false,
+      "has_design_guidelines": false,
+      "has_examples": false,
+      "has_screenshots": false,
+      "has_behavior": false,
+      "frames_found": [],
+      "frames_missing": [
+        "Design guidelines",
+        "Content guidelines",
+        "Components",
+        "Screenshots of use cases",
+        "Behavior demo",
+        "ready made examples"
+      ]
+    },
+    {
+      "slug": "loader",
+      "component": "Loader",
+      "page_id": "7372:2195",
+      "extracted_at": "2026-05-04T14:37:24.649Z",
+      "_stub": true,
+      "has_content_guidelines": false,
+      "has_design_guidelines": false,
+      "has_examples": false,
+      "has_screenshots": false,
+      "has_behavior": false,
+      "frames_found": [],
+      "frames_missing": [
+        "Design guidelines",
+        "Content guidelines",
+        "Components",
+        "Screenshots of use cases",
+        "Behavior demo",
+        "ready made examples"
+      ]
+    },
+    {
+      "slug": "tile-item",
+      "component": "Tile, Item",
+      "page_id": "7613:7853",
+      "extracted_at": "2026-05-04T14:37:24.649Z",
+      "_stub": true,
+      "has_content_guidelines": false,
+      "has_design_guidelines": false,
+      "has_examples": false,
+      "has_screenshots": false,
+      "has_behavior": false,
+      "frames_found": [],
+      "frames_missing": [
+        "Design guidelines",
+        "Content guidelines",
+        "Components",
+        "Screenshots of use cases",
+        "Behavior demo",
+        "ready made examples"
+      ]
+    },
+    {
+      "slug": "spinner",
+      "component": "Spinner",
+      "page_id": "7372:2170",
+      "extracted_at": "2026-05-04T14:37:24.649Z",
+      "_stub": true,
+      "has_content_guidelines": false,
+      "has_design_guidelines": false,
+      "has_examples": false,
+      "has_screenshots": false,
+      "has_behavior": false,
+      "frames_found": [],
+      "frames_missing": [
+        "Design guidelines",
+        "Content guidelines",
+        "Components",
+        "Screenshots of use cases",
+        "Behavior demo",
+        "ready made examples"
+      ]
+    }
+  ]
+}

--- a/plugins/actian-design-system/vendor/components/guidelines/alert-banner.json
+++ b/plugins/actian-design-system/vendor/components/guidelines/alert-banner.json
@@ -1,0 +1,92 @@
+{
+  "component": "Alert / banner",
+  "page_id": "9253:21058",
+  "extracted_at": "2026-03-26T00:00:00Z",
+  "frames_found": [
+    "Design guidelines",
+    "Components"
+  ],
+  "frames_missing": [
+    "Content guidelines",
+    "ready made examples",
+    "Screenshots of use cases",
+    "Screenshots of current use cases",
+    "Behavior demo"
+  ],
+  "content_guidelines": null,
+  "has_design_guidelines": true,
+  "design_guidelines": {
+    "sections": [
+      {
+        "heading": "Types",
+        "items": [
+          "Four alert banner types: Primary (Info), Success, Warning, and Danger (Error)."
+        ]
+      },
+      {
+        "heading": "Specs",
+        "items": [
+          "Horizontal orientation with icon, text, optional action button, and optional close button.",
+          "Internal gap between elements: --zen-spacing-xs (8px).",
+          "Icon size: 16px.",
+          "Min height: 40px.",
+          "Border radius: --zen-radius-default (6px).",
+          "Horizontal padding: 36px; vertical padding: --zen-spacing-xs (8px)."
+        ]
+      },
+      {
+        "heading": "Icon and color mapping",
+        "tables": [
+          {
+            "headers": [
+              "Icon",
+              "Color token"
+            ],
+            "rows": [
+              [
+                "info-filled",
+                "--zen-color-primary-700"
+              ],
+              [
+                "success-filled",
+                "--zen-color-success-700"
+              ],
+              [
+                "warning-filled",
+                "--zen-color-warning-700"
+              ],
+              [
+                "error-filled",
+                "--zen-color-error-700"
+              ]
+            ]
+          }
+        ]
+      },
+      {
+        "heading": "Layout",
+        "items": [
+          "In between alert banners, keep 8px (spacing-xs).",
+          "Suggested spacing between alert banners and surrounding elements is 16px (spacing-md), but this can be reduced if space is limited or the element is directly related to the banner."
+        ]
+      }
+    ]
+  },
+  "variants": {
+    "axes": {
+      "Type": [
+        "Primary",
+        "Success",
+        "Warning",
+        "Danger"
+      ],
+      "Orientation": [
+        "Horizontal",
+        "Vertical"
+      ]
+    }
+  },
+  "examples": null,
+  "screenshots": null,
+  "behavior": null
+}

--- a/plugins/actian-design-system/vendor/components/guidelines/avatar.json
+++ b/plugins/actian-design-system/vendor/components/guidelines/avatar.json
@@ -1,0 +1,41 @@
+{
+  "component": "Avatar",
+  "page_id": "9253:18762",
+  "extracted_at": "2026-03-25T00:00:00Z",
+  "frames_found": [
+    "Design guidelines",
+    "Content guidelines",
+    "Components",
+    "Screenshots of use cases"
+  ],
+  "frames_missing": [
+    "ready made examples",
+    "Behavior demo"
+  ],
+  "content_guidelines": {
+    "sections": [
+      {
+        "heading": "Content",
+        "content": [
+          {
+            "rule": "Represent users in lists, comments, settings."
+          },
+          {
+            "rule": "Default to initials (first + last) when photo unavailable."
+          },
+          {
+            "rule": "Don't show full names in small containers."
+          }
+        ]
+      }
+    ]
+  },
+  "design_guidelines": null,
+  "variants": null,
+  "examples": null,
+  "screenshots": {
+    "count": 1,
+    "contexts": []
+  },
+  "behavior": null
+}

--- a/plugins/actian-design-system/vendor/components/guidelines/badge.json
+++ b/plugins/actian-design-system/vendor/components/guidelines/badge.json
@@ -1,0 +1,41 @@
+{
+  "component": "Badge",
+  "page_id": "9253:20900",
+  "extracted_at": "2026-03-25T00:00:00Z",
+  "frames_found": [
+    "Design guidelines",
+    "Content guidelines",
+    "Components",
+    "Ready made examples"
+  ],
+  "frames_missing": [
+    "Screenshots of use cases",
+    "Behavior demo"
+  ],
+  "content_guidelines": {
+    "sections": [
+      {
+        "heading": "Content",
+        "content": [
+          {
+            "rule": "Number badges appear with number ONLY."
+          },
+          {
+            "rule": "Optionally include tooltip for explanation (e.g., '5 unread notifications')."
+          },
+          {
+            "rule": "Non-clickable."
+          },
+          {
+            "rule": "Updated dynamically."
+          }
+        ]
+      }
+    ]
+  },
+  "design_guidelines": null,
+  "variants": null,
+  "examples": null,
+  "screenshots": null,
+  "behavior": null
+}

--- a/plugins/actian-design-system/vendor/components/guidelines/bar-graph.json
+++ b/plugins/actian-design-system/vendor/components/guidelines/bar-graph.json
@@ -1,0 +1,29 @@
+{
+  "component": "⛔️ Bar graph",
+  "_stub": true,
+  "_stubGeneratedAt": "2026-05-04T14:37:24.649Z",
+  "page_id": "15473:49489",
+  "extracted_at": "2026-05-04T14:37:24.649Z",
+  "frames_found": [],
+  "frames_missing": [
+    "Design guidelines",
+    "Content guidelines",
+    "Components",
+    "Screenshots of use cases",
+    "Behavior demo",
+    "ready made examples"
+  ],
+  "content_guidelines": null,
+  "design_guidelines": null,
+  "variants": {
+    "axes": {
+      "Property 1": [
+        "Default"
+      ]
+    },
+    "totalVariants": 1
+  },
+  "examples": null,
+  "screenshots": null,
+  "behavior": null
+}

--- a/plugins/actian-design-system/vendor/components/guidelines/breadcrumbs.json
+++ b/plugins/actian-design-system/vendor/components/guidelines/breadcrumbs.json
@@ -1,0 +1,24 @@
+{
+  "component": "Breadcrumbs",
+  "page_id": "9253:21088",
+  "extracted_at": "2026-03-25T00:00:00Z",
+  "frames_found": [
+    "Screenshots of use cases"
+  ],
+  "frames_missing": [
+    "Content guidelines",
+    "design guidelines",
+    "Components",
+    "ready made examples",
+    "Behavior demo"
+  ],
+  "content_guidelines": null,
+  "design_guidelines": null,
+  "variants": null,
+  "examples": null,
+  "screenshots": {
+    "count": 1,
+    "contexts": []
+  },
+  "behavior": null
+}

--- a/plugins/actian-design-system/vendor/components/guidelines/button.json
+++ b/plugins/actian-design-system/vendor/components/guidelines/button.json
@@ -1,0 +1,121 @@
+{
+  "component": "Button",
+  "page_id": "9085:24375",
+  "extracted_at": "2026-03-25T12:00:00Z",
+  "frames_found": [
+    "Content guidelines",
+    "Components",
+    "Screenshots of use cases"
+  ],
+  "frames_missing": [
+    "Design guidelines",
+    "ready made examples",
+    "Behavior demo"
+  ],
+  "content_guidelines": {
+    "sections": [
+      {
+        "heading": "Terminology for button labeling",
+        "content": [
+          {
+            "term": "Cancel vs Close",
+            "rule": "Use 'Cancel' to back out of a page/modal when information has been entered or confirmation is required. It should allow the user to return to the previous state without saving any changes. Use 'Close' for read-only messages or screens."
+          },
+          {
+            "term": "Create vs Add vs Insert",
+            "rule": "Use 'Create' when the user is making something brand new or bringing individual components to form something new. Use 'Add' when the user is bringing in similar information that already exists elsewhere. Use 'Insert' when the user is bringing in similar information and the ordering is important.",
+            "examples": [
+              "Create report",
+              "Create warehouse",
+              "Add to bid sheet",
+              "Add note",
+              "Insert property"
+            ],
+            "note": "The plus (+) icon is only needed when you are creating a new object to add to something else. When adding an existing object to a list, it's not needed."
+          },
+          {
+            "term": "OK",
+            "rule": "Use 'OK' for read-only pages that are not legally required to accept."
+          },
+          {
+            "term": "Accept and Decline",
+            "rule": "Use 'Accept' when legal terms of services need to be acknowledged before the user can proceed. 'Accept' can also be used with 'Decline' when the user must choose whether to implement proposed changes from someone else (or AI)."
+          },
+          {
+            "term": "Got it!",
+            "rule": "Use 'Got it!' when providing information confirmation modals where the user doesn't have to do anything."
+          },
+          {
+            "term": "Select vs Choose",
+            "rule": "Use 'Select' when the user is picking from a list with limited options. Use 'Choose' when the user is picking from a large number of options or an open-ended decision."
+          },
+          {
+            "term": "Submit vs Send vs Save",
+            "rule": "Use 'Submit' for a form. Use 'Send' only for email. Use 'Save' when the user is adding or changing selections on a modal."
+          },
+          {
+            "term": "View vs See",
+            "rule": "Use 'View' as a noun (e.g., 'Table view'). Use 'See' as a verb, but only with a modifier (e.g., 'See more')."
+          }
+        ]
+      },
+      {
+        "heading": "Stepper buttons",
+        "content": [
+          {
+            "rule": "Use verb + object for the creation button. With few exceptions, the verb should be 'Create'.",
+            "do": "Create integration",
+            "dont": "Integration (do not use a noun as a button label)"
+          },
+          {
+            "rule": "An exception: When the button is a dropdown, such as the Create button on the Home page. Just the verb is needed.",
+            "do": "Create"
+          },
+          {
+            "rule": "Use ONLY the verb (without the object) when finishing a stepper.",
+            "do": "Cancel / Create",
+            "dont": "Create integration (do NOT use the verb + noun to FINISH a stepper)"
+          },
+          {
+            "note": "In modals and steppers, the initial button and the final button should follow this guideline and use the same term in most cases! The exceptions are listed above (such as using the Save button instead)."
+          }
+        ]
+      }
+    ]
+  },
+  "design_guidelines": null,
+  "variants": {
+    "axes": {
+      "Type": [
+        "Primary",
+        "Secondary",
+        "Tertiary",
+        "Icon",
+        "Critical primary",
+        "Critical secondary"
+      ],
+      "Size": [
+        "Default",
+        "Small"
+      ],
+      "State": [
+        "Default",
+        "Hovered",
+        "Focused",
+        "Pressed",
+        "Selected",
+        "Disabled"
+      ]
+    },
+    "totalVariants": 72
+  },
+  "examples": null,
+  "screenshots": {
+    "count": 13,
+    "contexts": [
+      "Product screenshots showing button usage across the Actian platform",
+      "13 screenshots dated 2026-02-20 showing real UI implementations including forms, modals, headers, and data tables"
+    ]
+  },
+  "behavior": null
+}

--- a/plugins/actian-design-system/vendor/components/guidelines/calendar.json
+++ b/plugins/actian-design-system/vendor/components/guidelines/calendar.json
@@ -1,0 +1,110 @@
+{
+  "component": "Calendar",
+  "page_id": "12070:77589",
+  "extracted_at": "2026-03-25T12:00:00Z",
+  "frames_found": [
+    "Content guidelines",
+    "Components"
+  ],
+  "frames_missing": [
+    "Design guidelines",
+    "Screenshots of use cases",
+    "ready made examples",
+    "Behavior demo"
+  ],
+  "content_guidelines": {
+    "sections": [
+      {
+        "heading": "When to use",
+        "content": [
+          {
+            "rule": "Use for anything involving date ranges, filtering, or scheduling."
+          }
+        ]
+      },
+      {
+        "heading": "Style",
+        "content": [
+          {
+            "rule": "Use labels like 'From' and 'To', or 'Start date' and 'End date' for range fields."
+          },
+          {
+            "dont": "Leave any fields unlabeled."
+          },
+          {
+            "rule": "Display formats clearly (mm/dd/yyyy or regional format) with placeholders or hints where appropriate."
+          },
+          {
+            "dont": "Pre-fill dates for users."
+          }
+        ]
+      },
+      {
+        "heading": "Behavior",
+        "content": [
+          {
+            "rule": "Support both typing and calendar picking."
+          },
+          {
+            "rule": "Auto-close the calendar when the selection is complete."
+          },
+          {
+            "rule": "Highlight today, weekends, and other necessarily blocked dates visually when appropriate."
+          },
+          {
+            "rule": "Visually display any range in the calendar."
+          }
+        ]
+      }
+    ]
+  },
+  "design_guidelines": null,
+  "variants": {
+    "axes": {
+      "Type": [
+        "Single date select",
+        "Date range"
+      ],
+      "Selection": [
+        "Single",
+        "Range"
+      ],
+      "Display type": [
+        "Dates",
+        "Months",
+        "Years"
+      ],
+      "State (input)": [
+        "Enabled",
+        "Hovered",
+        "Focused",
+        "Active",
+        "Filled",
+        "Error",
+        "Disabled"
+      ],
+      "State (calendar item)": [
+        "Default",
+        "Hovered",
+        "Focused",
+        "Selected",
+        "Disabled"
+      ]
+    },
+    "sub_component": {
+      "name": ".Calendar item",
+      "axes": {
+        "State": [
+          "Default",
+          "Hovered",
+          "Focused",
+          "Selected",
+          "Disabled"
+        ]
+      }
+    }
+  },
+  "examples": null,
+  "screenshots": null,
+  "behavior": null
+}

--- a/plugins/actian-design-system/vendor/components/guidelines/card.json
+++ b/plugins/actian-design-system/vendor/components/guidelines/card.json
@@ -1,0 +1,90 @@
+{
+  "component": "Card",
+  "page_id": "9253:21106",
+  "extracted_at": "2026-03-25T00:00:00Z",
+  "frames_found": [
+    "Content guidelines",
+    "Components",
+    "Screenshots of current use cases"
+  ],
+  "frames_missing": [
+    "design guidelines",
+    "ready made examples",
+    "Behavior demo"
+  ],
+  "content_guidelines": {
+    "sections": [
+      {
+        "heading": "When to use (catalogs/items)",
+        "content": [
+          {
+            "rule": "Main dashboard item display."
+          },
+          {
+            "rule": "Details pages."
+          },
+          {
+            "rule": "Represent single object/dataset."
+          }
+        ]
+      },
+      {
+        "heading": "Format (catalogs/items)",
+        "content": [
+          {
+            "rule": "Headline/title with optional metadata tags."
+          },
+          {
+            "rule": "Hierarchy: Headline, Tags, Description."
+          }
+        ]
+      },
+      {
+        "heading": "Behavior (catalogs/items)",
+        "content": [
+          {
+            "rule": "Click tile (except title) to open in right-side drawer."
+          },
+          {
+            "rule": "Click title to open details page."
+          }
+        ]
+      },
+      {
+        "heading": "When to use (topics)",
+        "content": [
+          {
+            "rule": "ONLY on main Explorer dashboard."
+          },
+          {
+            "rule": "Clickable gateways to curated collections."
+          }
+        ]
+      },
+      {
+        "heading": "Format (topics)",
+        "content": [
+          {
+            "rule": "Hierarchy: Icon, Headline, # items, Description (1-2 lines)."
+          }
+        ]
+      },
+      {
+        "heading": "Behavior (topics)",
+        "content": [
+          {
+            "rule": "Click anywhere to open catalog with topic filters."
+          }
+        ]
+      }
+    ]
+  },
+  "design_guidelines": null,
+  "variants": null,
+  "examples": null,
+  "screenshots": {
+    "count": 1,
+    "contexts": []
+  },
+  "behavior": null
+}

--- a/plugins/actian-design-system/vendor/components/guidelines/chat-with-ai-steward.json
+++ b/plugins/actian-design-system/vendor/components/guidelines/chat-with-ai-steward.json
@@ -1,0 +1,34 @@
+{
+  "component": "Chat with AI Steward",
+  "_stub": true,
+  "_stubGeneratedAt": "2026-05-04T14:37:24.649Z",
+  "page_id": "15464:24509",
+  "extracted_at": "2026-05-04T14:37:24.649Z",
+  "frames_found": [],
+  "frames_missing": [
+    "Design guidelines",
+    "Content guidelines",
+    "Components",
+    "Screenshots of use cases",
+    "Behavior demo",
+    "ready made examples"
+  ],
+  "content_guidelines": null,
+  "design_guidelines": null,
+  "variants": {
+    "axes": {
+      "size": [
+        "Default",
+        "Drawer"
+      ],
+      "history": [
+        "Closed",
+        "Open"
+      ]
+    },
+    "totalVariants": 4
+  },
+  "examples": null,
+  "screenshots": null,
+  "behavior": null
+}

--- a/plugins/actian-design-system/vendor/components/guidelines/checkbox-with-label.json
+++ b/plugins/actian-design-system/vendor/components/guidelines/checkbox-with-label.json
@@ -1,0 +1,38 @@
+{
+  "component": "Checkbox with label",
+  "_stub": true,
+  "_stubGeneratedAt": "2026-05-04T14:37:24.649Z",
+  "page_id": "9478:17216",
+  "extracted_at": "2026-05-04T14:37:24.649Z",
+  "frames_found": [],
+  "frames_missing": [
+    "Design guidelines",
+    "Content guidelines",
+    "Components",
+    "Screenshots of use cases",
+    "Behavior demo",
+    "ready made examples"
+  ],
+  "content_guidelines": null,
+  "design_guidelines": null,
+  "variants": {
+    "axes": {
+      "Selected": [
+        "Yes",
+        "Indeterminate",
+        "No"
+      ],
+      "State": [
+        "Default",
+        "Hover",
+        "Focus",
+        "Pressed",
+        "Disabled"
+      ]
+    },
+    "totalVariants": 15
+  },
+  "examples": null,
+  "screenshots": null,
+  "behavior": null
+}

--- a/plugins/actian-design-system/vendor/components/guidelines/checkbox.json
+++ b/plugins/actian-design-system/vendor/components/guidelines/checkbox.json
@@ -1,0 +1,109 @@
+{
+  "component": "Checkbox",
+  "page_id": "12070:77593",
+  "extracted_at": "2026-03-26T00:00:00Z",
+  "frames_found": [
+    "Design guidelines",
+    "Content guidelines",
+    "Components",
+    "Screenshots of current use cases"
+  ],
+  "frames_missing": [
+    "ready made examples",
+    "Behavior demo"
+  ],
+  "content_guidelines": {
+    "sections": [
+      {
+        "heading": "Default format - When to use",
+        "content": [
+          {
+            "rule": "Allow users to select multiple options."
+          },
+          {
+            "rule": "Binary settings independent of other choices."
+          },
+          {
+            "rule": "Filtering/refining data."
+          }
+        ]
+      },
+      {
+        "heading": "Default format - Style",
+        "content": [
+          {
+            "rule": "Use clear, direct labels."
+          },
+          {
+            "do": "Show archived items",
+            "dont": "Don't hide archived items"
+          },
+          {
+            "rule": "Group related checkboxes under group label."
+          }
+        ]
+      },
+      {
+        "heading": "Card format - When to use",
+        "content": [
+          {
+            "rule": "When each option needs rich context (title, description, image, metadata)."
+          },
+          {
+            "rule": "Primary decision points."
+          }
+        ]
+      },
+      {
+        "heading": "Card format - Behavior",
+        "content": [
+          {
+            "rule": "Indicate selected state visually."
+          },
+          {
+            "rule": "Click anywhere on tile to toggle."
+          },
+          {
+            "rule": "Multi-select: checkbox behavior. Single-select: radio group behavior."
+          }
+        ]
+      }
+    ]
+  },
+  "has_design_guidelines": true,
+  "design_guidelines": {
+    "sections": [
+      {
+        "heading": "Anatomy",
+        "items": [
+          "1. Checkbox (24px square with rounded corners, --zen-radius-default)",
+          "2. Label (inline text, vertically centered with checkbox)"
+        ]
+      },
+      {
+        "heading": "Specs",
+        "items": [
+          "Checkbox size: 24px x 24px.",
+          "Gap between checkbox and label: 4px (--zen-spacing-2xs).",
+          "Label is vertically centered with the checkbox."
+        ]
+      },
+      {
+        "heading": "Checkbox group layout",
+        "items": [
+          "Group label and description separated by 4px gap.",
+          "Gap between group header (label + description) and first checkbox item: 8px.",
+          "Gap between individual checkbox items in a group: 8px."
+        ]
+      }
+    ]
+  },
+  "variants": null,
+  "examples": null,
+  "screenshots": {
+    "count": 1,
+    "contexts": []
+  },
+  "behavior": null,
+  "_note": "Variant metadata could not be retrieved due to Figma MCP tool call limit. Re-run extraction when limit resets."
+}

--- a/plugins/actian-design-system/vendor/components/guidelines/collapse-accordion.json
+++ b/plugins/actian-design-system/vendor/components/guidelines/collapse-accordion.json
@@ -1,0 +1,50 @@
+{
+  "component": "Collapse / Accordion",
+  "page_id": "9253:20890",
+  "extracted_at": "2026-03-26T00:00:00Z",
+  "frames_found": [
+    "Design guidelines",
+    "Content guidelines",
+    "Components"
+  ],
+  "frames_missing": [
+    "ready made examples",
+    "Screenshots of use cases",
+    "Behavior demo"
+  ],
+  "content_guidelines": {
+    "sections": [
+      {
+        "heading": "Content",
+        "content": [
+          {
+            "rule": "Use clear, action-oriented headers ('Show details', 'Advanced settings')."
+          },
+          {
+            "rule": "Keep titles concise and scannable."
+          },
+          {
+            "rule": "Include summary text when collapsed if helpful."
+          }
+        ]
+      }
+    ]
+  },
+  "has_design_guidelines": true,
+  "design_guidelines": {
+    "sections": [
+      {
+        "heading": "Behavior",
+        "items": [
+          "With few exceptions, only one section should be open at a time. Opening one should close the currently open one.",
+          "Transitions should be smooth. Avoid layout shift.",
+          "Arrow/chevron icon should rotate to indicate open and closed states."
+        ]
+      }
+    ]
+  },
+  "variants": null,
+  "examples": null,
+  "screenshots": null,
+  "behavior": null
+}

--- a/plugins/actian-design-system/vendor/components/guidelines/confirmation.json
+++ b/plugins/actian-design-system/vendor/components/guidelines/confirmation.json
@@ -1,0 +1,29 @@
+{
+  "component": "Confirmation",
+  "_stub": true,
+  "_stubGeneratedAt": "2026-05-04T14:37:24.649Z",
+  "page_id": "13871:32310",
+  "extracted_at": "2026-05-04T14:37:24.649Z",
+  "frames_found": [],
+  "frames_missing": [
+    "Design guidelines",
+    "Content guidelines",
+    "Components",
+    "Screenshots of use cases",
+    "Behavior demo",
+    "ready made examples"
+  ],
+  "content_guidelines": null,
+  "design_guidelines": null,
+  "variants": {
+    "axes": {
+      "Size": [
+        "Large"
+      ]
+    },
+    "totalVariants": 1
+  },
+  "examples": null,
+  "screenshots": null,
+  "behavior": null
+}

--- a/plugins/actian-design-system/vendor/components/guidelines/data-viz-glossary-item-hierarchy.json
+++ b/plugins/actian-design-system/vendor/components/guidelines/data-viz-glossary-item-hierarchy.json
@@ -1,0 +1,64 @@
+{
+  "component": "Data viz: glossary item hierarchy",
+  "page_id": "14747:29925",
+  "extracted_at": "2026-03-25T00:00:00Z",
+  "frames_found": [
+    "Screenshots of use cases"
+  ],
+  "frames_missing": [
+    "Content guidelines",
+    "Design guidelines",
+    "Components",
+    "ready made examples",
+    "Behavior demo"
+  ],
+  "content_guidelines": null,
+  "design_guidelines": null,
+  "variants": {
+    "axes": {
+      "Glossary item hierarchy diagram": {
+        "node_id": "14747:30211",
+        "description": "Main component containing glossary items and connecting lines",
+        "sub_components": [
+          {
+            "name": "Glossary item",
+            "node_id": "14747:30223",
+            "variants": {
+              "Type": [
+                "Main item",
+                "Sub items"
+              ],
+              "State": [
+                "Default",
+                "Hovered",
+                "Pressed",
+                "Focused",
+                "Selected",
+                "Disabled"
+              ]
+            }
+          },
+          {
+            "name": "Glossary connecting line",
+            "node_id": "14747:30216",
+            "variants": {
+              "Type": [
+                "Straight",
+                "Going down",
+                "Going up"
+              ]
+            }
+          }
+        ]
+      }
+    }
+  },
+  "examples": null,
+  "screenshots": {
+    "count": 1,
+    "contexts": [
+      "Screenshot 2026-02-25 at 10.42.02 AM"
+    ]
+  },
+  "behavior": null
+}

--- a/plugins/actian-design-system/vendor/components/guidelines/data-viz-lineage.json
+++ b/plugins/actian-design-system/vendor/components/guidelines/data-viz-lineage.json
@@ -1,0 +1,101 @@
+{
+  "component": "Data viz: lineage",
+  "page_id": "14747:19872",
+  "extracted_at": "2026-03-25T00:00:00Z",
+  "frames_found": [
+    "Components",
+    "Screenshots of use cases"
+  ],
+  "frames_missing": [
+    "Content guidelines",
+    "Design guidelines",
+    "ready made examples",
+    "Behavior demo"
+  ],
+  "content_guidelines": null,
+  "design_guidelines": null,
+  "variants": {
+    "axes": {
+      "Lineage widget": {
+        "node_id": "14747:19902",
+        "variants": {
+          "Type": [
+            "Main item",
+            "Sub item"
+          ],
+          "State": [
+            "Default",
+            "Selected",
+            "Disabled"
+          ],
+          "Fields": [
+            "Collapsed",
+            "Expanded"
+          ]
+        }
+      },
+      "Lineage connecting line": {
+        "node_id": "14747:20085",
+        "variants": {
+          "Direction": [
+            "Straight",
+            "Down",
+            "Up"
+          ],
+          "State": [
+            "Default",
+            "Selected",
+            "Disabled"
+          ]
+        }
+      },
+      "Lineage expand collapse control": {
+        "node_id": "14747:20046",
+        "variants": {
+          "Icon": [
+            "Collapse",
+            "Expand"
+          ],
+          "State": [
+            "Default",
+            "Disabled"
+          ]
+        }
+      },
+      "Lineage connector icon": {
+        "node_id": "14747:20113",
+        "variants": {
+          "State": [
+            "Default",
+            "Disabled"
+          ]
+        }
+      },
+      "Lineage field": {
+        "node_id": "14747:20078",
+        "variants": {
+          "Type": [
+            "Default"
+          ]
+        }
+      }
+    }
+  },
+  "examples": {
+    "descriptions": [
+      "Lineage graph example showing connected widgets with directional lines (node 14747:20120)",
+      "V2 full-page layout with sidebar, page header, toolbar, and data lineage graph (node 14747:20390)",
+      "Lineage - Selected state with expanded fields and multiple connected nodes (node 14747:20478)",
+      "Lineage - Default - Expanded view showing full graph layout (node 14747:20536)"
+    ]
+  },
+  "screenshots": {
+    "count": 3,
+    "contexts": [
+      "Screenshot 2026-02-25 at 10.39.56 AM - lineage graph in app context",
+      "Screenshot 2026-03-13 at 10.05.13 AM - compact lineage view",
+      "Screenshot 2026-03-20 at 1.42.12 PM - narrow vertical lineage"
+    ]
+  },
+  "behavior": null
+}

--- a/plugins/actian-design-system/vendor/components/guidelines/data-viz-metamodel.json
+++ b/plugins/actian-design-system/vendor/components/guidelines/data-viz-metamodel.json
@@ -1,0 +1,67 @@
+{
+  "component": "Data viz: metamodel",
+  "page_id": "14747:23223",
+  "extracted_at": "2026-03-25T00:00:00Z",
+  "frames_found": [
+    "Components",
+    "Screenshots of use cases"
+  ],
+  "frames_missing": [
+    "Content guidelines",
+    "Design guidelines",
+    "ready made examples",
+    "Behavior demo"
+  ],
+  "content_guidelines": null,
+  "design_guidelines": null,
+  "variants": {
+    "axes": {
+      "Metamodel widget": {
+        "node_id": "14747:23588",
+        "variants": {
+          "Type": [
+            "Dataset",
+            "Visualisation",
+            "Field",
+            "Data Process",
+            "Business Term"
+          ]
+        }
+      },
+      ".metamodel property section": {
+        "node_id": "14747:23614",
+        "variants": {
+          "Section": [
+            "Collapsed",
+            "Expanded"
+          ]
+        }
+      },
+      ".metamodel connecting line": {
+        "node_id": "14747:23654",
+        "variants": {
+          "Direction": [
+            "1",
+            "2",
+            "3",
+            "4"
+          ]
+        }
+      }
+    }
+  },
+  "examples": {
+    "descriptions": [
+      "Metamodel graph example showing connected widgets of different types with connecting lines (node 14747:23642)",
+      "Second example layout with same component arrangement (node 14747:23630)"
+    ]
+  },
+  "screenshots": {
+    "count": 2,
+    "contexts": [
+      "Screenshot 2026-02-25 at 10.38.28 AM - metamodel diagram in app",
+      "Reference screenshot from 2025-06-30 showing metamodel in context"
+    ]
+  },
+  "behavior": null
+}

--- a/plugins/actian-design-system/vendor/components/guidelines/data-viz-progressive-bar.json
+++ b/plugins/actian-design-system/vendor/components/guidelines/data-viz-progressive-bar.json
@@ -1,0 +1,75 @@
+{
+  "component": "Data viz: progressive bar",
+  "page_id": "14136:1567",
+  "extracted_at": "2026-03-26T00:00:00Z",
+  "has_content_guidelines": true,
+  "frames_found": [
+    "Content guidelines",
+    "Components",
+    "Screenshots of current use cases"
+  ],
+  "frames_missing": [
+    "Design guidelines",
+    "ready made examples",
+    "Behavior demo"
+  ],
+  "content_guidelines": {
+    "sections": [
+      {
+        "heading": "Main title",
+        "content": [
+          {
+            "rule": "Use to show progress of a task such as uploads, data processing, or form completion."
+          },
+          {
+            "rule": "Use percentages or absolute numbers when progress can be measured.",
+            "examples": [
+              "65% complete",
+              "5 of 10 files copied",
+              "Step 2 of 5"
+            ]
+          },
+          {
+            "rule": "Use visual-only indicators with a looping animation when the system is working but the length or quantity is unknown."
+          },
+          {
+            "rule": "Upon completion, transition to success state, confirmation message, or next step."
+          },
+          {
+            "dont": "Avoid freezing the progress indicator -- always provide user feedback if stalled."
+          }
+        ]
+      }
+    ]
+  },
+  "design_guidelines": null,
+  "variants": {
+    "axes": {
+      "Progress bar": {
+        "node_id": "14136:1615",
+        "variants": {
+          "Size": [
+            "Default",
+            "Large"
+          ],
+          "Completeness": [
+            "0%",
+            "50%",
+            "100%"
+          ]
+        }
+      }
+    }
+  },
+  "examples": null,
+  "screenshots": {
+    "count": 1,
+    "contexts": [
+      "Screenshot 2026-03-10 at 3.33.50 PM - progress bar in loading context"
+    ]
+  },
+  "behavior": null,
+  "notes": [
+    "Jeff's note: Based on guidelines research, we do need to add some text to the current design, such as 'Loading Studio', or whatever is appropriate."
+  ]
+}

--- a/plugins/actian-design-system/vendor/components/guidelines/data-viz-toolbar.json
+++ b/plugins/actian-design-system/vendor/components/guidelines/data-viz-toolbar.json
@@ -1,0 +1,53 @@
+{
+  "component": "Data viz: toolbar",
+  "page_id": "8239:5170",
+  "extracted_at": "2026-03-25T00:00:00Z",
+  "frames_found": [
+    "Components",
+    "Screenshots of use cases"
+  ],
+  "frames_missing": [
+    "Content guidelines",
+    "Design guidelines",
+    "ready made examples",
+    "Behavior demo"
+  ],
+  "content_guidelines": null,
+  "design_guidelines": null,
+  "variants": {
+    "axes": {
+      "Toolbar": {
+        "node_id": "14335:16907",
+        "variants": {
+          "Type": [
+            "Single",
+            "Group",
+            "Combined"
+          ],
+          "Orientation": [
+            "Horizontal",
+            "Vertical"
+          ]
+        }
+      }
+    }
+  },
+  "examples": {
+    "descriptions": [
+      "V2 full-page layout showing toolbar in data lineage context with sidebar, page header, tabs, dropdowns, search, and icon buttons (node 14241:37014)"
+    ]
+  },
+  "screenshots": {
+    "count": 7,
+    "contexts": [
+      "Screenshot 2026-02-25 at 10.38.28 AM - toolbar in metamodel view",
+      "Screenshot 2026-02-25 at 10.39.56 AM - toolbar in lineage view",
+      "Screenshot 2026-02-25 at 10.40.07 AM - toolbar in another data viz context",
+      "Screenshot 2026-02-25 at 10.42.02 AM - toolbar in glossary view",
+      "Screenshot 2026-03-13 at 10.05.13 AM - compact toolbar",
+      "Reference screenshot from 2025-06-30 - toolbar in app context",
+      "Screenshot 2026-03-17 at 9.24.33 AM - toolbar variant"
+    ]
+  },
+  "behavior": null
+}

--- a/plugins/actian-design-system/vendor/components/guidelines/data-viz-wip-all-others.json
+++ b/plugins/actian-design-system/vendor/components/guidelines/data-viz-wip-all-others.json
@@ -1,0 +1,52 @@
+{
+  "component": "Data viz: WIP all others",
+  "page_id": "14747:33303",
+  "extracted_at": "2026-03-25T00:00:00Z",
+  "frames_found": [
+    "Components",
+    "Screenshots of use cases"
+  ],
+  "frames_missing": [
+    "Content guidelines",
+    "Design guidelines",
+    "ready made examples",
+    "Behavior demo"
+  ],
+  "content_guidelines": null,
+  "design_guidelines": null,
+  "variants": {
+    "axes": {
+      ".data-viz-legend-item": {
+        "node_id": "14747:33310",
+        "variants": {
+          "Property 1": [
+            "Default",
+            "Hovered",
+            "Focused",
+            "Pressed",
+            "Selected"
+          ]
+        }
+      },
+      "Line graph": {
+        "node_id": "14747:33326",
+        "note": "Instance, no variant axes discovered from metadata"
+      },
+      "Bar graph": {
+        "node_id": "14747:33327",
+        "note": "Instance, no variant axes discovered from metadata"
+      }
+    }
+  },
+  "examples": null,
+  "screenshots": {
+    "count": 4,
+    "contexts": [
+      "Screenshot 2026-03-17 at 9.24.33 AM - chart visualization",
+      "Screenshot 2026-03-13 at 10.06.29 AM - data viz in app",
+      "Screenshot 2026-03-13 at 10.05.36 AM - wider data viz view",
+      "Screenshot 2026-02-25 at 10.40.07 AM - another data viz context"
+    ]
+  },
+  "behavior": null
+}

--- a/plugins/actian-design-system/vendor/components/guidelines/digram-item-types.json
+++ b/plugins/actian-design-system/vendor/components/guidelines/digram-item-types.json
@@ -1,0 +1,60 @@
+{
+  "component": "Digram, Item types",
+  "_stub": true,
+  "_stubGeneratedAt": "2026-05-04T14:37:24.649Z",
+  "page_id": "14007:23209",
+  "extracted_at": "2026-05-04T14:37:24.649Z",
+  "frames_found": [],
+  "frames_missing": [
+    "Design guidelines",
+    "Content guidelines",
+    "Components",
+    "Screenshots of use cases",
+    "Behavior demo",
+    "ready made examples"
+  ],
+  "content_guidelines": null,
+  "design_guidelines": null,
+  "variants": {
+    "axes": {
+      "Item type": [
+        "Dataset",
+        "Data process",
+        "Data product",
+        "Field",
+        "Output port",
+        "Use case",
+        "Visualization",
+        "Category",
+        "Custom 1",
+        "Custom 2",
+        "Custom 3",
+        "Custom 4",
+        "Custom 5",
+        "Custom 6",
+        "Custom 7",
+        "Custom 8",
+        "Custom 9",
+        "Custom 10",
+        "Custom 11",
+        "Custom 12",
+        "Custom 13",
+        "Custom 14",
+        "Custom 16",
+        "Glossary 1",
+        "Glossary 2",
+        "Glossary 3",
+        "Glossary 4",
+        "Glossary 5"
+      ],
+      "Size": [
+        "Default",
+        "Large"
+      ]
+    },
+    "totalVariants": 56
+  },
+  "examples": null,
+  "screenshots": null,
+  "behavior": null
+}

--- a/plugins/actian-design-system/vendor/components/guidelines/digram-topic.json
+++ b/plugins/actian-design-system/vendor/components/guidelines/digram-topic.json
@@ -1,0 +1,38 @@
+{
+  "component": "Digram, Topic",
+  "_stub": true,
+  "_stubGeneratedAt": "2026-05-04T14:37:24.649Z",
+  "page_id": "14128:3800",
+  "extracted_at": "2026-05-04T14:37:24.649Z",
+  "frames_found": [],
+  "frames_missing": [
+    "Design guidelines",
+    "Content guidelines",
+    "Components",
+    "Screenshots of use cases",
+    "Behavior demo",
+    "ready made examples"
+  ],
+  "content_guidelines": null,
+  "design_guidelines": null,
+  "variants": {
+    "axes": {
+      "Type": [
+        "Light purple",
+        "Dark purple",
+        "Light blue",
+        "Dark blue",
+        "Light green",
+        "Dark green",
+        "Yellow",
+        "Orange",
+        "Red",
+        "Dark orange"
+      ]
+    },
+    "totalVariants": 10
+  },
+  "examples": null,
+  "screenshots": null,
+  "behavior": null
+}

--- a/plugins/actian-design-system/vendor/components/guidelines/digram.json
+++ b/plugins/actian-design-system/vendor/components/guidelines/digram.json
@@ -1,0 +1,88 @@
+{
+  "component": "Digram",
+  "page_id": "14007:22442",
+  "extracted_at": "2026-03-25T00:00:00Z",
+  "frames_found": [
+    "Components",
+    "Screenshots of current use cases"
+  ],
+  "frames_missing": [
+    "Content guidelines",
+    "Design guidelines",
+    "ready made examples",
+    "Behavior demo"
+  ],
+  "content_guidelines": null,
+  "design_guidelines": null,
+  "variants": {
+    "axes": {
+      "Digram, Item types": {
+        "node_id": "14007:23209",
+        "variants": {
+          "Item type": [
+            "Category",
+            "Dataset",
+            "Data process",
+            "Data product",
+            "Field",
+            "Output port",
+            "Use case",
+            "Visualization",
+            "Custom 1",
+            "Custom 2",
+            "Custom 3",
+            "Custom 4",
+            "Custom 5",
+            "Custom 6",
+            "Custom 7",
+            "Custom 8",
+            "Custom 9",
+            "Custom 10",
+            "Custom 11",
+            "Custom 12",
+            "Custom 13",
+            "Custom 14",
+            "Custom 16",
+            "Glossary 1",
+            "Glossary 2",
+            "Glossary 3",
+            "Glossary 4",
+            "Glossary 5"
+          ],
+          "Size": [
+            "Default",
+            "Large"
+          ]
+        }
+      },
+      "Digram, Topic": {
+        "node_id": "14128:3800",
+        "variants": {
+          "Type": [
+            "Light purple",
+            "Dark purple",
+            "Light blue",
+            "Dark blue",
+            "Light green",
+            "Dark green",
+            "Yellow",
+            "Orange",
+            "Red",
+            "Dark orange"
+          ]
+        }
+      }
+    }
+  },
+  "examples": null,
+  "screenshots": {
+    "count": 4,
+    "contexts": [
+      "Screenshot 2026-03-03 at 4.04.47 PM - digram in app",
+      "Screenshot 2026-03-03 at 3.26.41 PM - digram compact view",
+      "Screenshot 2026-03-03 at 3.34.32 PM - digram expanded view",
+      "Screenshot 2026-03-13 at 9.49.34 AM - digram with annotations"
+    ]
+  },
+  "behavior": null
+}

--- a/plugins/actian-design-system/vendor/components/guidelines/drawer-side-panel.json
+++ b/plugins/actian-design-system/vendor/components/guidelines/drawer-side-panel.json
@@ -1,0 +1,33 @@
+{
+  "component": "Drawer, side panel",
+  "_stub": true,
+  "_stubGeneratedAt": "2026-05-04T14:37:24.649Z",
+  "page_id": "14294:5758",
+  "extracted_at": "2026-05-04T14:37:24.649Z",
+  "frames_found": [],
+  "frames_missing": [
+    "Design guidelines",
+    "Content guidelines",
+    "Components",
+    "Screenshots of use cases",
+    "Behavior demo",
+    "ready made examples"
+  ],
+  "content_guidelines": null,
+  "design_guidelines": null,
+  "variants": {
+    "axes": {
+      "App": ["Studio", "Explorer"]
+    },
+    "totalVariants": 2
+  },
+  "examples": null,
+  "screenshots": null,
+  "behavior": {
+    "motion": {
+      "pattern": "drawer",
+      "overrides": null,
+      "notes": "Same canonical drawer choreography as the Drawer component (open: duration-slow + ease-entrance, close: duration-base + ease-exit). Note: this guideline is a stub — the motion data is forward-compatible; brief output requires the stub to be curated first OR card_motion routing to be updated to bypass the stub short-circuit."
+    }
+  }
+}

--- a/plugins/actian-design-system/vendor/components/guidelines/drawer.json
+++ b/plugins/actian-design-system/vendor/components/guidelines/drawer.json
@@ -1,0 +1,35 @@
+{
+  "component": "Drawer / Side panel",
+  "page_id": "12054:49858",
+  "extracted_at": "2026-03-25T00:00:00Z",
+  "frames_found": ["Components", "Screenshots of current use cases"],
+  "frames_missing": [
+    "Content guidelines",
+    "Design guidelines",
+    "ready made examples",
+    "Screenshots of use cases",
+    "Behavior demo"
+  ],
+  "content_guidelines": null,
+  "design_guidelines": null,
+  "variants": {
+    "axes": {
+      "App": ["Studio", "Explorer"]
+    }
+  },
+  "examples": null,
+  "screenshots": {
+    "count": 14,
+    "contexts": [
+      "Frame 1: 5 screenshots showing Studio drawer use cases (2026-03-12)",
+      "Frame 2: 9 screenshots showing Explorer drawer use cases (2026-03-12)"
+    ]
+  },
+  "behavior": {
+    "motion": {
+      "pattern": "drawer",
+      "overrides": null,
+      "notes": "Canonical drawer choreography. Open uses duration-slow + ease-entrance (responsive feel that settles); close uses duration-base + ease-exit (clears out faster)."
+    }
+  }
+}

--- a/plugins/actian-design-system/vendor/components/guidelines/dropdown-select-default.json
+++ b/plugins/actian-design-system/vendor/components/guidelines/dropdown-select-default.json
@@ -1,0 +1,40 @@
+{
+  "component": "Dropdown, Select, default",
+  "_stub": true,
+  "_stubGeneratedAt": "2026-05-04T14:37:24.649Z",
+  "page_id": "13972:708",
+  "extracted_at": "2026-05-04T14:37:24.649Z",
+  "frames_found": [],
+  "frames_missing": [
+    "Design guidelines",
+    "Content guidelines",
+    "Components",
+    "Screenshots of use cases",
+    "Behavior demo",
+    "ready made examples"
+  ],
+  "content_guidelines": null,
+  "design_guidelines": null,
+  "variants": {
+    "axes": {
+      "Type": [
+        "Default",
+        "Search/Multiple",
+        "With avatar",
+        "Compact/Custom"
+      ],
+      "State": [
+        "Default",
+        "Hovered",
+        "Focused",
+        "Active",
+        "Filled",
+        "Disabled"
+      ]
+    },
+    "totalVariants": 24
+  },
+  "examples": null,
+  "screenshots": null,
+  "behavior": null
+}

--- a/plugins/actian-design-system/vendor/components/guidelines/dropdown-select.json
+++ b/plugins/actian-design-system/vendor/components/guidelines/dropdown-select.json
@@ -1,0 +1,103 @@
+{
+  "component": "Dropdown / Select",
+  "page_id": "12070:77588",
+  "extracted_at": "2026-03-25T12:00:00Z",
+  "frames_found": [
+    "Content guidelines",
+    "Components",
+    "Screenshots of use cases"
+  ],
+  "frames_missing": [
+    "Design guidelines",
+    "ready made examples",
+    "Behavior demo"
+  ],
+  "content_guidelines": {
+    "sections": [
+      {
+        "heading": "When to use",
+        "content": [
+          {
+            "rule": "When offering 2-7 related actions that can't fit inline."
+          },
+          {
+            "rule": "When top-level button triggers default action with dropdown alternatives."
+          },
+          {
+            "rule": "For bulk/item-level controls."
+          }
+        ]
+      },
+      {
+        "heading": "Behavior",
+        "content": [
+          {
+            "rule": "Menu opens on click (not hover)."
+          },
+          {
+            "rule": "Close menu on ESC key or outside click."
+          }
+        ]
+      },
+      {
+        "heading": "Style",
+        "content": [
+          {
+            "rule": "Label the button with a clear action or noun (ex: 'Actions', 'More')."
+          },
+          {
+            "rule": "Menu items should be verb + noun (ex: 'Download PDF', 'Add tag', 'Delete record')."
+          },
+          {
+            "rule": "Use sentence case."
+          },
+          {
+            "rule": "Multi-selection dropdowns: include checkboxes, and selections should persist."
+          }
+        ]
+      }
+    ]
+  },
+  "design_guidelines": null,
+  "variants": {
+    "axes": {
+      "Type": [
+        "Default",
+        "Search/Multiple",
+        "With avatar",
+        "Compact/Custom"
+      ],
+      "State": [
+        "Default",
+        "Hovered",
+        "Focused",
+        "Active",
+        "Filled",
+        "Disabled"
+      ],
+      "Menu item type": [
+        "Selectable item",
+        "Category",
+        "Divider"
+      ],
+      "Menu item state": [
+        "Default",
+        "Hovered",
+        "Focused",
+        "Pressed",
+        "Selected"
+      ]
+    },
+    "note": "Uses PrimeNG Select (third party)"
+  },
+  "examples": null,
+  "screenshots": {
+    "count": 10,
+    "contexts": [
+      "Product screenshots showing dropdown in various contexts (2026-02-27)",
+      "Storybook documentation captures for DropdownButtonComponent",
+      "Screenshots of compact/custom dropdown, search/multiple dropdown, and with-avatar dropdown in real product UI"
+    ]
+  },
+  "behavior": null
+}

--- a/plugins/actian-design-system/vendor/components/guidelines/empty-state.json
+++ b/plugins/actian-design-system/vendor/components/guidelines/empty-state.json
@@ -1,0 +1,206 @@
+{
+  "component": "Empty state",
+  "page_id": "7314:3195",
+  "extracted_at": "2026-03-26T00:00:00Z",
+  "frames_found": [
+    "Content guidelines",
+    "Design guidelines",
+    "Components"
+  ],
+  "frames_missing": [
+    "ready made examples",
+    "Screenshots of use cases",
+    "Screenshots of current use cases",
+    "Behavior demo"
+  ],
+  "content_guidelines": {
+    "sections": [
+      {
+        "heading": "Empty state",
+        "content": [
+          {
+            "rule": "Empty states should be used when the expected content cannot be displayed. They can be used to provide instructions, guidance, or information to the user.",
+            "examples": [
+              "The tone should be direct and helpful.",
+              "Action-first CTAs should be used whenever possible.",
+              "Be consistent and prioritize important pieces."
+            ]
+          }
+        ]
+      },
+      {
+        "heading": "Types",
+        "content": [
+          {
+            "term": "No data empty states",
+            "rule": "These are the most recognizable first use empty states, explaining what will be in the space once it is populated with data, and providing guidance for the next step the user can take to populate the space."
+          },
+          {
+            "term": "User action empty states",
+            "rule": "These empty states occur as a result of a user action.",
+            "examples": [
+              "No Results: A message showing there are no search results",
+              "Confirmation: A success confirmation for completion of a process or set of tasks"
+            ],
+            "note": "Should provide follow up step to guide the user."
+          }
+        ]
+      },
+      {
+        "heading": "Usage",
+        "content": [
+          {
+            "rule": "Based on the use case, use different types of empty states where appropriate:",
+            "examples": [
+              {
+                "use_case": "Full page list or feature",
+                "solution": "Large illustration",
+                "cta_example": "Create your first project"
+              },
+              {
+                "use_case": "Smaller window pane or widget",
+                "solution": "Small illustration or icon",
+                "cta_example": "Optional/situational: (Create policy)"
+              },
+              {
+                "use_case": "Multiple empty states on one page",
+                "solution": "*Prioritize most important",
+                "cta_example": "Start here"
+              },
+              {
+                "use_case": "No user action possible",
+                "solution": "No illustration, text only.",
+                "cta_example": "No access requests created yet"
+              }
+            ]
+          },
+          {
+            "note": "*Prioritize: Determine most important empty state (e.g., tasks list over sidebar widgets). Use full-page empty state with large illustration if primary area is empty. Use smaller inline empty states without illustration for support/smaller areas. There should only be one large empty state."
+          },
+          {
+            "term": "Image choice considerations",
+            "rule": "The image choice should relate to the situation."
+          }
+        ]
+      },
+      {
+        "heading": "Content",
+        "content": [
+          {
+            "rule": "You can optionally use a title in bold, but every empty state must include the description text. The CTA should be a ghost button or link.",
+            "note": "Character count: Descriptions should not exceed 60 characters in width, before optionally continuing on a new line."
+          }
+        ]
+      },
+      {
+        "heading": "Maintenance state",
+        "content": [
+          {
+            "term": "When to use",
+            "examples": [
+              "During planned downtime for updates, migrations, or upgrades",
+              "When performing system maintenance that affects data access or platform functionality",
+              "When a specific dataset or tool is temporarily locked or restricted for updates"
+            ]
+          },
+          {
+            "term": "Content",
+            "examples": [
+              "State the nature of the maintenance, and whether it was planned or unplanned.",
+              "Provide a time estimate or range for completion if possible",
+              "Clearly identify workarounds, or recovery actions",
+              "If maintenance is unplanned, provide a link to real-time updates or who to contact for support."
+            ]
+          }
+        ]
+      },
+      {
+        "heading": "Error state",
+        "content": [
+          {
+            "rule": "Error state content is similar to that of empty states, and should follow similar guidelines with some exceptions: The tone should be direct, helpful, and immediately provide a call to action.",
+            "dont": "NEVER blame the user for the error."
+          }
+        ]
+      },
+      {
+        "heading": "Success state",
+        "content": [
+          {
+            "term": "When to use",
+            "examples": [
+              "Large page steppers need confirmation notifications for their processes, but if the resulting page does not lead to a list or table of created items, the notification cannot appear as a banner. A full confirmation page is necessary.",
+              "When the resulting confirmation needs its own page for clarity or follow-up, and the banner won't cover everything needed."
+            ]
+          },
+          {
+            "term": "Content",
+            "examples": [
+              "Success! message as the title, alternatives can be used in small cases.",
+              "Description should indicate what has happened, and what comes next.",
+              "Primary button is mandatory for navigation purposes, as there will be no other available action on the page. Primary button should take them to next logical page.",
+              "Secondary button should be optional but rare. Use in cases where you can view a log or report, etc."
+            ]
+          }
+        ]
+      }
+    ]
+  },
+  "has_design_guidelines": true,
+  "design_guidelines": {
+    "sections": [
+      {
+        "heading": "Anatomy",
+        "items": [
+          "Large: Illustration (240x160px), H2 heading, Body1 description, Ghost button (Small) + Outlined button (Small).",
+          "Medium: Illustration (80x50px), H4 heading, Body2 description, Ghost button (Small).",
+          "Small: Illustration (28x21px) inline with Body2 text. No heading or button."
+        ]
+      },
+      {
+        "heading": "Specs",
+        "items": [
+          "Large: illustration 240px wide x 160px tall; spacing-md (16px) between illustration and text; spacing-2xs (4px) between heading and description; spacing-xs (8px) between text and actions; content centered.",
+          "Medium: illustration 80px wide x 50px tall (or 68px x 49px); spacing-xs (8px) between illustration and text; spacing-2xs (4px) between heading and description; content centered.",
+          "Small: illustration 28px wide x 21px tall; spacing-xs (8px) gap between illustration and inline text."
+        ]
+      },
+      {
+        "heading": "Layout",
+        "items": [
+          "Empty states are always centered within the main body of a component or page.",
+          "Large: occupies the full main content area, centered both horizontally and vertically.",
+          "Medium (tab panel): spacing-2xl (40px) from the top of the content area to the empty state.",
+          "Medium (side panel / drawer): spacing-lg (24px) top and bottom padding around the empty state.",
+          "Small (card or widget): spacing-md (16px) padding around the empty state."
+        ]
+      },
+      {
+        "heading": "Pattern",
+        "items": [
+          "Users can use the button in the empty state component to resolve the empty state. Once resolved, the main button will appear, allowing them to add, create, or edit.",
+          "Before resolution: empty state is shown centered with illustration, title, description, and CTA.",
+          "After resolution: empty state is replaced by actual data (table rows, list items, cards)."
+        ]
+      }
+    ]
+  },
+  "variants": {
+    "axes": {
+      "Size": [
+        "Large",
+        "Medium",
+        "Small"
+      ],
+      "State": [
+        "Empty state",
+        "Maintenance state",
+        "Error state",
+        "Success state"
+      ]
+    }
+  },
+  "examples": null,
+  "screenshots": null,
+  "behavior": null
+}

--- a/plugins/actian-design-system/vendor/components/guidelines/error-state.json
+++ b/plugins/actian-design-system/vendor/components/guidelines/error-state.json
@@ -1,0 +1,30 @@
+{
+  "component": "Error state",
+  "_stub": true,
+  "_stubGeneratedAt": "2026-05-04T14:37:24.649Z",
+  "page_id": "13087:34544",
+  "extracted_at": "2026-05-04T14:37:24.649Z",
+  "frames_found": [],
+  "frames_missing": [
+    "Design guidelines",
+    "Content guidelines",
+    "Components",
+    "Screenshots of use cases",
+    "Behavior demo",
+    "ready made examples"
+  ],
+  "content_guidelines": null,
+  "design_guidelines": null,
+  "variants": {
+    "axes": {
+      "Size": [
+        "Large",
+        "Medium"
+      ]
+    },
+    "totalVariants": 2
+  },
+  "examples": null,
+  "screenshots": null,
+  "behavior": null
+}

--- a/plugins/actian-design-system/vendor/components/guidelines/filters.json
+++ b/plugins/actian-design-system/vendor/components/guidelines/filters.json
@@ -1,0 +1,85 @@
+{
+  "component": "Filters",
+  "page_id": "9474:8729",
+  "extracted_at": "2026-03-25T12:00:00Z",
+  "frames_found": [
+    "Content guidelines",
+    "Components",
+    "Screenshots of use cases"
+  ],
+  "frames_missing": [
+    "Design guidelines",
+    "ready made examples",
+    "Behavior demo"
+  ],
+  "content_guidelines": {
+    "sections": [
+      {
+        "heading": "Description",
+        "content": [
+          {
+            "rule": "Filters allow users to refine visible data by applying structured criteria."
+          },
+          {
+            "rule": "They reduce results without modifying underlying data."
+          },
+          {
+            "rule": "Filters must be consistent in terminology, placement, and behavior across all products."
+          }
+        ]
+      },
+      {
+        "heading": "Usage",
+        "content": [
+          {
+            "rule": "Use when users need to narrow results."
+          },
+          {
+            "rule": "Use when multiple attributes can refine results."
+          },
+          {
+            "rule": "Use when filtering changes only visible result set."
+          },
+          {
+            "dont": "Use for configuration, preferences, or sorting."
+          }
+        ]
+      },
+      {
+        "heading": "Terminology",
+        "content": [
+          {
+            "rule": "Use singular nouns (Item type, Owner, Domain)."
+          },
+          {
+            "rule": "Avoid articles, verbs, punctuation, abbreviations."
+          },
+          {
+            "rule": "Use sentence case."
+          },
+          {
+            "rule": "Match system terminology."
+          }
+        ]
+      }
+    ]
+  },
+  "design_guidelines": null,
+  "variants": {
+    "axes": {
+      "Type": [
+        "Explorer",
+        "Studio"
+      ]
+    }
+  },
+  "examples": null,
+  "screenshots": {
+    "count": 2,
+    "contexts": [
+      "Screenshot of Explorer filter panel (2026-03-03)",
+      "Screenshot of Studio filter panel (2026-03-03)"
+    ]
+  },
+  "behavior": null
+}

--- a/plugins/actian-design-system/vendor/components/guidelines/global-header.json
+++ b/plugins/actian-design-system/vendor/components/guidelines/global-header.json
@@ -1,0 +1,52 @@
+{
+  "component": "Global header",
+  "page_id": "9052:17057",
+  "extracted_at": "2026-03-25T00:00:00Z",
+  "frames_found": [
+    "Content guidelines",
+    "Components",
+    "Screenshots of use cases"
+  ],
+  "frames_missing": [
+    "design guidelines",
+    "ready made examples",
+    "Behavior demo"
+  ],
+  "content_guidelines": {
+    "sections": [
+      {
+        "heading": "When to use",
+        "content": [
+          {
+            "rule": "Permanently anchored top of screen across all pages."
+          },
+          {
+            "rule": "For switching between product areas, accessing global tools, viewing account options."
+          }
+        ]
+      },
+      {
+        "heading": "Behavior",
+        "content": [
+          {
+            "rule": "Only branded title and nav context change between apps."
+          },
+          {
+            "rule": "Utility icons unlabeled but with tooltips."
+          },
+          {
+            "rule": "Nav elements reflect current app."
+          }
+        ]
+      }
+    ]
+  },
+  "design_guidelines": null,
+  "variants": null,
+  "examples": null,
+  "screenshots": {
+    "count": 1,
+    "contexts": []
+  },
+  "behavior": null
+}

--- a/plugins/actian-design-system/vendor/components/guidelines/glossary-item-hierarchy-diagram.json
+++ b/plugins/actian-design-system/vendor/components/guidelines/glossary-item-hierarchy-diagram.json
@@ -1,0 +1,29 @@
+{
+  "component": "Glossary item hierarchy diagram",
+  "_stub": true,
+  "_stubGeneratedAt": "2026-05-04T14:37:24.649Z",
+  "page_id": "14747:30242",
+  "extracted_at": "2026-05-04T14:37:24.649Z",
+  "frames_found": [],
+  "frames_missing": [
+    "Design guidelines",
+    "Content guidelines",
+    "Components",
+    "Screenshots of use cases",
+    "Behavior demo",
+    "ready made examples"
+  ],
+  "content_guidelines": null,
+  "design_guidelines": null,
+  "variants": {
+    "axes": {
+      "Type": [
+        "Default"
+      ]
+    },
+    "totalVariants": 1
+  },
+  "examples": null,
+  "screenshots": null,
+  "behavior": null
+}

--- a/plugins/actian-design-system/vendor/components/guidelines/identification-key.json
+++ b/plugins/actian-design-system/vendor/components/guidelines/identification-key.json
@@ -1,0 +1,29 @@
+{
+  "component": "Identification key",
+  "_stub": true,
+  "_stubGeneratedAt": "2026-05-04T14:37:24.649Z",
+  "page_id": "14349:15323",
+  "extracted_at": "2026-05-04T14:37:24.649Z",
+  "frames_found": [],
+  "frames_missing": [
+    "Design guidelines",
+    "Content guidelines",
+    "Components",
+    "Screenshots of use cases",
+    "Behavior demo",
+    "ready made examples"
+  ],
+  "content_guidelines": null,
+  "design_guidelines": null,
+  "variants": {
+    "axes": {
+      "Property 1": [
+        "Default"
+      ]
+    },
+    "totalVariants": 1
+  },
+  "examples": null,
+  "screenshots": null,
+  "behavior": null
+}

--- a/plugins/actian-design-system/vendor/components/guidelines/input-date.json
+++ b/plugins/actian-design-system/vendor/components/guidelines/input-date.json
@@ -1,0 +1,39 @@
+{
+  "component": "Input, date",
+  "_stub": true,
+  "_stubGeneratedAt": "2026-05-04T14:37:24.649Z",
+  "page_id": "8194:7305",
+  "extracted_at": "2026-05-04T14:37:24.649Z",
+  "frames_found": [],
+  "frames_missing": [
+    "Design guidelines",
+    "Content guidelines",
+    "Components",
+    "Screenshots of use cases",
+    "Behavior demo",
+    "ready made examples"
+  ],
+  "content_guidelines": null,
+  "design_guidelines": null,
+  "variants": {
+    "axes": {
+      "Type": [
+        "Single date",
+        "Date range"
+      ],
+      "States": [
+        "Enabled",
+        "Hovered",
+        "Focused",
+        "Error",
+        "Disabled",
+        "Fille",
+        "Activ"
+      ]
+    },
+    "totalVariants": 14
+  },
+  "examples": null,
+  "screenshots": null,
+  "behavior": null
+}

--- a/plugins/actian-design-system/vendor/components/guidelines/input.json
+++ b/plugins/actian-design-system/vendor/components/guidelines/input.json
@@ -1,0 +1,36 @@
+{
+  "component": "Input",
+  "_stub": true,
+  "_stubGeneratedAt": "2026-05-04T14:37:24.649Z",
+  "page_id": "7238:2487",
+  "extracted_at": "2026-05-04T14:37:24.649Z",
+  "frames_found": [],
+  "frames_missing": [
+    "Design guidelines",
+    "Content guidelines",
+    "Components",
+    "Screenshots of use cases",
+    "Behavior demo",
+    "ready made examples"
+  ],
+  "content_guidelines": null,
+  "design_guidelines": null,
+  "variants": {
+    "axes": {
+      "States": [
+        "Default",
+        "Hovered",
+        "Focused",
+        "Active",
+        "Filled",
+        "Error",
+        "Disabled",
+        "Read-only"
+      ]
+    },
+    "totalVariants": 8
+  },
+  "examples": null,
+  "screenshots": null,
+  "behavior": null
+}

--- a/plugins/actian-design-system/vendor/components/guidelines/line-graph.json
+++ b/plugins/actian-design-system/vendor/components/guidelines/line-graph.json
@@ -1,0 +1,29 @@
+{
+  "component": "⛔️ Line graph",
+  "_stub": true,
+  "_stubGeneratedAt": "2026-05-04T14:37:24.649Z",
+  "page_id": "15473:49490",
+  "extracted_at": "2026-05-04T14:37:24.649Z",
+  "frames_found": [],
+  "frames_missing": [
+    "Design guidelines",
+    "Content guidelines",
+    "Components",
+    "Screenshots of use cases",
+    "Behavior demo",
+    "ready made examples"
+  ],
+  "content_guidelines": null,
+  "design_guidelines": null,
+  "variants": {
+    "axes": {
+      "Property 1": [
+        "Default"
+      ]
+    },
+    "totalVariants": 1
+  },
+  "examples": null,
+  "screenshots": null,
+  "behavior": null
+}

--- a/plugins/actian-design-system/vendor/components/guidelines/lineage-connecting-line.json
+++ b/plugins/actian-design-system/vendor/components/guidelines/lineage-connecting-line.json
@@ -1,0 +1,37 @@
+{
+  "component": "Lineage connecting line",
+  "_stub": true,
+  "_stubGeneratedAt": "2026-05-04T14:37:24.649Z",
+  "page_id": "14747:20085",
+  "extracted_at": "2026-05-04T14:37:24.649Z",
+  "frames_found": [],
+  "frames_missing": [
+    "Design guidelines",
+    "Content guidelines",
+    "Components",
+    "Screenshots of use cases",
+    "Behavior demo",
+    "ready made examples"
+  ],
+  "content_guidelines": null,
+  "design_guidelines": null,
+  "variants": {
+    "axes": {
+      "Direction": [
+        "Down",
+        "Straight",
+        "up",
+        "Up"
+      ],
+      "State": [
+        "Default",
+        "Selected",
+        "Disabled"
+      ]
+    },
+    "totalVariants": 12
+  },
+  "examples": null,
+  "screenshots": null,
+  "behavior": null
+}

--- a/plugins/actian-design-system/vendor/components/guidelines/lineage-grouped-node.json
+++ b/plugins/actian-design-system/vendor/components/guidelines/lineage-grouped-node.json
@@ -1,0 +1,34 @@
+{
+  "component": "Lineage grouped node",
+  "_stub": true,
+  "_stubGeneratedAt": "2026-05-04T14:37:24.649Z",
+  "page_id": "15634:17895",
+  "extracted_at": "2026-05-04T14:37:24.649Z",
+  "frames_found": [],
+  "frames_missing": [
+    "Design guidelines",
+    "Content guidelines",
+    "Components",
+    "Screenshots of use cases",
+    "Behavior demo",
+    "ready made examples"
+  ],
+  "content_guidelines": null,
+  "design_guidelines": null,
+  "variants": {
+    "axes": {
+      "State": [
+        "Default",
+        "Expanded"
+      ],
+      "Type": [
+        "Main item",
+        "Sub item"
+      ]
+    },
+    "totalVariants": 4
+  },
+  "examples": null,
+  "screenshots": null,
+  "behavior": null
+}

--- a/plugins/actian-design-system/vendor/components/guidelines/lineage-individual-node.json
+++ b/plugins/actian-design-system/vendor/components/guidelines/lineage-individual-node.json
@@ -1,0 +1,39 @@
+{
+  "component": "Lineage individual node",
+  "_stub": true,
+  "_stubGeneratedAt": "2026-05-04T14:37:24.649Z",
+  "page_id": "14747:19902",
+  "extracted_at": "2026-05-04T14:37:24.649Z",
+  "frames_found": [],
+  "frames_missing": [
+    "Design guidelines",
+    "Content guidelines",
+    "Components",
+    "Screenshots of use cases",
+    "Behavior demo",
+    "ready made examples"
+  ],
+  "content_guidelines": null,
+  "design_guidelines": null,
+  "variants": {
+    "axes": {
+      "Type": [
+        "Main item",
+        "Sub item"
+      ],
+      "State": [
+        "Default",
+        "Selected",
+        "Disabled"
+      ],
+      "Fields": [
+        "Collapsed",
+        "Expanded"
+      ]
+    },
+    "totalVariants": 12
+  },
+  "examples": null,
+  "screenshots": null,
+  "behavior": null
+}

--- a/plugins/actian-design-system/vendor/components/guidelines/link.json
+++ b/plugins/actian-design-system/vendor/components/guidelines/link.json
@@ -1,0 +1,135 @@
+{
+  "component": "Link",
+  "page_id": "12054:32076",
+  "extracted_at": "2026-03-26T00:00:00Z",
+  "frames_found": [
+    "Design guidelines",
+    "Content guidelines",
+    "Components"
+  ],
+  "frames_missing": [
+    "ready made examples",
+    "Screenshots of use cases",
+    "Behavior demo"
+  ],
+  "content_guidelines": {
+    "sections": [
+      {
+        "heading": "When to use",
+        "content": [
+          {
+            "rule": "Use for navigation to internal or external destinations."
+          },
+          {
+            "rule": "Use for inline standalone contextual actions."
+          },
+          {
+            "dont": "Use links for actions; use ghost buttons instead."
+          }
+        ]
+      },
+      {
+        "heading": "Button vs Link",
+        "content": [
+          {
+            "rule": "Use links for navigation. Use buttons for actions.",
+            "examples": [
+              "A link for 'View more articles', a button for form submit."
+            ]
+          }
+        ]
+      },
+      {
+        "heading": "Style",
+        "content": [
+          {
+            "rule": "Use meaningful, descriptive text (e.g., 'View pipeline details', not 'Click here')."
+          },
+          {
+            "dont": "Use standalone icons as links."
+          },
+          {
+            "rule": "Use sentence case and no terminal punctuation."
+          }
+        ]
+      },
+      {
+        "heading": "Behavior",
+        "content": [
+          {
+            "rule": "Opens in same tab unless explicitly labeled as external."
+          },
+          {
+            "rule": "Underline on hover."
+          },
+          {
+            "rule": "Visited state should be visually distinct."
+          }
+        ]
+      },
+      {
+        "heading": "Clear and Descriptive Link Text",
+        "content": [
+          {
+            "do": "View your order details",
+            "dont": "Click here"
+          },
+          {
+            "dont": "Use URLs as link text."
+          }
+        ]
+      },
+      {
+        "heading": "Action-Oriented Language",
+        "content": [
+          {
+            "do": "Download report",
+            "dont": "Get report"
+          },
+          {
+            "do": "Explore features",
+            "dont": "Click to learn more"
+          }
+        ]
+      },
+      {
+        "heading": "Consistency in Link Text",
+        "content": [
+          {
+            "do": "View our services",
+            "dont": "Click here to view our list of services"
+          }
+        ]
+      },
+      {
+        "heading": "Avoid Linking Full Sentences",
+        "content": [
+          {
+            "do": "Read our user experience design blog.",
+            "dont": "Click here to read our blog about user experience design"
+          }
+        ]
+      }
+    ]
+  },
+  "has_design_guidelines": true,
+  "design_guidelines": {
+    "sections": [
+      {
+        "heading": "Accessibility",
+        "items": [
+          "Default State: Underlined. Standard practice is to underline links in their default state. This ensures the link is distinguishable from surrounding text by a visual cue other than color alone.",
+          "Exception: Non-Underlined Links. In specific instances where links are not underlined by default, they must meet the following WCAG 2.1 Level AA requirements:",
+          "Contrast with Surrounding Text: The link text must have at least a 3:1 contrast ratio against the surrounding body text.",
+          "Contrast with Background: The link text must maintain at least a 4.5:1 contrast ratio against the background color.",
+          "Hover/Focus Requirement: A non-color visual indicator (typically an underline) must appear when the link is hovered with a mouse or focused via keyboard."
+        ]
+      }
+    ]
+  },
+  "variants": null,
+  "examples": null,
+  "screenshots": null,
+  "behavior": null,
+  "_note": "Metadata for variants could not be retrieved due to Figma MCP tool call limit. Re-run extraction when limit resets to populate variants and screenshots."
+}

--- a/plugins/actian-design-system/vendor/components/guidelines/loader.json
+++ b/plugins/actian-design-system/vendor/components/guidelines/loader.json
@@ -1,0 +1,31 @@
+{
+  "component": "Loader",
+  "_stub": true,
+  "_stubGeneratedAt": "2026-05-04T14:37:24.649Z",
+  "page_id": "7372:2195",
+  "extracted_at": "2026-05-04T14:37:24.649Z",
+  "frames_found": [],
+  "frames_missing": [
+    "Design guidelines",
+    "Content guidelines",
+    "Components",
+    "Screenshots of use cases",
+    "Behavior demo",
+    "ready made examples"
+  ],
+  "content_guidelines": null,
+  "design_guidelines": null,
+  "variants": {
+    "axes": {
+      "Percent": [
+        "99%",
+        "10%",
+        "Percent3"
+      ]
+    },
+    "totalVariants": 3
+  },
+  "examples": null,
+  "screenshots": null,
+  "behavior": null
+}

--- a/plugins/actian-design-system/vendor/components/guidelines/loading-skeleton.json
+++ b/plugins/actian-design-system/vendor/components/guidelines/loading-skeleton.json
@@ -1,0 +1,33 @@
+{
+  "component": "Loading skeleton",
+  "_stub": true,
+  "_stubGeneratedAt": "2026-05-04T14:37:24.649Z",
+  "page_id": "14294:8086",
+  "extracted_at": "2026-05-04T14:37:24.649Z",
+  "frames_found": [],
+  "frames_missing": [
+    "Design guidelines",
+    "Content guidelines",
+    "Components",
+    "Screenshots of use cases",
+    "Behavior demo",
+    "ready made examples"
+  ],
+  "content_guidelines": null,
+  "design_guidelines": null,
+  "variants": {
+    "axes": {
+      "Transition": ["1", "2"]
+    },
+    "totalVariants": 2
+  },
+  "examples": null,
+  "screenshots": null,
+  "behavior": {
+    "motion": {
+      "pattern": "skeleton-loading",
+      "overrides": null,
+      "notes": "Continuous 2000ms linear shimmer (looping); not tokenized — value is fixed. Provides visual confirmation the system is active and reduces perceived wait time for data-heavy views. Note: this guideline is a stub — motion data is forward-compatible."
+    }
+  }
+}

--- a/plugins/actian-design-system/vendor/components/guidelines/loading.json
+++ b/plugins/actian-design-system/vendor/components/guidelines/loading.json
@@ -1,0 +1,22 @@
+{
+  "component": "Loading / Loader / Spinner / Skeleton",
+  "page_id": "9253:29118",
+  "extracted_at": "2026-03-25T00:00:00Z",
+  "frames_found": [],
+  "frames_missing": [
+    "Content guidelines",
+    "Design guidelines",
+    "Components",
+    "ready made examples",
+    "Screenshots of use cases",
+    "Screenshots of current use cases",
+    "Behavior demo"
+  ],
+  "content_guidelines": null,
+  "design_guidelines": null,
+  "variants": null,
+  "examples": null,
+  "screenshots": null,
+  "behavior": null,
+  "_note": "Figma MCP connection lost before metadata could be retrieved for this page. Re-run extraction when API quota resets."
+}

--- a/plugins/actian-design-system/vendor/components/guidelines/maintenance-banner.json
+++ b/plugins/actian-design-system/vendor/components/guidelines/maintenance-banner.json
@@ -1,0 +1,33 @@
+{
+  "component": "Maintenance banner",
+  "page_id": "13868:11327",
+  "extracted_at": "2026-03-25T00:00:00Z",
+  "frames_found": [
+    "Components",
+    "Screenshots of use cases"
+  ],
+  "frames_missing": [
+    "Content guidelines",
+    "Design guidelines",
+    "ready made examples",
+    "Screenshots of current use cases",
+    "Behavior demo"
+  ],
+  "content_guidelines": null,
+  "design_guidelines": null,
+  "variants": {
+    "axes": {
+      "Type": [
+        "Default"
+      ]
+    }
+  },
+  "examples": null,
+  "screenshots": {
+    "count": 1,
+    "contexts": [
+      "Storybook documentation screenshot: MaintenanceBannerComponent"
+    ]
+  },
+  "behavior": null
+}

--- a/plugins/actian-design-system/vendor/components/guidelines/maintenance-state.json
+++ b/plugins/actian-design-system/vendor/components/guidelines/maintenance-state.json
@@ -1,0 +1,29 @@
+{
+  "component": "Maintenance state",
+  "_stub": true,
+  "_stubGeneratedAt": "2026-05-04T14:37:24.649Z",
+  "page_id": "13871:32311",
+  "extracted_at": "2026-05-04T14:37:24.649Z",
+  "frames_found": [],
+  "frames_missing": [
+    "Design guidelines",
+    "Content guidelines",
+    "Components",
+    "Screenshots of use cases",
+    "Behavior demo",
+    "ready made examples"
+  ],
+  "content_guidelines": null,
+  "design_guidelines": null,
+  "variants": {
+    "axes": {
+      "Size": [
+        "Large"
+      ]
+    },
+    "totalVariants": 1
+  },
+  "examples": null,
+  "screenshots": null,
+  "behavior": null
+}

--- a/plugins/actian-design-system/vendor/components/guidelines/metamodel-widget.json
+++ b/plugins/actian-design-system/vendor/components/guidelines/metamodel-widget.json
@@ -1,0 +1,33 @@
+{
+  "component": "Metamodel widget",
+  "_stub": true,
+  "_stubGeneratedAt": "2026-05-04T14:37:24.649Z",
+  "page_id": "14747:23588",
+  "extracted_at": "2026-05-04T14:37:24.649Z",
+  "frames_found": [],
+  "frames_missing": [
+    "Design guidelines",
+    "Content guidelines",
+    "Components",
+    "Screenshots of use cases",
+    "Behavior demo",
+    "ready made examples"
+  ],
+  "content_guidelines": null,
+  "design_guidelines": null,
+  "variants": {
+    "axes": {
+      "Type": [
+        "Dataset",
+        "Business Term",
+        "Data Process",
+        "Field",
+        "Visualisation"
+      ]
+    },
+    "totalVariants": 5
+  },
+  "examples": null,
+  "screenshots": null,
+  "behavior": null
+}

--- a/plugins/actian-design-system/vendor/components/guidelines/modal.json
+++ b/plugins/actian-design-system/vendor/components/guidelines/modal.json
@@ -1,0 +1,144 @@
+{
+  "component": "Modal",
+  "page_id": "9253:29287",
+  "extracted_at": "2026-03-25T00:00:00Z",
+  "frames_found": [
+    "Content guidelines",
+    "Components",
+    "Screenshots of current use cases"
+  ],
+  "frames_missing": [
+    "Design guidelines",
+    "ready made examples",
+    "Behavior demo"
+  ],
+  "content_guidelines": {
+    "sections": [
+      {
+        "heading": "Terminology",
+        "content": [
+          {
+            "rule": "The modal should be launched from a CTA that uses a standardized term as described in Buttons and CTAs. The title of the modal must then use the same term. And finally, except as noted in Buttons and CTAs, the confirmation button at the end of the modal must also use the same verb terminology."
+          }
+        ]
+      },
+      {
+        "heading": "Types",
+        "content": [
+          {
+            "term": "Standard (Transactional)",
+            "rule": "Requires user to confirm or cancel, etc."
+          },
+          {
+            "term": "Confirmation (or Acknowledgement)",
+            "rule": "Mostly informational but requires user to click a button to confirm."
+          },
+          {
+            "term": "Stepper",
+            "rule": "Has multiple pages with user input needed, OK, Cancel, Next, Previous, etc."
+          },
+          {
+            "term": "Passive",
+            "rule": "No user input, just info, status, etc. Close using X or click outside."
+          }
+        ]
+      },
+      {
+        "heading": "Modal title",
+        "content": [
+          {
+            "rule": "Use a brief verb phrase to describe the purpose."
+          },
+          {
+            "rule": "With few exceptions, if the modal is accessed by a CTA, use the button label in the modal title."
+          },
+          {
+            "dont": "Do not mix and match button or icon labels and modal titles. For example, if the icon name is New user, use New user as the modal title, not Create user."
+          },
+          {
+            "rule": "If your product has a more conversational tone, use articles (a, an, the) in the modal title even though the button label doesn't include the article, for example Create an access group."
+          },
+          {
+            "rule": "Sometimes, you might need to provide contextual information for the modal, such as when the actions performed using the modal apply to a specific item and you want to make it clear which item the actions apply to. For example, if the user needs to know the path to the object that they are editing, you might put the path in the optional label."
+          }
+        ]
+      },
+      {
+        "heading": "Modal description",
+        "content": [
+          {
+            "rule": "If the purpose or goal of the modal is not readily apparent, provide a sentence or two of embedded assistance to help the user understand the modal. But this is optional."
+          }
+        ]
+      },
+      {
+        "heading": "Body content",
+        "content": [
+          {
+            "rule": "Any links in the modal should open a new tab on click."
+          },
+          {
+            "do": "Use a clear label, such as \"Learn more about topic\" or \"Actian Support\"."
+          }
+        ]
+      },
+      {
+        "heading": "Buttons",
+        "content": [
+          {
+            "rule": "For action button labels, except as noted in Buttons and CTAs, use the same verb you used in the modal's launch button and the modal title. Otherwise, use active words that describe the purpose of the modal, such as Add, Delete, and Save.",
+            "dont": "Avoid vague or passive words when possible, such as Done or OK."
+          }
+        ]
+      },
+      {
+        "heading": "Content examples",
+        "content": [
+          {
+            "term": "Example 1",
+            "examples": [
+              "CTA: 'Revert description' -> Modal title: 'Revert to the source description?' -> Confirm buttons: 'Cancel' | 'Revert'"
+            ]
+          },
+          {
+            "term": "Example 2",
+            "examples": [
+              "Modal title: 'Add contacts' -> Button disabled until content completed"
+            ]
+          }
+        ]
+      }
+    ]
+  },
+  "design_guidelines": null,
+  "variants": {
+    "axes": {
+      "Size & Type": [
+        "1200px",
+        "900px create",
+        "900px edit",
+        "700px create",
+        "700px setting",
+        "450px warning",
+        "450px confirm"
+      ]
+    }
+  },
+  "examples": null,
+  "screenshots": {
+    "count": 18,
+    "contexts": [
+      "Storybook documentation: ModalConfirmComponent",
+      "Application screenshot 2026-03-11",
+      "Application screenshot 2026-03-10",
+      "Grouped by size: 1200px, 900px, 700px, 500px, 450px, 400px with multiple real use case screenshots each"
+    ]
+  },
+  "behavior": {
+    "motion": {
+      "pattern": "layered-overlays",
+      "overrides": null,
+      "notes": "Modal uses Layered Overlays pattern. Open: scales 95→100% + scrim fades in over duration-slow with ease-entrance. Close: scales 100→95% + fades + scrim fades, all duration-fast with ease-exit. The slow open communicates entering a new context; the quick close stays out of the user's way."
+    }
+  }
+}

--- a/plugins/actian-design-system/vendor/components/guidelines/notification-dropdown.json
+++ b/plugins/actian-design-system/vendor/components/guidelines/notification-dropdown.json
@@ -1,0 +1,30 @@
+{
+  "component": "Notification dropdown",
+  "_stub": true,
+  "_stubGeneratedAt": "2026-05-04T14:37:24.649Z",
+  "page_id": "9114:15379",
+  "extracted_at": "2026-05-04T14:37:24.649Z",
+  "frames_found": [],
+  "frames_missing": [
+    "Design guidelines",
+    "Content guidelines",
+    "Components",
+    "Screenshots of use cases",
+    "Behavior demo",
+    "ready made examples"
+  ],
+  "content_guidelines": null,
+  "design_guidelines": null,
+  "variants": {
+    "axes": {
+      "Property 1": [
+        "Empty",
+        "List"
+      ]
+    },
+    "totalVariants": 2
+  },
+  "examples": null,
+  "screenshots": null,
+  "behavior": null
+}

--- a/plugins/actian-design-system/vendor/components/guidelines/notification-toast.json
+++ b/plugins/actian-design-system/vendor/components/guidelines/notification-toast.json
@@ -1,0 +1,37 @@
+{
+  "component": "Notification / Toast",
+  "page_id": "13868:11578",
+  "extracted_at": "2026-03-25T00:00:00Z",
+  "frames_found": ["Components", "Screenshots of use cases"],
+  "frames_missing": [
+    "Content guidelines",
+    "Design guidelines",
+    "ready made examples",
+    "Screenshots of current use cases",
+    "Behavior demo"
+  ],
+  "content_guidelines": null,
+  "design_guidelines": null,
+  "variants": {
+    "axes": {
+      "Type": ["Default", "Critical"]
+    }
+  },
+  "examples": null,
+  "screenshots": {
+    "count": 4,
+    "contexts": [
+      "Screenshot 2026-02-19 at 4.07.28 PM",
+      "Screenshot 2026-02-19 at 4.03.40 PM",
+      "Screenshot 2026-02-19 at 4.03.24 PM",
+      "Screenshot 2026-02-19 at 4.18.36 PM"
+    ]
+  },
+  "behavior": {
+    "motion": {
+      "pattern": "success-toast",
+      "overrides": null,
+      "notes": "Three-phase toast choreography: Entry (slide in from bottom, duration-base + ease-entrance) → Hold (delay-long settle, ~4000ms total at the product level) → Exit (fade out, duration-fast + ease-exit). Hold duration is product-level, not a motion token — delay-long is the unit, full hold is configured per call site."
+    }
+  }
+}

--- a/plugins/actian-design-system/vendor/components/guidelines/notification.json
+++ b/plugins/actian-design-system/vendor/components/guidelines/notification.json
@@ -1,0 +1,30 @@
+{
+  "component": "Notification",
+  "_stub": true,
+  "_stubGeneratedAt": "2026-05-04T14:37:24.649Z",
+  "page_id": "13868:11595",
+  "extracted_at": "2026-05-04T14:37:24.649Z",
+  "frames_found": [],
+  "frames_missing": [
+    "Design guidelines",
+    "Content guidelines",
+    "Components",
+    "Screenshots of use cases",
+    "Behavior demo",
+    "ready made examples"
+  ],
+  "content_guidelines": null,
+  "design_guidelines": null,
+  "variants": {
+    "axes": {
+      "Type": [
+        "Default",
+        "Critical"
+      ]
+    },
+    "totalVariants": 2
+  },
+  "examples": null,
+  "screenshots": null,
+  "behavior": null
+}

--- a/plugins/actian-design-system/vendor/components/guidelines/page-header.json
+++ b/plugins/actian-design-system/vendor/components/guidelines/page-header.json
@@ -1,0 +1,44 @@
+{
+  "component": "Page header",
+  "page_id": "9253:29981",
+  "extracted_at": "2026-03-25T00:00:00Z",
+  "frames_found": [
+    "Components",
+    "Screenshots of current use cases"
+  ],
+  "frames_missing": [
+    "Content guidelines",
+    "Design guidelines",
+    "ready made examples",
+    "Behavior demo"
+  ],
+  "content_guidelines": null,
+  "design_guidelines": null,
+  "variants": {
+    "axes": {
+      "Page header": {
+        "node_id": "12923:2794",
+        "variants": {
+          "Type": [
+            "Default",
+            "Details page",
+            "Explorer home",
+            "Explorer detail"
+          ]
+        }
+      }
+    }
+  },
+  "examples": null,
+  "screenshots": {
+    "count": 5,
+    "contexts": [
+      "Screenshot 2026-03-06 at 4.54.45 PM - page header in default context",
+      "Screenshot 2026-03-06 at 4.54.53 PM - page header with explorer layout",
+      "Screenshot 2026-03-06 at 4.55.10 PM - page header in detail page",
+      "Screenshot 2026-03-06 at 4.55.21 PM - page header compact variant",
+      "Screenshot 2026-03-06 at 4.55.49 PM - page header alternate layout"
+    ]
+  },
+  "behavior": null
+}

--- a/plugins/actian-design-system/vendor/components/guidelines/perimeter-card.json
+++ b/plugins/actian-design-system/vendor/components/guidelines/perimeter-card.json
@@ -1,0 +1,29 @@
+{
+  "component": "Perimeter card",
+  "_stub": true,
+  "_stubGeneratedAt": "2026-05-04T14:37:24.649Z",
+  "page_id": "14783:7565",
+  "extracted_at": "2026-05-04T14:37:24.649Z",
+  "frames_found": [],
+  "frames_missing": [
+    "Design guidelines",
+    "Content guidelines",
+    "Components",
+    "Screenshots of use cases",
+    "Behavior demo",
+    "ready made examples"
+  ],
+  "content_guidelines": null,
+  "design_guidelines": null,
+  "variants": {
+    "axes": {
+      "Property 1": [
+        "Default"
+      ]
+    },
+    "totalVariants": 1
+  },
+  "examples": null,
+  "screenshots": null,
+  "behavior": null
+}

--- a/plugins/actian-design-system/vendor/components/guidelines/popover.json
+++ b/plugins/actian-design-system/vendor/components/guidelines/popover.json
@@ -1,0 +1,28 @@
+{
+  "component": "Popover",
+  "page_id": "13298:2723",
+  "extracted_at": "2026-03-25T00:00:00Z",
+  "frames_found": [],
+  "frames_missing": [
+    "Content guidelines",
+    "Design guidelines",
+    "Components",
+    "ready made examples",
+    "Screenshots of use cases",
+    "Screenshots of current use cases",
+    "Behavior demo"
+  ],
+  "content_guidelines": null,
+  "design_guidelines": null,
+  "variants": null,
+  "examples": null,
+  "screenshots": null,
+  "behavior": {
+    "motion": {
+      "pattern": "anchor-motion",
+      "overrides": null,
+      "notes": "Popover uses the anchor-motion pattern (same as tooltips and dropdowns). Open: duration-base + ease-entrance, fades in + scales up from trigger. Close: duration-fast + ease-standard."
+    }
+  },
+  "_note": "Figma MCP tool call limit reached before metadata could be retrieved for this page. Re-run extraction when API quota resets."
+}

--- a/plugins/actian-design-system/vendor/components/guidelines/progress-bar-small.json
+++ b/plugins/actian-design-system/vendor/components/guidelines/progress-bar-small.json
@@ -1,0 +1,35 @@
+{
+  "component": "Progress bar small",
+  "_stub": true,
+  "_stubGeneratedAt": "2026-05-04T14:37:24.649Z",
+  "page_id": "14136:1615",
+  "extracted_at": "2026-05-04T14:37:24.649Z",
+  "frames_found": [],
+  "frames_missing": [
+    "Design guidelines",
+    "Content guidelines",
+    "Components",
+    "Screenshots of use cases",
+    "Behavior demo",
+    "ready made examples"
+  ],
+  "content_guidelines": null,
+  "design_guidelines": null,
+  "variants": {
+    "axes": {
+      "Size": [
+        "Default",
+        "Large"
+      ],
+      "Completeness": [
+        "0%",
+        "100%",
+        "50%"
+      ]
+    },
+    "totalVariants": 6
+  },
+  "examples": null,
+  "screenshots": null,
+  "behavior": null
+}

--- a/plugins/actian-design-system/vendor/components/guidelines/radio-button.json
+++ b/plugins/actian-design-system/vendor/components/guidelines/radio-button.json
@@ -1,0 +1,136 @@
+{
+  "component": "Radio button",
+  "page_id": "12070:77592",
+  "extracted_at": "2026-03-25T12:00:00Z",
+  "frames_found": [
+    "Content guidelines",
+    "Components",
+    "Screenshots of use cases"
+  ],
+  "frames_missing": [
+    "Design guidelines",
+    "ready made examples",
+    "Behavior demo"
+  ],
+  "content_guidelines": {
+    "sections": [
+      {
+        "heading": "Default format - When to use",
+        "content": [
+          {
+            "rule": "For short lists of options (2-6) that can be easily scanned."
+          },
+          {
+            "rule": "When all choices should be visible up front rather than hidden in a dropdown."
+          }
+        ]
+      },
+      {
+        "heading": "Default format - Style",
+        "content": [
+          {
+            "rule": "Use short, descriptive labels that clearly state each option."
+          },
+          {
+            "rule": "Write labels as direct answers to the group's prompt or question (e.g., 'Yes / No' instead of 'Select yes if you agree')."
+          },
+          {
+            "rule": "Ensure the group label or question is always visible next to the option."
+          },
+          {
+            "rule": "Avoid jargon or abbreviations."
+          },
+          {
+            "rule": "Keep labels parallel in structure (all nouns, or all verbs)."
+          }
+        ]
+      },
+      {
+        "heading": "Card format - When to use",
+        "content": [
+          {
+            "rule": "Use instead of traditional check boxes or radio boxes when each option needs to present rich context (title, description, image, metadata, tags) and the selection should feel like a visual choice rather than a text label."
+          },
+          {
+            "rule": "Primary decision point: When consequences of the choice are important, or they drive a main workflow or journey."
+          },
+          {
+            "examples": [
+              "Pricing tiers",
+              "Template selections (e.g., use cases)",
+              "Layout choices"
+            ]
+          }
+        ]
+      },
+      {
+        "heading": "Card format - Behavior",
+        "content": [
+          {
+            "rule": "Indicate selected state visually ('Selected', highlight border, etc.)."
+          },
+          {
+            "rule": "Click anywhere on the tile to toggle selection."
+          },
+          {
+            "rule": "For multi-select: checkbox behavior. For single-select: radio group behavior."
+          },
+          {
+            "rule": "Maintain selection across steps if part of a multi-step process."
+          },
+          {
+            "rule": "Title: Short, descriptive, and consistent across tiles."
+          },
+          {
+            "rule": "Supporting text: Use only in the large variant."
+          }
+        ]
+      }
+    ]
+  },
+  "design_guidelines": null,
+  "variants": {
+    "axes": {
+      "Format": [
+        "Default",
+        "Card format"
+      ],
+      "State": [
+        "Default",
+        "Hovered",
+        "Focused",
+        "Pressed",
+        "Disabled"
+      ],
+      "Selected": [
+        "Yes",
+        "No"
+      ]
+    },
+    "sub_component": {
+      "name": ".Radio button",
+      "axes": {
+        "State": [
+          "Default",
+          "Hovered",
+          "Focused",
+          "Pressed",
+          "Disabled"
+        ],
+        "Selected": [
+          "Yes",
+          "No"
+        ]
+      }
+    }
+  },
+  "examples": null,
+  "screenshots": {
+    "count": 2,
+    "contexts": [
+      "Product screenshot showing radio button usage (2025-07-28)",
+      "Storybook documentation capture for RadioButtonComponent"
+    ]
+  },
+  "behavior": null
+}

--- a/plugins/actian-design-system/vendor/components/guidelines/rich-text.json
+++ b/plugins/actian-design-system/vendor/components/guidelines/rich-text.json
@@ -1,0 +1,33 @@
+{
+  "component": "Rich text",
+  "page_id": "12070:77590",
+  "extracted_at": "2026-03-25T12:00:00Z",
+  "frames_found": [
+    "Components",
+    "Screenshots of use cases"
+  ],
+  "frames_missing": [
+    "Content guidelines",
+    "Design guidelines",
+    "ready made examples",
+    "Behavior demo"
+  ],
+  "content_guidelines": null,
+  "design_guidelines": null,
+  "variants": {
+    "axes": {
+      "State": [
+        "Default",
+        "Expanded"
+      ]
+    }
+  },
+  "examples": null,
+  "screenshots": {
+    "count": 1,
+    "contexts": [
+      "Screenshot showing rich text editor in product context (2026-02-27)"
+    ]
+  },
+  "behavior": null
+}

--- a/plugins/actian-design-system/vendor/components/guidelines/scroll-bar.json
+++ b/plugins/actian-design-system/vendor/components/guidelines/scroll-bar.json
@@ -1,0 +1,32 @@
+{
+  "component": "Scroll bar",
+  "page_id": "9253:31918",
+  "extracted_at": "2026-03-25T00:00:00Z",
+  "frames_found": [
+    "Components"
+  ],
+  "frames_missing": [
+    "Content guidelines",
+    "Design guidelines",
+    "Screenshots of use cases",
+    "ready made examples",
+    "Behavior demo"
+  ],
+  "content_guidelines": null,
+  "design_guidelines": null,
+  "variants": {
+    "axes": {
+      "Scroll bar": {
+        "node_id": "14747:17639",
+        "variants": {
+          "Property 1": [
+            "Default"
+          ]
+        }
+      }
+    }
+  },
+  "examples": null,
+  "screenshots": null,
+  "behavior": null
+}

--- a/plugins/actian-design-system/vendor/components/guidelines/search-dropdown-menu.json
+++ b/plugins/actian-design-system/vendor/components/guidelines/search-dropdown-menu.json
@@ -1,0 +1,32 @@
+{
+  "component": "Search dropdown menu",
+  "_stub": true,
+  "_stubGeneratedAt": "2026-05-04T14:37:24.649Z",
+  "page_id": "8756:9994",
+  "extracted_at": "2026-05-04T14:37:24.649Z",
+  "frames_found": [],
+  "frames_missing": [
+    "Design guidelines",
+    "Content guidelines",
+    "Components",
+    "Screenshots of use cases",
+    "Behavior demo",
+    "ready made examples"
+  ],
+  "content_guidelines": null,
+  "design_guidelines": null,
+  "variants": {
+    "axes": {
+      "Type": [
+        "No result",
+        "Before typed",
+        "After typed",
+        "Explorer home"
+      ]
+    },
+    "totalVariants": 4
+  },
+  "examples": null,
+  "screenshots": null,
+  "behavior": null
+}

--- a/plugins/actian-design-system/vendor/components/guidelines/search-filters.json
+++ b/plugins/actian-design-system/vendor/components/guidelines/search-filters.json
@@ -1,0 +1,30 @@
+{
+  "component": "Search filters",
+  "_stub": true,
+  "_stubGeneratedAt": "2026-05-04T14:37:24.649Z",
+  "page_id": "9660:49637",
+  "extracted_at": "2026-05-04T14:37:24.649Z",
+  "frames_found": [],
+  "frames_missing": [
+    "Design guidelines",
+    "Content guidelines",
+    "Components",
+    "Screenshots of use cases",
+    "Behavior demo",
+    "ready made examples"
+  ],
+  "content_guidelines": null,
+  "design_guidelines": null,
+  "variants": {
+    "axes": {
+      "Type": [
+        "Explorer",
+        "Studio"
+      ]
+    },
+    "totalVariants": 2
+  },
+  "examples": null,
+  "screenshots": null,
+  "behavior": null
+}

--- a/plugins/actian-design-system/vendor/components/guidelines/search-result-card.json
+++ b/plugins/actian-design-system/vendor/components/guidelines/search-result-card.json
@@ -1,0 +1,27 @@
+{
+  "component": "Search result card",
+  "page_id": "9253:31959",
+  "extracted_at": "2026-03-25T00:00:00Z",
+  "frames_found": [
+    "Components",
+    "Content guidelines",
+    "Screenshots of current use cases"
+  ],
+  "frames_missing": [
+    "Design guidelines",
+    "ready made examples",
+    "Behavior demo"
+  ],
+  "content_guidelines": null,
+  "design_guidelines": null,
+  "variants": null,
+  "examples": null,
+  "screenshots": {
+    "count": 1,
+    "contexts": []
+  },
+  "behavior": null,
+  "notes": [
+    "Figma MCP rate limit reached before metadata could be fetched for this page. Re-run extraction to populate variants and content_guidelines."
+  ]
+}

--- a/plugins/actian-design-system/vendor/components/guidelines/search.json
+++ b/plugins/actian-design-system/vendor/components/guidelines/search.json
@@ -1,0 +1,59 @@
+{
+  "component": "Search",
+  "page_id": "9085:22545",
+  "extracted_at": "2026-03-25T12:00:00Z",
+  "frames_found": [
+    "Content guidelines",
+    "Components",
+    "Screenshots of use cases"
+  ],
+  "frames_missing": [
+    "Design guidelines",
+    "ready made examples",
+    "Behavior demo"
+  ],
+  "content_guidelines": {
+    "sections": [
+      {
+        "heading": "Placeholder text",
+        "content": [
+          {
+            "rule": "Provide hint as to what's being searched. No period."
+          },
+          {
+            "rule": "When retrieving assets by metadata, use 'Search in <assetNames>' (plural)."
+          },
+          {
+            "rule": "Safe default: 'Search <assetNames>'."
+          }
+        ]
+      },
+      {
+        "heading": "Examples",
+        "content": [
+          {
+            "rule": "Use domain-specific plural nouns.",
+            "examples": [
+              "Search item types",
+              "Search users",
+              "Search contacts",
+              "Search items",
+              "Search properties",
+              "Search glossary types",
+              "Search topics"
+            ]
+          }
+        ]
+      }
+    ]
+  },
+  "design_guidelines": null,
+  "variants": null,
+  "examples": null,
+  "screenshots": {
+    "count": 1,
+    "contexts": []
+  },
+  "behavior": null,
+  "_note": "Variant metadata could not be retrieved due to Figma MCP tool call limit. Re-run extraction when limit resets."
+}

--- a/plugins/actian-design-system/vendor/components/guidelines/segmented-control.json
+++ b/plugins/actian-design-system/vendor/components/guidelines/segmented-control.json
@@ -1,0 +1,59 @@
+{
+  "component": "Segmented control / Button group",
+  "page_id": "9253:33950",
+  "extracted_at": "2026-03-25T00:00:00Z",
+  "frames_found": [
+    "Components",
+    "Screenshots of use cases"
+  ],
+  "frames_missing": [
+    "Content guidelines",
+    "Design guidelines",
+    "ready made examples",
+    "Behavior demo"
+  ],
+  "content_guidelines": null,
+  "design_guidelines": null,
+  "variants": {
+    "axes": {
+      "Segmented control": {
+        "node_id": "7618:5187",
+        "variants": {
+          "Type": [
+            "Default"
+          ]
+        }
+      },
+      ".segmented control sub component": {
+        "node_id": "7618:5084",
+        "variants": {
+          "State": [
+            "Default",
+            "Hovered",
+            "Focused",
+            "Pressed",
+            "Selected",
+            "Disabled"
+          ]
+        }
+      }
+    }
+  },
+  "examples": {
+    "descriptions": [
+      "ZNG (Eng library) Storybook reference screenshot showing ButtonGroupComponent docs (node 13539:44210)"
+    ]
+  },
+  "screenshots": {
+    "count": 6,
+    "contexts": [
+      "Screenshot 2026-02-20 at 2.31.37 PM - segmented control in app",
+      "Screenshot 2026-02-20 at 2.32.16 PM - segmented control variant",
+      "Screenshot 2026-02-20 at 2.32.40 PM - segmented control in context",
+      "Screenshot 2026-02-20 at 2.33.24 PM - segmented control usage",
+      "Screenshot 2026-02-25 at 10.39.13 AM - segmented control in data viz",
+      "Screenshot 2026-02-25 at 10.42.46 AM - segmented control wide layout"
+    ]
+  },
+  "behavior": null
+}

--- a/plugins/actian-design-system/vendor/components/guidelines/side-nav.json
+++ b/plugins/actian-design-system/vendor/components/guidelines/side-nav.json
@@ -1,0 +1,25 @@
+{
+  "component": "Side nav",
+  "page_id": "13599:19122",
+  "extracted_at": "2026-03-25T00:00:00Z",
+  "frames_found": ["Behavior demo"],
+  "frames_missing": [
+    "Content guidelines",
+    "design guidelines",
+    "Components",
+    "ready made examples",
+    "Screenshots of use cases"
+  ],
+  "content_guidelines": null,
+  "design_guidelines": null,
+  "variants": null,
+  "examples": null,
+  "screenshots": null,
+  "behavior": {
+    "motion": {
+      "pattern": "drawer",
+      "overrides": null,
+      "notes": "Side nav uses the canonical drawer choreography. Open: duration-slow + ease-entrance; close: duration-base + ease-exit. Collapse-to-rail variant follows the same timing but animates width instead of x-translation."
+    }
+  }
+}

--- a/plugins/actian-design-system/vendor/components/guidelines/spinner.json
+++ b/plugins/actian-design-system/vendor/components/guidelines/spinner.json
@@ -1,0 +1,32 @@
+{
+  "component": "Spinner",
+  "_stub": true,
+  "_stubGeneratedAt": "2026-05-04T14:37:24.649Z",
+  "page_id": "7372:2170",
+  "extracted_at": "2026-05-04T14:37:24.649Z",
+  "frames_found": [],
+  "frames_missing": [
+    "Design guidelines",
+    "Content guidelines",
+    "Components",
+    "Screenshots of use cases",
+    "Behavior demo",
+    "ready made examples"
+  ],
+  "content_guidelines": null,
+  "design_guidelines": null,
+  "variants": {
+    "axes": {
+      "Complete": [
+        "50%",
+        "75%",
+        "100%",
+        "25%"
+      ]
+    },
+    "totalVariants": 4
+  },
+  "examples": null,
+  "screenshots": null,
+  "behavior": null
+}

--- a/plugins/actian-design-system/vendor/components/guidelines/stepper.json
+++ b/plugins/actian-design-system/vendor/components/guidelines/stepper.json
@@ -1,0 +1,24 @@
+{
+  "component": "Stepper",
+  "page_id": "9253:33976",
+  "extracted_at": "2026-03-25T00:00:00Z",
+  "frames_found": [
+    "Components",
+    "Screenshots of current use cases"
+  ],
+  "frames_missing": [
+    "Content guidelines",
+    "design guidelines",
+    "ready made examples",
+    "Behavior demo"
+  ],
+  "content_guidelines": null,
+  "design_guidelines": null,
+  "variants": null,
+  "examples": null,
+  "screenshots": {
+    "count": 1,
+    "contexts": []
+  },
+  "behavior": null
+}

--- a/plugins/actian-design-system/vendor/components/guidelines/sticky-footer.json
+++ b/plugins/actian-design-system/vendor/components/guidelines/sticky-footer.json
@@ -1,0 +1,70 @@
+{
+  "component": "Sticky footer",
+  "page_id": "9253:33986",
+  "extracted_at": "2026-03-26T00:00:00Z",
+  "has_content_guidelines": true,
+  "frames_found": [
+    "Content guidelines",
+    "Sticky footer",
+    "Screenshots of use cases"
+  ],
+  "frames_missing": [
+    "Design guidelines",
+    "ready made examples",
+    "Behavior demo"
+  ],
+  "content_guidelines": {
+    "sections": [
+      {
+        "heading": "Usage",
+        "items": [
+          "A page or drawer contains primary actions that must remain available during scrolling.",
+          "Users complete steppers, or multi-field forms that extend beyond the current view.",
+          "The action affects the entire page, drawer, or form's state."
+        ]
+      },
+      {
+        "heading": "Button hierarchy",
+        "items": [
+          "The sticky footer must contain exactly one primary action.",
+          "Exception: An additional 'destructive' button (such as Delete).",
+          "An optional secondary action can be included.",
+          "Limit to a maximum of 3 buttons. More actions increase the cognitive load."
+        ]
+      },
+      {
+        "heading": "Button labels",
+        "items": [
+          "Use clear verbs that describe the OUTCOME. Labels should describe what will happen, not what the button is.",
+          "Examples: Save, Update, Create, Confirm, Submit, Cancel, Delete, Continue (as part of a defined stepper).",
+          "Avoid generic action labels such as 'Done'."
+        ]
+      },
+      {
+        "heading": "Steppers",
+        "items": [
+          "Label terminology: Back, Next, Submit (final step).",
+          "Do not mix: Continue and Next, or Finish and Submit."
+        ]
+      }
+    ]
+  },
+  "design_guidelines": null,
+  "variants": {
+    "axes": {
+      "Property 1": [
+        "Default"
+      ]
+    }
+  },
+  "examples": null,
+  "screenshots": {
+    "count": 3,
+    "contexts": [
+      "Screenshot showing sticky footer in page context with buttons (2026-02-20)",
+      "Screenshot showing sticky footer with multi-field form (2026-02-20)",
+      "Screenshot showing sticky footer in modal/drawer (2026-02-20)"
+    ]
+  },
+  "behavior": null
+}

--- a/plugins/actian-design-system/vendor/components/guidelines/tab.json
+++ b/plugins/actian-design-system/vendor/components/guidelines/tab.json
@@ -1,0 +1,24 @@
+{
+  "component": "Tab",
+  "page_id": "9253:33996",
+  "extracted_at": "2026-03-25T00:00:00Z",
+  "frames_found": [
+    "Components",
+    "Screenshots of current use cases"
+  ],
+  "frames_missing": [
+    "Content guidelines",
+    "design guidelines",
+    "ready made examples",
+    "Behavior demo"
+  ],
+  "content_guidelines": null,
+  "design_guidelines": null,
+  "variants": null,
+  "examples": null,
+  "screenshots": {
+    "count": 1,
+    "contexts": []
+  },
+  "behavior": null
+}

--- a/plugins/actian-design-system/vendor/components/guidelines/table.json
+++ b/plugins/actian-design-system/vendor/components/guidelines/table.json
@@ -1,0 +1,58 @@
+{
+  "component": "Table",
+  "page_id": "9253:34015",
+  "extracted_at": "2026-03-25T00:00:00Z",
+  "frames_found": [
+    "Components",
+    "Screenshots of current use cases"
+  ],
+  "frames_missing": [
+    "Content guidelines",
+    "Design guidelines",
+    "ready made examples",
+    "Behavior demo"
+  ],
+  "content_guidelines": null,
+  "design_guidelines": null,
+  "variants": {
+    "axes": {
+      "main_component": {
+        "Type": [
+          "Default"
+        ]
+      },
+      "sub_components": {
+        ".Table column": {
+          "Type": [
+            "Default",
+            "Actions",
+            "Tag"
+          ]
+        },
+        ".Table cell": {
+          "Type": [
+            "Header",
+            "Action",
+            "Tag",
+            "Text",
+            "Skeleton"
+          ]
+        }
+      }
+    }
+  },
+  "examples": null,
+  "screenshots": {
+    "count": 7,
+    "contexts": [
+      "Screenshot 2026-03-06 at 3.09.43 PM",
+      "Screenshot 2026-03-06 at 3.10.22 PM",
+      "Screenshot 2026-03-06 at 3.10.29 PM",
+      "Screenshot 2026-03-06 at 3.11.27 PM",
+      "Screenshot 2026-03-06 at 3.11.49 PM",
+      "Screenshot 2026-03-06 at 3.10.04 PM",
+      "Screenshot 2026-03-06 at 3.13.09 PM"
+    ]
+  },
+  "behavior": null
+}

--- a/plugins/actian-design-system/vendor/components/guidelines/tabs.json
+++ b/plugins/actian-design-system/vendor/components/guidelines/tabs.json
@@ -1,0 +1,29 @@
+{
+  "component": "Tabs",
+  "_stub": true,
+  "_stubGeneratedAt": "2026-05-04T14:37:24.649Z",
+  "page_id": "14747:14818",
+  "extracted_at": "2026-05-04T14:37:24.649Z",
+  "frames_found": [],
+  "frames_missing": [
+    "Design guidelines",
+    "Content guidelines",
+    "Components",
+    "Screenshots of use cases",
+    "Behavior demo",
+    "ready made examples"
+  ],
+  "content_guidelines": null,
+  "design_guidelines": null,
+  "variants": {
+    "axes": {
+      "Property 1": [
+        "Default"
+      ]
+    },
+    "totalVariants": 1
+  },
+  "examples": null,
+  "screenshots": null,
+  "behavior": null
+}

--- a/plugins/actian-design-system/vendor/components/guidelines/tag-catalog-item-type.json
+++ b/plugins/actian-design-system/vendor/components/guidelines/tag-catalog-item-type.json
@@ -1,0 +1,36 @@
+{
+  "component": "✍️ Tag, Catalog item type",
+  "_stub": true,
+  "_stubGeneratedAt": "2026-05-04T14:37:24.649Z",
+  "page_id": "11300:8312",
+  "extracted_at": "2026-05-04T14:37:24.649Z",
+  "frames_found": [],
+  "frames_missing": [
+    "Design guidelines",
+    "Content guidelines",
+    "Components",
+    "Screenshots of use cases",
+    "Behavior demo",
+    "ready made examples"
+  ],
+  "content_guidelines": null,
+  "design_guidelines": null,
+  "variants": {
+    "axes": {
+      "Type": [
+        "Category",
+        "Dataset",
+        "Data process",
+        "Data product",
+        "Field",
+        "Output port",
+        "Use case",
+        "Visualization"
+      ]
+    },
+    "totalVariants": 8
+  },
+  "examples": null,
+  "screenshots": null,
+  "behavior": null
+}

--- a/plugins/actian-design-system/vendor/components/guidelines/tag-catalog.json
+++ b/plugins/actian-design-system/vendor/components/guidelines/tag-catalog.json
@@ -1,0 +1,29 @@
+{
+  "component": "✍️ Tag, Catalog",
+  "_stub": true,
+  "_stubGeneratedAt": "2026-05-04T14:37:24.649Z",
+  "page_id": "13812:22309",
+  "extracted_at": "2026-05-04T14:37:24.649Z",
+  "frames_found": [],
+  "frames_missing": [
+    "Design guidelines",
+    "Content guidelines",
+    "Components",
+    "Screenshots of use cases",
+    "Behavior demo",
+    "ready made examples"
+  ],
+  "content_guidelines": null,
+  "design_guidelines": null,
+  "variants": {
+    "axes": {
+      "Type": [
+        "Default"
+      ]
+    },
+    "totalVariants": 1
+  },
+  "examples": null,
+  "screenshots": null,
+  "behavior": null
+}

--- a/plugins/actian-design-system/vendor/components/guidelines/tag-default.json
+++ b/plugins/actian-design-system/vendor/components/guidelines/tag-default.json
@@ -1,0 +1,37 @@
+{
+  "component": "✍️ Tag, Default",
+  "_stub": true,
+  "_stubGeneratedAt": "2026-05-04T14:37:24.649Z",
+  "page_id": "7257:3037",
+  "extracted_at": "2026-05-04T14:37:24.649Z",
+  "frames_found": [],
+  "frames_missing": [
+    "Design guidelines",
+    "Content guidelines",
+    "Components",
+    "Screenshots of use cases",
+    "Behavior demo",
+    "ready made examples"
+  ],
+  "content_guidelines": null,
+  "design_guidelines": null,
+  "variants": {
+    "axes": {
+      "Color": [
+        "Default",
+        "Pink",
+        "Purple",
+        "Indigo",
+        "Yellow",
+        "Lime",
+        "Teal",
+        "Orange",
+        "Gray"
+      ]
+    },
+    "totalVariants": 9
+  },
+  "examples": null,
+  "screenshots": null,
+  "behavior": null
+}

--- a/plugins/actian-design-system/vendor/components/guidelines/tag-glossary-item-type.json
+++ b/plugins/actian-design-system/vendor/components/guidelines/tag-glossary-item-type.json
@@ -1,0 +1,29 @@
+{
+  "component": "✍️ Tag, Glossary item type",
+  "_stub": true,
+  "_stubGeneratedAt": "2026-05-04T14:37:24.649Z",
+  "page_id": "13812:22308",
+  "extracted_at": "2026-05-04T14:37:24.649Z",
+  "frames_found": [],
+  "frames_missing": [
+    "Design guidelines",
+    "Content guidelines",
+    "Components",
+    "Screenshots of use cases",
+    "Behavior demo",
+    "ready made examples"
+  ],
+  "content_guidelines": null,
+  "design_guidelines": null,
+  "variants": {
+    "axes": {
+      "Property 1": [
+        "Default"
+      ]
+    },
+    "totalVariants": 1
+  },
+  "examples": null,
+  "screenshots": null,
+  "behavior": null
+}

--- a/plugins/actian-design-system/vendor/components/guidelines/tag-interactive.json
+++ b/plugins/actian-design-system/vendor/components/guidelines/tag-interactive.json
@@ -1,0 +1,34 @@
+{
+  "component": "✍️ Tag, Interactive",
+  "_stub": true,
+  "_stubGeneratedAt": "2026-05-04T14:37:24.649Z",
+  "page_id": "13845:33759",
+  "extracted_at": "2026-05-04T14:37:24.649Z",
+  "frames_found": [],
+  "frames_missing": [
+    "Design guidelines",
+    "Content guidelines",
+    "Components",
+    "Screenshots of use cases",
+    "Behavior demo",
+    "ready made examples"
+  ],
+  "content_guidelines": null,
+  "design_guidelines": null,
+  "variants": {
+    "axes": {
+      "State": [
+        "Default",
+        "Hovered",
+        "Pressed",
+        "Selected",
+        "Disabled",
+        "Focused"
+      ]
+    },
+    "totalVariants": 6
+  },
+  "examples": null,
+  "screenshots": null,
+  "behavior": null
+}

--- a/plugins/actian-design-system/vendor/components/guidelines/tag-stage.json
+++ b/plugins/actian-design-system/vendor/components/guidelines/tag-stage.json
@@ -1,0 +1,36 @@
+{
+  "component": "✍️ Tag, Stage",
+  "_stub": true,
+  "_stubGeneratedAt": "2026-05-04T14:37:24.649Z",
+  "page_id": "8655:10279",
+  "extracted_at": "2026-05-04T14:37:24.649Z",
+  "frames_found": [],
+  "frames_missing": [
+    "Design guidelines",
+    "Content guidelines",
+    "Components",
+    "Screenshots of use cases",
+    "Behavior demo",
+    "ready made examples"
+  ],
+  "content_guidelines": null,
+  "design_guidelines": null,
+  "variants": {
+    "axes": {
+      "Color": [
+        "Gray",
+        "Orange",
+        "Indigo",
+        "Purple",
+        "Lime",
+        "Teal",
+        "Yellow",
+        "Pink"
+      ]
+    },
+    "totalVariants": 8
+  },
+  "examples": null,
+  "screenshots": null,
+  "behavior": null
+}

--- a/plugins/actian-design-system/vendor/components/guidelines/tag-status.json
+++ b/plugins/actian-design-system/vendor/components/guidelines/tag-status.json
@@ -1,0 +1,39 @@
+{
+  "component": "✍️ Tag, Status",
+  "_stub": true,
+  "_stubGeneratedAt": "2026-05-04T14:37:24.649Z",
+  "page_id": "7257:3705",
+  "extracted_at": "2026-05-04T14:37:24.649Z",
+  "frames_found": [],
+  "frames_missing": [
+    "Design guidelines",
+    "Content guidelines",
+    "Components",
+    "Screenshots of use cases",
+    "Behavior demo",
+    "ready made examples"
+  ],
+  "content_guidelines": null,
+  "design_guidelines": null,
+  "variants": {
+    "axes": {
+      "Status": [
+        "Fail",
+        "Warning",
+        "Success",
+        "Loading",
+        "Maintenance",
+        "Scheduled",
+        "Queued",
+        "Stopped",
+        "Sleeping",
+        "Offline",
+        "Pending"
+      ]
+    },
+    "totalVariants": 11
+  },
+  "examples": null,
+  "screenshots": null,
+  "behavior": null
+}

--- a/plugins/actian-design-system/vendor/components/guidelines/tag-updated.json
+++ b/plugins/actian-design-system/vendor/components/guidelines/tag-updated.json
@@ -1,0 +1,29 @@
+{
+  "component": "✍️ Tag, Updated",
+  "_stub": true,
+  "_stubGeneratedAt": "2026-05-04T14:37:24.649Z",
+  "page_id": "13812:22307",
+  "extracted_at": "2026-05-04T14:37:24.649Z",
+  "frames_found": [],
+  "frames_missing": [
+    "Design guidelines",
+    "Content guidelines",
+    "Components",
+    "Screenshots of use cases",
+    "Behavior demo",
+    "ready made examples"
+  ],
+  "content_guidelines": null,
+  "design_guidelines": null,
+  "variants": {
+    "axes": {
+      "Type": [
+        "Default"
+      ]
+    },
+    "totalVariants": 1
+  },
+  "examples": null,
+  "screenshots": null,
+  "behavior": null
+}

--- a/plugins/actian-design-system/vendor/components/guidelines/tag.json
+++ b/plugins/actian-design-system/vendor/components/guidelines/tag.json
@@ -1,0 +1,88 @@
+{
+  "component": "Tag / Identification key",
+  "page_id": "9253:34505",
+  "extracted_at": "2026-03-26T00:00:00Z",
+  "frames_found": [
+    "Design guidelines"
+  ],
+  "frames_missing": [
+    "Content guidelines",
+    "Components",
+    "ready made examples",
+    "Screenshots of use cases",
+    "Screenshots of current use cases",
+    "Behavior demo"
+  ],
+  "content_guidelines": null,
+  "has_design_guidelines": true,
+  "design_guidelines": {
+    "sections": [
+      {
+        "heading": "Anatomy",
+        "items": [
+          "Leading icon, Label, Trailing icon, Container."
+        ]
+      },
+      {
+        "heading": "Specs",
+        "items": [
+          "Tag height: 24px.",
+          "Horizontal padding (left/right): 8px (spacing-xs).",
+          "Vertical padding (top/bottom): 4px (spacing-2xs).",
+          "Gap between icon and label: 4px (spacing-2xs).",
+          "Gap between label and trailing icon: 4px (spacing-2xs)."
+        ]
+      },
+      {
+        "heading": "Variations - Interactive",
+        "items": [
+          "Sort: Use a group of interactive chips as quick filter or sort.",
+          "Filters: Tags can be used as filters.",
+          "Stage or status update: Stage or status can be updated with dropdown."
+        ]
+      },
+      {
+        "heading": "Variations - Read-only",
+        "items": [
+          "General: Use the default tag to indicate category or property.",
+          "Stage: Use the stage tag to indicate different stages.",
+          "Status: Use the status tag to indicate progressive status.",
+          "Updated: Use the updated tag to indicate something is new or updated."
+        ]
+      },
+      {
+        "heading": "Limits",
+        "items": [
+          "The maximum width of the tag is 10 rem (160px), which can contain up to 20 characters.",
+          "The label truncates automatically when it exceeds the maximum width of 10 rem (160px).",
+          "For a property tag, truncate both the property label and value, giving them equal space within the maximum tag width."
+        ]
+      },
+      {
+        "heading": "Behavior",
+        "items": [
+          "Hovering over tags brings up a tooltip with the full tag content."
+        ]
+      },
+      {
+        "heading": "Layout",
+        "items": [
+          "Keep 4px (--zen-spacing-2xs) clearance between tags."
+        ]
+      },
+      {
+        "heading": "Usage",
+        "items": [
+          "Do: Place tags immediately beneath and close to the items they describe.",
+          "Don't: Place tags away from the item that they are categorizing and change the layout.",
+          "Do: Use colors and icons to distinguish between different types of tags for easier scanning.",
+          "Don't: Use the same color or styling for multiple tags if they are supposed to be different."
+        ]
+      }
+    ]
+  },
+  "variants": null,
+  "examples": null,
+  "screenshots": null,
+  "behavior": null
+}

--- a/plugins/actian-design-system/vendor/components/guidelines/text-input.json
+++ b/plugins/actian-design-system/vendor/components/guidelines/text-input.json
@@ -1,0 +1,118 @@
+{
+  "component": "Text input",
+  "page_id": "12070:77587",
+  "extracted_at": "2026-03-25T12:00:00Z",
+  "frames_found": [
+    "Content guidelines",
+    "Components",
+    "Screenshots of use cases"
+  ],
+  "frames_missing": [
+    "Design guidelines",
+    "ready made examples",
+    "Behavior demo"
+  ],
+  "content_guidelines": {
+    "sections": [
+      {
+        "heading": "Labels",
+        "content": [
+          {
+            "rule": "Input forms MUST always include a visible label."
+          },
+          {
+            "rule": "Initial state can use placeholder as label."
+          },
+          {
+            "rule": "Once content entered, label moves above."
+          },
+          {
+            "dont": "Repeat label as placeholder."
+          }
+        ]
+      },
+      {
+        "heading": "Behavior",
+        "content": [
+          {
+            "rule": "Error validation should happen at the latest when the user clicks out of the text entry focus."
+          }
+        ]
+      },
+      {
+        "heading": "Placeholder text",
+        "content": [
+          {
+            "rule": "Provides a brief example of the expected input content. It should be used only to model good input, and not to convey instructions or restrictions for the field."
+          },
+          {
+            "dont": "Simply repeat the field label or description in the placeholder."
+          },
+          {
+            "rule": "Use placeholder text when: An example would model the correct input; Naming conventions or restrictions should be reinforced; The field label could be interpreted in different ways, and an example would reduce that ambiguity."
+          },
+          {
+            "dont": "Use placeholder text if the label text is sufficient."
+          },
+          {
+            "rule": "Keep placeholders concise and brief: No full sentences. No ending punctuation. Between 2-5 words. The placeholder should scan instantly and disappear without cognitive load."
+          },
+          {
+            "dont": "Include restrictions and rules such as character limits, allowed or restricted characters, or formatting rules in placeholder text."
+          },
+          {
+            "do": "Customer Orders, Sales Performance",
+            "dont": "Type here, Name, Enter name"
+          }
+        ]
+      },
+      {
+        "heading": "Accessibility",
+        "content": [
+          {
+            "rule": "Placeholder text must never replace a field's label."
+          },
+          {
+            "rule": "All critical guidance must remain visible after the user starts typing."
+          },
+          {
+            "rule": "The UI must remain usable if placeholder text is removed."
+          }
+        ]
+      }
+    ]
+  },
+  "design_guidelines": null,
+  "variants": {
+    "axes": {
+      "State": [
+        "Default",
+        "Hovered",
+        "Focused",
+        "Active",
+        "Filled",
+        "Error",
+        "Disabled",
+        "Read-only"
+      ]
+    },
+    "sub_component": {
+      "name": ".Textfield buttons",
+      "axes": {
+        "Type": [
+          "Default"
+        ]
+      }
+    }
+  },
+  "examples": null,
+  "screenshots": {
+    "count": 6,
+    "contexts": [
+      "Screenshots showing text input in product forms (2026-02-27)",
+      "Screenshots showing various text input states in real UI",
+      "Captures from 2025-03-26 and 2025-07-22 showing historical usage"
+    ]
+  },
+  "behavior": null
+}

--- a/plugins/actian-design-system/vendor/components/guidelines/tile-item.json
+++ b/plugins/actian-design-system/vendor/components/guidelines/tile-item.json
@@ -1,0 +1,40 @@
+{
+  "component": "Tile, Item",
+  "_stub": true,
+  "_stubGeneratedAt": "2026-05-04T14:37:24.649Z",
+  "page_id": "7613:7853",
+  "extracted_at": "2026-05-04T14:37:24.649Z",
+  "frames_found": [],
+  "frames_missing": [
+    "Design guidelines",
+    "Content guidelines",
+    "Components",
+    "Screenshots of use cases",
+    "Behavior demo",
+    "ready made examples"
+  ],
+  "content_guidelines": null,
+  "design_guidelines": null,
+  "variants": {
+    "axes": {
+      "Type": [
+        "Catalog",
+        "Item",
+        "item type",
+        "Glossary type",
+        "Topic"
+      ],
+      "State": [
+        "Default",
+        "Hover",
+        "Focus",
+        "Pressed",
+        "Selected"
+      ]
+    },
+    "totalVariants": 25
+  },
+  "examples": null,
+  "screenshots": null,
+  "behavior": null
+}

--- a/plugins/actian-design-system/vendor/components/guidelines/toggle-control.json
+++ b/plugins/actian-design-system/vendor/components/guidelines/toggle-control.json
@@ -1,0 +1,71 @@
+{
+  "component": "Toggle control",
+  "page_id": "12070:77591",
+  "extracted_at": "2026-03-26T00:00:00Z",
+  "frames_found": [
+    "Design guidelines",
+    "Content guidelines",
+    "Components"
+  ],
+  "frames_missing": [
+    "ready made examples",
+    "Screenshots of use cases",
+    "Behavior demo"
+  ],
+  "content_guidelines": {
+    "sections": [
+      {
+        "heading": "Style",
+        "content": [
+          {
+            "rule": "Label next to or above control ('Enable alerts')."
+          },
+          {
+            "rule": "Show label for currently selected state ('Off' when off, 'On' when on, not both)."
+          }
+        ]
+      },
+      {
+        "heading": "Behavior",
+        "content": [
+          {
+            "rule": "Action happens on toggle (no confirmation)."
+          },
+          {
+            "rule": "Left = off, right = on."
+          },
+          {
+            "rule": "Should update instantly."
+          }
+        ]
+      },
+      {
+        "heading": "Toggle vs Checkbox",
+        "content": [
+          {
+            "rule": "Toggle for instant changes, system state, rarely in forms."
+          },
+          {
+            "rule": "Checkbox for form submissions, multiple options."
+          }
+        ]
+      }
+    ]
+  },
+  "has_design_guidelines": true,
+  "design_guidelines": {
+    "sections": [
+      {
+        "heading": "Toggle alignment",
+        "items": [
+          "When the toggle label is short (e.g., 'On'/'Off'), the toggle is left-aligned with the label to its right.",
+          "When the toggle has a longer descriptive label (e.g., 'Activate on current page'), the toggle is right-aligned with the label to its left."
+        ]
+      }
+    ]
+  },
+  "variants": null,
+  "examples": null,
+  "screenshots": null,
+  "behavior": null
+}

--- a/plugins/actian-design-system/vendor/components/guidelines/toolbar.json
+++ b/plugins/actian-design-system/vendor/components/guidelines/toolbar.json
@@ -1,0 +1,35 @@
+{
+  "component": "Toolbar",
+  "_stub": true,
+  "_stubGeneratedAt": "2026-05-04T14:37:24.649Z",
+  "page_id": "14335:16907",
+  "extracted_at": "2026-05-04T14:37:24.649Z",
+  "frames_found": [],
+  "frames_missing": [
+    "Design guidelines",
+    "Content guidelines",
+    "Components",
+    "Screenshots of use cases",
+    "Behavior demo",
+    "ready made examples"
+  ],
+  "content_guidelines": null,
+  "design_guidelines": null,
+  "variants": {
+    "axes": {
+      "Type": [
+        "Single",
+        "Combined",
+        "Group"
+      ],
+      "Orientation": [
+        "Horizontal",
+        "Vertical"
+      ]
+    },
+    "totalVariants": 6
+  },
+  "examples": null,
+  "screenshots": null,
+  "behavior": null
+}

--- a/plugins/actian-design-system/vendor/components/guidelines/tooltip.json
+++ b/plugins/actian-design-system/vendor/components/guidelines/tooltip.json
@@ -1,0 +1,108 @@
+{
+  "component": "Tooltip",
+  "page_id": "9253:37504",
+  "extracted_at": "2026-03-26T00:00:00Z",
+  "frames_found": ["Design guidelines"],
+  "frames_missing": [
+    "Content guidelines",
+    "Components",
+    "ready made examples",
+    "Screenshots of use cases",
+    "Screenshots of current use cases",
+    "Behavior demo"
+  ],
+  "content_guidelines": null,
+  "has_design_guidelines": true,
+  "design_guidelines": {
+    "sections": [
+      {
+        "heading": "Elements",
+        "tables": [
+          {
+            "headers": ["Element name", "Values"],
+            "rows": [
+              ["Title (optional)", "Heading 2XS"],
+              ["Body", "Body SM"],
+              ["Actions (optional)", "TBD (small ghost buttons)"],
+              ["Container", "CoolGrey90, radius 4px"]
+            ]
+          }
+        ]
+      },
+      {
+        "heading": "Content and variations",
+        "items": [
+          "Default: Simple text tooltip with body text only.",
+          "Rich: Tooltip with title, body text, and optional actions.",
+          "Keep tooltip text concise and to the point. They are considered microcontent and should be used sparingly.",
+          "Avoid placing essential information in tooltips, as users might overlook them.",
+          "Use tooltips for clarifications, definitions, or hints, not for critical or detailed information.",
+          "Limit to 1-2 sentences (or about 60-100 characters) for definition tooltips.",
+          "Icon tooltips should use 1-2 words AT MOST.",
+          "Ensure tooltips are scannable and don't require scrolling or extensive reading.",
+          "For longer explanations, use components like modals, help panels, or popovers instead.",
+          "Accessibility tip: While interactive elements can be used in tooltips, they should not be used except in extreme cases. Interactive elements in tooltips are not accessible."
+        ]
+      },
+      {
+        "heading": "Parent element, usage, content, and behavior",
+        "items": [
+          "Icon button: Clarify the action or name of an interactive icon button. Should contain only one or two words. Hover on desktop or tap and hold on mobile.",
+          "Info icon: Provides additional help or defines an item or term, often used on field labels or elements in a UI. Should contain brief, read-only text. Hover on desktop or tap and hold on mobile.",
+          "Dotted-underlined text: Best used for onboarding experiences and product tours. Provide a short description. The cumulative text should not exceed 4 lines. Click or tap to reveal and click or tap the parent element again to close."
+        ]
+      },
+      {
+        "heading": "Interactions",
+        "items": [
+          "Triggering a new tooltip immediately closes any other open tooltip. Only display one tooltip at a time.",
+          "Tooltip shows after hovering for 1 second."
+        ]
+      },
+      {
+        "heading": "Target area",
+        "items": [
+          "Icon button's container is the target area, which a user can hover on or touch to reveal the tooltip.",
+          "The info icon including surrounding 4px margins is the target area, which a user can hover on or touch to reveal the tooltip.",
+          "Dotted-underlined text including surrounding 4px margins is the target area, which a user can click or touch it to reveal the tooltip."
+        ]
+      },
+      {
+        "heading": "Clearance",
+        "items": ["Keep 2px clearance between the target area and the tooltip."]
+      },
+      {
+        "heading": "Spacing",
+        "items": [
+          "Container padding: 8px on all sides.",
+          "Gap between title and body: 4px.",
+          "Gap between body lines: 8px.",
+          "Gap between body and actions: 8px.",
+          "Flex width with maximum width of 240px."
+        ]
+      },
+      {
+        "heading": "Maximum width",
+        "items": ["The maximum width of the tooltip is 200px."]
+      },
+      {
+        "heading": "Positioning",
+        "items": [
+          "By default, tooltips are positioned directly above the parent element in the center.",
+          "They adjust position to avoid going off screen.",
+          "Tooltips shouldn't cover the parent element."
+        ]
+      }
+    ]
+  },
+  "variants": null,
+  "examples": null,
+  "screenshots": null,
+  "behavior": {
+    "motion": {
+      "pattern": "anchor-motion",
+      "overrides": null,
+      "notes": "Tooltip is the canonical anchor-motion case. Open: duration-base + ease-entrance, fades in + scales up from trigger. Close: duration-fast + ease-standard. Apply delay-intent (300ms) for hover-triggered tooltips to prevent accidental triggers; keyboard focus (Tab) ignores the delay."
+    }
+  }
+}

--- a/plugins/actian-design-system/vendor/components/guidelines/traffic-light.json
+++ b/plugins/actian-design-system/vendor/components/guidelines/traffic-light.json
@@ -1,0 +1,24 @@
+{
+  "component": "Traffic light",
+  "page_id": "14719:5902",
+  "extracted_at": "2026-03-25T00:00:00Z",
+  "frames_found": [
+    "Components",
+    "Screenshots of current use cases"
+  ],
+  "frames_missing": [
+    "Content guidelines",
+    "design guidelines",
+    "ready made examples",
+    "Behavior demo"
+  ],
+  "content_guidelines": null,
+  "design_guidelines": null,
+  "variants": null,
+  "examples": null,
+  "screenshots": {
+    "count": 1,
+    "contexts": []
+  },
+  "behavior": null
+}

--- a/plugins/actian-design-system/vendor/components/guidelines/whats-new-dropdown.json
+++ b/plugins/actian-design-system/vendor/components/guidelines/whats-new-dropdown.json
@@ -1,0 +1,32 @@
+{
+  "component": "Whats new dropdown",
+  "_stub": true,
+  "_stubGeneratedAt": "2026-05-04T14:37:24.649Z",
+  "page_id": "9114:16794",
+  "extracted_at": "2026-05-04T14:37:24.649Z",
+  "frames_found": [],
+  "frames_missing": [
+    "Design guidelines",
+    "Content guidelines",
+    "Components",
+    "Screenshots of use cases",
+    "Behavior demo",
+    "ready made examples"
+  ],
+  "content_guidelines": null,
+  "design_guidelines": null,
+  "variants": {
+    "axes": {
+      "Property 1": [
+        "Drilldown1",
+        "Drilldown2",
+        "Empty",
+        "List"
+      ]
+    },
+    "totalVariants": 4
+  },
+  "examples": null,
+  "screenshots": null,
+  "behavior": null
+}

--- a/plugins/actian-design-system/vendor/components/registries/dskit.json
+++ b/plugins/actian-design-system/vendor/components/registries/dskit.json
@@ -1,0 +1,4966 @@
+{
+  "library": "ds",
+  "fileKey": "l8biHxfarNi1I2RMvVxVOK",
+  "lastSynced": "2026-05-09T15:47:11.422Z",
+  "componentCount": 322,
+  "components": {
+    "xs-grid": {
+      "name": "XS grid",
+      "key": "e939d776621f097562d024535a10d5c011fd493c",
+      "nodeId": "14744:8073",
+      "importMethod": "set",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:11.422Z",
+      "page": "✅ Breakpoint, grid & structure",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null,
+      "variants": {
+        "Property 1": [
+          "Default"
+        ]
+      }
+    },
+    "checkbox-with-label": {
+      "name": "Checkbox with label",
+      "key": "f88de6fe161264680045b2b5ec77d311b1b3adb6",
+      "nodeId": "9478:17216",
+      "importMethod": "set",
+      "description": "Used for binary choices (on/off) or when a user can select multiple options from a list of related items.",
+      "lastSynced": "2026-05-09T15:47:11.422Z",
+      "page": "✅ Checkbox",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null,
+      "variants": {
+        "Selected": [
+          "Yes",
+          "Indeterminate",
+          "No"
+        ],
+        "State": [
+          "Default",
+          "Hover",
+          "Focus",
+          "Pressed",
+          "Disabled"
+        ]
+      }
+    },
+    "breadcrumbs": {
+      "name": "Breadcrumbs",
+      "key": "72976d77668b8e085d716fc8c5bc0bd144cb7274",
+      "nodeId": "13792:15247",
+      "importMethod": "set",
+      "description": "Use to show the user's current location within a hierarchical multi-level structure. Enables 1-click navigation back to parent pages.",
+      "lastSynced": "2026-05-09T15:47:11.422Z",
+      "page": "✅ Breadcrumbs",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null,
+      "variants": {
+        "Type": [
+          "Default"
+        ]
+      }
+    },
+    "lineage-individual-node": {
+      "name": "Lineage individual node",
+      "key": "5904351595c9b5b263bb5891bd1ed038fbaff636",
+      "nodeId": "14747:19902",
+      "importMethod": "set",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:11.422Z",
+      "page": "✅ Data viz: lineage",
+      "properties": {
+        "Show left control#14691:0": {
+          "type": "BOOLEAN",
+          "default": true
+        }
+      },
+      "nestedComponents": [],
+      "guidelinesFile": null,
+      "variants": {
+        "Type": [
+          "Main item",
+          "Sub item"
+        ],
+        "State": [
+          "Default",
+          "Selected",
+          "Disabled"
+        ],
+        "Fields": [
+          "Collapsed",
+          "Expanded"
+        ]
+      }
+    },
+    "tag-glossary-item-type": {
+      "name": "✍️ Tag, Glossary item type",
+      "key": "639773a27d790a489c5e115360b64c7d05a45ac3",
+      "nodeId": "13812:22308",
+      "importMethod": "set",
+      "description": "Use for glossary item types. Can be interactive (removable) or static metadata.",
+      "lastSynced": "2026-05-09T15:47:11.422Z",
+      "page": "✍️ Tag (Identification key)",
+      "properties": {
+        "Show Counter#14128:9": {
+          "type": "BOOLEAN",
+          "default": false
+        }
+      },
+      "nestedComponents": [],
+      "guidelinesFile": null,
+      "variants": {
+        "Property 1": [
+          "Default"
+        ]
+      }
+    },
+    "card": {
+      "name": "Card",
+      "key": "3b8d2c7adc118fdd5f31e68440fa35e952fee92e",
+      "nodeId": "14782:29281",
+      "importMethod": "set",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:11.422Z",
+      "page": "✅ Card",
+      "properties": {
+        "Slot#15927:0": {
+          "type": "SLOT",
+          "default": {
+            "guid": {
+              "sessionID": -1,
+              "localID": -1
+            }
+          }
+        },
+        "Show header#15927:2": {
+          "type": "BOOLEAN",
+          "default": true
+        }
+      },
+      "nestedComponents": [],
+      "guidelinesFile": null,
+      "variants": {
+        "Property 1": [
+          "Default"
+        ]
+      }
+    },
+    "rich-text": {
+      "name": "Rich text",
+      "key": "e904c7b5c3ef6d223d9743546484e5a99b7a7808",
+      "nodeId": "9480:17723",
+      "importMethod": "set",
+      "description": "A multi-line input field that allows for text formatting (bold, links, lists). Use for long-form content like descriptions or comments.",
+      "lastSynced": "2026-05-09T15:47:11.422Z",
+      "page": "✅ Rich text (existing)",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null,
+      "variants": {
+        "State": [
+          "Expanded",
+          "Default"
+        ]
+      }
+    },
+    "white-label-merck-favicon": {
+      "name": "White-label-merck-favicon",
+      "key": "3befa3fc619a900f666288d3f7046251d78658b3",
+      "nodeId": "15609:14859",
+      "importMethod": "set",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:11.422Z",
+      "page": "White-label services",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null,
+      "variants": {
+        "Property 1": [
+          "Merck-favicon-admin",
+          "Merck-favicon-explorer",
+          "Merck-favicon-studio"
+        ]
+      }
+    },
+    "maintenance-banner": {
+      "name": "Maintenance banner",
+      "key": "0b2532c1213a748aea1559458099a058bd486959",
+      "nodeId": "13868:11535",
+      "importMethod": "set",
+      "description": "A specialized Alert variant for scheduled downtime or degraded performance.",
+      "lastSynced": "2026-05-09T15:47:11.422Z",
+      "page": "✅ Maintenance banner",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null,
+      "variants": {
+        "Type": [
+          "Default"
+        ]
+      }
+    },
+    "actian-data-intelligence": {
+      "name": "Actian Data Intelligence",
+      "key": "2e53061b856da7a42b2328279d16718d252e0780",
+      "nodeId": "7764:7617",
+      "importMethod": "set",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:11.422Z",
+      "page": "Product logos",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null,
+      "variants": {
+        "Type": [
+          "Explorer",
+          "Data Intelligence",
+          "Studio",
+          "Admin"
+        ],
+        "Orientation": [
+          "Horizontal",
+          "Vertical"
+        ]
+      }
+    },
+    "toglge": {
+      "name": "Toglge",
+      "key": "4e7793f094eed660e01d8f7c804f2391e72115d2",
+      "nodeId": "14000:4395",
+      "importMethod": "set",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:11.422Z",
+      "page": "Toggle control",
+      "properties": {
+        "Show Helper text#13981:32": {
+          "type": "BOOLEAN",
+          "default": true
+        }
+      },
+      "nestedComponents": [],
+      "guidelinesFile": null,
+      "variants": {
+        "Toggle location": [
+          "Left",
+          "Right"
+        ],
+        "Selected": [
+          "No",
+          "Yes"
+        ],
+        "State": [
+          "Default",
+          "Hover",
+          "Focus",
+          "Pressed",
+          "Disabled"
+        ]
+      }
+    },
+    "tag-interactive": {
+      "name": "✍️ Tag, Interactive",
+      "key": "19d8ed0dd3f5dc406017130026a6229f121f169d",
+      "nodeId": "13845:33759",
+      "importMethod": "set",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:11.422Z",
+      "page": "✍️ Tag (Identification key)",
+      "properties": {
+        "Leading icon show#13846:14": {
+          "type": "BOOLEAN",
+          "default": false
+        },
+        "Leading icon#13846:21": {
+          "type": "INSTANCE_SWAP",
+          "default": "7206:3772"
+        },
+        "Trailing icon show#13846:28": {
+          "type": "BOOLEAN",
+          "default": true
+        },
+        "Trailing icon#13849:35": {
+          "type": "INSTANCE_SWAP",
+          "default": "7207:2839"
+        }
+      },
+      "nestedComponents": [],
+      "guidelinesFile": null,
+      "variants": {
+        "State": [
+          "Default",
+          "Hovered",
+          "Pressed",
+          "Selected",
+          "Disabled",
+          "Focused"
+        ]
+      }
+    },
+    "notification-dropdown": {
+      "name": "Notification dropdown",
+      "key": "927eb804d065b6e2be5f8dfa54643774304d7d6c",
+      "nodeId": "9114:15379",
+      "importMethod": "set",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:11.422Z",
+      "page": "✅ Global header",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null,
+      "variants": {
+        "Property 1": [
+          "Empty",
+          "List"
+        ]
+      }
+    },
+    "zeenea-logo": {
+      "name": "Zeenea logo",
+      "key": "b1071930165c007be3fe93de3f881d09794235ce",
+      "nodeId": "12770:6651",
+      "importMethod": "set",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:11.422Z",
+      "page": "Product logos",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null,
+      "variants": {
+        "Type": [
+          "Dev Logo Explorer",
+          "Dev Logo Studio",
+          "Dev Logo Zenea Corporate",
+          "Favicon Zeenea 1",
+          "Logo Explorer",
+          "Logo Studio",
+          "Logo Zenea Corporate",
+          "Favicon Explorer",
+          "Favicon Studio"
+        ]
+      }
+    },
+    "illustration": {
+      "name": "Illustration",
+      "key": "00302ca7dc4298c719f19ca4766029909ecbeb9d",
+      "nodeId": "8837:9945",
+      "importMethod": "set",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:11.422Z",
+      "page": "Illustrations & graphics",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null,
+      "variants": {
+        "Type": [
+          "Empty state large",
+          "Empty state medium",
+          "Empty state small",
+          "Error state",
+          "Maintenance",
+          "Success",
+          "Error state medium"
+        ]
+      }
+    },
+    "component-1": {
+      "name": "Component 1",
+      "key": "21e6d9f1dc0fd84b226c3a52649eb25bfb45105b",
+      "nodeId": "8927:9233",
+      "importMethod": "set",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:11.422Z",
+      "page": "Product logos",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null,
+      "variants": {
+        "Layout": [
+          "Horizontal",
+          "Vertical"
+        ]
+      }
+    },
+    "data-intelligence-dev-logo": {
+      "name": "Data Intelligence Dev Logo",
+      "key": "528044aaf9ab8b637aa37e94f67e60c5363cf751",
+      "nodeId": "12770:6655",
+      "importMethod": "set",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:11.422Z",
+      "page": "Product logos",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null,
+      "variants": {
+        "Property 1": [
+          "Dev Actian Data Intelligence Admin",
+          "Dev Actian Data Intelligence Explorer",
+          "Dev Actian Data Intelligence Studio"
+        ]
+      }
+    },
+    "tooltip": {
+      "name": "⚠️ Tooltip",
+      "key": "558adad968a5b5e1e3714307fb19de73d1ac6d21",
+      "nodeId": "7038:351",
+      "importMethod": "set",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:11.422Z",
+      "page": "⚠️ Tooltip",
+      "properties": {
+        "Body#7038:10": {
+          "type": "TEXT",
+          "default": "Body line text lorem ipsum dolor sit amet, consectetur"
+        }
+      },
+      "nestedComponents": [],
+      "guidelinesFile": null,
+      "variants": {
+        "Type": [
+          "Default"
+        ]
+      }
+    },
+    "xl-grid": {
+      "name": "XL grid",
+      "key": "d6b83246f85c6e57d45bbd35ec6d8acab2e16488",
+      "nodeId": "12054:30623",
+      "importMethod": "set",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:11.422Z",
+      "page": "✅ Breakpoint, grid & structure",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null,
+      "variants": {
+        "Property": [
+          "Default",
+          "Side nav collapsed",
+          "Side nav expanded"
+        ]
+      }
+    },
+    "whats-new-dropdown": {
+      "name": "Whats new dropdown",
+      "key": "f7040db58ba132df1b3d292a72a003399433765f",
+      "nodeId": "9114:16794",
+      "importMethod": "set",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:11.422Z",
+      "page": "✅ Global header",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null,
+      "variants": {
+        "Property 1": [
+          "Drilldown1",
+          "Drilldown2",
+          "Empty",
+          "List"
+        ]
+      }
+    },
+    "tag-default": {
+      "name": "✍️ Tag, Default",
+      "key": "69c8a031b8b1f1703474cc000eaeb14611f0319c",
+      "nodeId": "7257:3037",
+      "importMethod": "set",
+      "description": "Use for categorizing or labeling items (e.g., \"Design\", \"In Progress\"). Can be interactive (removable) or static metadata.",
+      "lastSynced": "2026-05-09T15:47:11.422Z",
+      "page": "✍️ Tag (Identification key)",
+      "properties": {
+        "Label#257:0": {
+          "type": "TEXT",
+          "default": "Label"
+        },
+        "Leading icon show#7276:0": {
+          "type": "BOOLEAN",
+          "default": true
+        },
+        "Leading icon#8400:0": {
+          "type": "INSTANCE_SWAP",
+          "default": "7206:3772"
+        },
+        "Trailing icon show#13812:149": {
+          "type": "BOOLEAN",
+          "default": false
+        },
+        "Trailing icon#13812:158": {
+          "type": "INSTANCE_SWAP",
+          "default": "7207:2839"
+        }
+      },
+      "nestedComponents": [],
+      "guidelinesFile": null,
+      "variants": {
+        "Color": [
+          "Pink",
+          "Purple",
+          "Indigo",
+          "Yellow",
+          "Lime",
+          "Teal",
+          "Orange",
+          "Gray",
+          "Default"
+        ]
+      }
+    },
+    "metamodel-widget": {
+      "name": "Metamodel widget",
+      "key": "6b29851b99078abe643d2c6873e8e1a89f8ff0b4",
+      "nodeId": "14747:23588",
+      "importMethod": "set",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:11.422Z",
+      "page": "✅ Data viz: metamodel",
+      "properties": {
+        "Show Section#8582:0": {
+          "type": "BOOLEAN",
+          "default": true
+        }
+      },
+      "nestedComponents": [],
+      "guidelinesFile": null,
+      "variants": {
+        "Type": [
+          "Dataset",
+          "Business Term",
+          "Data Process",
+          "Field",
+          "Visualisation"
+        ]
+      }
+    },
+    "glossary-item-hierarchy-diagram": {
+      "name": "Glossary item hierarchy diagram",
+      "key": "ccb3fbc9c238527e5fa4998e8fd6ae9b5c31b7da",
+      "nodeId": "14747:30242",
+      "importMethod": "set",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:11.422Z",
+      "page": "✅ Data viz: glossary item hierarchy",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null,
+      "variants": {
+        "Type": [
+          "Default"
+        ]
+      }
+    },
+    "search-result-card": {
+      "name": "Search result card",
+      "key": "0549dc90f04862d64b5b4f8808f26f4968327ce9",
+      "nodeId": "12932:3259",
+      "importMethod": "set",
+      "description": "A specialized card variant optimized for scannability during a search. Highlights relevant metadata and matching keywords.",
+      "lastSynced": "2026-05-09T15:47:11.422Z",
+      "page": "✅ Search result card",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null,
+      "variants": {
+        "App": [
+          "Explorer",
+          "Studio"
+        ],
+        "State": [
+          "Default",
+          "Hover",
+          "Focus",
+          "Pressed",
+          "Selected"
+        ]
+      }
+    },
+    "chat-with-ai-steward": {
+      "name": "Chat with AI Steward",
+      "key": "8ba9d4d075ffab728d03d5bf771173f39d41e5ac",
+      "nodeId": "15464:24509",
+      "importMethod": "set",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:11.422Z",
+      "page": "✍️ Chat with AI Steward",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null,
+      "variants": {
+        "size": [
+          "Default",
+          "Drawer"
+        ],
+        "history": [
+          "Closed",
+          "Open"
+        ]
+      }
+    },
+    "digram-item-types": {
+      "name": "Digram, Item types",
+      "key": "1705ad4e55489bb9ca0f203be5bd0edbd77e82b2",
+      "nodeId": "14007:23209",
+      "importMethod": "set",
+      "description": "Works like tags but contains only 2 letters (initials of category name)",
+      "lastSynced": "2026-05-09T15:47:11.422Z",
+      "page": "✅ Digram",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null,
+      "variants": {
+        "Item type": [
+          "Dataset",
+          "Data process",
+          "Data product",
+          "Field",
+          "Output port",
+          "Use case",
+          "Visualization",
+          "Category",
+          "Custom 1",
+          "Custom 2",
+          "Custom 3",
+          "Custom 4",
+          "Custom 5",
+          "Custom 6",
+          "Custom 7",
+          "Custom 8",
+          "Custom 9",
+          "Custom 10",
+          "Custom 11",
+          "Custom 12",
+          "Custom 13",
+          "Custom 14",
+          "Custom 16",
+          "Glossary 1",
+          "Glossary 2",
+          "Glossary 3",
+          "Glossary 4",
+          "Glossary 5"
+        ],
+        "Size": [
+          "Default",
+          "Large"
+        ]
+      }
+    },
+    "progress-bar-small": {
+      "name": "Progress bar small",
+      "key": "3ad726123245a1052e193ff80b894ba98b9a3e52",
+      "nodeId": "14136:1615",
+      "importMethod": "set",
+      "description": "Visualizes the completion percentage of a task.  Use as a static visualization like a bar graph to show the completeness.",
+      "lastSynced": "2026-05-09T15:47:11.422Z",
+      "page": "✅ Data viz: progressive bar",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null,
+      "variants": {
+        "Size": [
+          "Default",
+          "Large"
+        ],
+        "Completeness": [
+          "0%",
+          "100%",
+          "50%"
+        ]
+      }
+    },
+    "popover": {
+      "name": "⛔️ Popover",
+      "key": "6116aac0bacf92b34f2f796633953616ab9efd7c",
+      "nodeId": "14294:7345",
+      "importMethod": "set",
+      "description": "A non-modal floating container triggered by a click. Use for displaying a small menu or related content that doesn't fit in a tooltip. Stays open until a user clicks outside.",
+      "lastSynced": "2026-05-09T15:47:11.422Z",
+      "page": "⛔️ Popover",
+      "properties": {
+        "Show info icon#14294:20": {
+          "type": "BOOLEAN",
+          "default": true
+        }
+      },
+      "nestedComponents": [],
+      "guidelinesFile": null,
+      "variants": {
+        "Type": [
+          "Interaction guide",
+          "Advanced search"
+        ]
+      }
+    },
+    "confirmation": {
+      "name": "Confirmation",
+      "key": "41a7ce5d67baa4a49843fc0768bee6df42f945a7",
+      "nodeId": "13871:32310",
+      "importMethod": "set",
+      "description": "A placeholder shown when success. Must include an illustration, a clear title, and a \"Call to Action\" button to help the user get started.",
+      "lastSynced": "2026-05-09T15:47:11.422Z",
+      "page": "✅ Empty state",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null,
+      "variants": {
+        "Size": [
+          "Large"
+        ]
+      }
+    },
+    "avatar": {
+      "name": "Avatar",
+      "key": "67e11f5d63bbe3cb24cae7d38ab5e90ee506d266",
+      "nodeId": "7384:14212",
+      "importMethod": "set",
+      "description": "Visual representation of a user or entity. Use \"Image\" variant if a photo exists, or \"Initials\" as a fallback.",
+      "lastSynced": "2026-05-09T15:47:11.422Z",
+      "page": "✅ Avatar",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null,
+      "variants": {
+        "State": [
+          "Default",
+          "Hovered",
+          "Focused",
+          "Pressed",
+          "Disabled",
+          "Selected"
+        ],
+        "Type": [
+          "One group",
+          "Two groups",
+          "Default"
+        ]
+      }
+    },
+    "scroll-bar": {
+      "name": "Scroll bar",
+      "key": "374c471abeb21e0693327b61cc12a31a5eeef5ba",
+      "nodeId": "14747:17639",
+      "importMethod": "set",
+      "description": "Custom UI for indicating and controlling scroll position within a specific container. Only use when standard browser scroll is insufficient.",
+      "lastSynced": "2026-05-09T15:47:11.422Z",
+      "page": "✅ Scroll bar",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null,
+      "variants": {
+        "Property 1": [
+          "Default"
+        ]
+      }
+    },
+    "s-grid": {
+      "name": "S grid",
+      "key": "15772025d13a090b6327442a396f6f9757858031",
+      "nodeId": "14744:8072",
+      "importMethod": "set",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:11.422Z",
+      "page": "✅ Breakpoint, grid & structure",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null,
+      "variants": {
+        "Property 1": [
+          "Default"
+        ]
+      }
+    },
+    "traffic-light": {
+      "name": "Traffic light",
+      "key": "4d34e14670144322fcfb202e843dc75534ff917f",
+      "nodeId": "13797:13103",
+      "importMethod": "set",
+      "description": "A status indicator (Red, Amber, Green). Use to communicate system health, task urgency, or a quick \"Pass/Fail\" summary.",
+      "lastSynced": "2026-05-09T15:47:11.422Z",
+      "page": "✅ Traffic light",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null,
+      "variants": {
+        "Type": [
+          "Default",
+          "Green",
+          "Orange",
+          "Red"
+        ]
+      }
+    },
+    "radio-button": {
+      "name": "Radio button",
+      "key": "9ceb34116fd119a17b08b9b445a204de28f9d249",
+      "nodeId": "9474:16884",
+      "importMethod": "set",
+      "description": "Used for mutually exclusive choices where the user must select exactly one option from a small list (2–5 items).",
+      "lastSynced": "2026-05-09T15:47:11.422Z",
+      "page": "✅ Radio button",
+      "properties": {
+        "Show Helper text#13981:32": {
+          "type": "BOOLEAN",
+          "default": true
+        },
+        "Show Icon#14119:0": {
+          "type": "BOOLEAN",
+          "default": true
+        }
+      },
+      "nestedComponents": [],
+      "guidelinesFile": null,
+      "variants": {
+        "Format": [
+          "Default",
+          "Card format"
+        ],
+        "Selected": [
+          "No",
+          "Yes"
+        ],
+        "State": [
+          "Default",
+          "Hover",
+          "Focus",
+          "Pressed",
+          "Disabled"
+        ]
+      }
+    },
+    "segmented-control": {
+      "name": "Segmented control",
+      "key": "062274018b2daab1c45c7e634c95c5a4eaa42b69",
+      "nodeId": "7618:5187",
+      "importMethod": "set",
+      "description": "Use for mutually exclusive options that impact the immediate view. Best for 2–4 options (e.g., \"Week / Month / Year\").",
+      "lastSynced": "2026-05-09T15:47:11.422Z",
+      "page": "✅ Segmented control (Button group)",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null,
+      "variants": {
+        "Type": [
+          "Default"
+        ]
+      }
+    },
+    "tag-catalog-item-type": {
+      "name": "✍️ Tag, Catalog item type",
+      "key": "40393216be9b998d35ac0b4bd63929ccbc4de25e",
+      "nodeId": "11300:8312",
+      "importMethod": "set",
+      "description": "Use for physical metamodel item types. Can be interactive (removable) or static metadata.",
+      "lastSynced": "2026-05-09T15:47:11.422Z",
+      "page": "✍️ Tag (Identification key)",
+      "properties": {
+        "Show counter#14128:0": {
+          "type": "BOOLEAN",
+          "default": false
+        }
+      },
+      "nestedComponents": [],
+      "guidelinesFile": null,
+      "variants": {
+        "Type": [
+          "Category",
+          "Dataset",
+          "Data process",
+          "Data product",
+          "Field",
+          "Output port",
+          "Use case",
+          "Visualization"
+        ]
+      }
+    },
+    "identification-key": {
+      "name": "Identification key",
+      "key": "3bf340c5e6f49afc5b73140935558a558b3e8855",
+      "nodeId": "14349:15323",
+      "importMethod": "set",
+      "description": "Use for identification keys. Can be interactive (removable) or static metadata.",
+      "lastSynced": "2026-05-09T15:47:11.422Z",
+      "page": "✍️ Tag (Identification key)",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null,
+      "variants": {
+        "Property 1": [
+          "Default"
+        ]
+      }
+    },
+    "loading-skeleton": {
+      "name": "Loading skeleton",
+      "key": "b798100889bf79e5b9b3c0bb28bafe9713342871",
+      "nodeId": "14294:8086",
+      "importMethod": "set",
+      "description": "Indicates a background process is active. Use Skeleton for page-level transitions to reduce perceived wait time.",
+      "lastSynced": "2026-05-09T15:47:11.422Z",
+      "page": "✅ Loading (Loader, Spinner, Skeleton)",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null,
+      "variants": {
+        "Transition": [
+          "1",
+          "2"
+        ]
+      }
+    },
+    "tabs": {
+      "name": "Tabs",
+      "key": "dbd33845613381780e5364600815d9bc983d5230",
+      "nodeId": "14747:14818",
+      "importMethod": "set",
+      "description": "Use to switch between related views within the same context without navigating to a new page. Ideal for organizing content at the same level.",
+      "lastSynced": "2026-05-09T15:47:11.422Z",
+      "page": "✅ Tab",
+      "properties": {
+        "Show Avatar#14797:0": {
+          "type": "BOOLEAN",
+          "default": true
+        }
+      },
+      "nestedComponents": [],
+      "guidelinesFile": null,
+      "variants": {
+        "Property 1": [
+          "Default"
+        ]
+      }
+    },
+    "stepper": {
+      "name": "Stepper",
+      "key": "9d73595077c798866bf42c87a53893bbdc8d4ce0",
+      "nodeId": "7676:4492",
+      "importMethod": "set",
+      "description": "Use to guide a user through a linear process with defined steps (e.g., Onboarding). Indicates current, completed, and upcoming steps.",
+      "lastSynced": "2026-05-09T15:47:11.422Z",
+      "page": "✅ Stepper",
+      "properties": {
+        "Show Body#14072:0": {
+          "type": "BOOLEAN",
+          "default": true
+        },
+        "Body#14072:5": {
+          "type": "TEXT",
+          "default": "Optional body"
+        }
+      },
+      "nestedComponents": [],
+      "guidelinesFile": null,
+      "variants": {
+        "State": [
+          "Complete",
+          "Active",
+          "Default",
+          "State5"
+        ]
+      }
+    },
+    "m-grid": {
+      "name": "M grid",
+      "key": "ed642e9bb87c7b5e1cdab020943ad2f999374a39",
+      "nodeId": "12054:30576",
+      "importMethod": "set",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:11.422Z",
+      "page": "✅ Breakpoint, grid & structure",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null,
+      "variants": {
+        "Property 1": [
+          "Default",
+          "Sid nav collapsed"
+        ]
+      }
+    },
+    "l-grid": {
+      "name": "L grid",
+      "key": "8601f7461f9b21847400f69ebb63d7f591119987",
+      "nodeId": "12054:30598",
+      "importMethod": "set",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:11.422Z",
+      "page": "✅ Breakpoint, grid & structure",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null,
+      "variants": {
+        "Property": [
+          "Default",
+          "Side nav collapsed",
+          "Side nav expanded"
+        ]
+      }
+    },
+    "tag-catalog": {
+      "name": "✍️ Tag, Catalog",
+      "key": "a28b5c2f8b2b9fe218a7fc6674e43c3baacb24c2",
+      "nodeId": "13812:22309",
+      "importMethod": "set",
+      "description": "Use for catalog types. Can be interactive (removable) or static metadata.",
+      "lastSynced": "2026-05-09T15:47:11.422Z",
+      "page": "✍️ Tag (Identification key)",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null,
+      "variants": {
+        "Type": [
+          "Default"
+        ]
+      }
+    },
+    "tag-status": {
+      "name": "✍️ Tag, Status",
+      "key": "1663e13e4fe1648aeef7bf6978f7faeea14a4c17",
+      "nodeId": "7257:3705",
+      "importMethod": "set",
+      "description": "Use for status. Can be interactive (removable) or static metadata.",
+      "lastSynced": "2026-05-09T15:47:11.422Z",
+      "page": "✍️ Tag (Identification key)",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null,
+      "variants": {
+        "Status": [
+          "Fail",
+          "Warning",
+          "Success",
+          "Loading",
+          "Maintenance",
+          "Scheduled",
+          "Queued",
+          "Stopped",
+          "Sleeping",
+          "Offline",
+          "Pending"
+        ]
+      }
+    },
+    "global-header": {
+      "name": "Global header",
+      "key": "e3e1e5d29f092fbd6ba5f0f40141ba55473548a8",
+      "nodeId": "7384:22554",
+      "importMethod": "set",
+      "description": "The persistent top-level container for branding, primary site-wide navigation, and user-specific actions (e.g., Profile, Logout).",
+      "lastSynced": "2026-05-09T15:47:11.422Z",
+      "page": "✅ Global header",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null,
+      "variants": {
+        "App type": [
+          "Explorer",
+          "Admin",
+          "Studio"
+        ],
+        "Breakpoints": [
+          "XL",
+          "L",
+          "M",
+          "S",
+          "XS"
+        ]
+      }
+    },
+    "perimeter-card": {
+      "name": "Perimeter card",
+      "key": "c1672b025b85c4ed0ddc645d89aa202803a95f07",
+      "nodeId": "14783:7565",
+      "importMethod": "set",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:11.422Z",
+      "page": "✅ Card",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null,
+      "variants": {
+        "Property 1": [
+          "Default"
+        ]
+      }
+    },
+    "drawer-side-panel": {
+      "name": "Drawer, side panel",
+      "key": "3fe66a28fd56e3dbfd87a6f6be08df327bda27bf",
+      "nodeId": "14294:5758",
+      "importMethod": "set",
+      "description": "A container that slides from right side of the screen. Use for secondary tasks that require high focus but need to maintain the context of the main page.",
+      "lastSynced": "2026-05-09T15:47:11.422Z",
+      "page": "✅ Drawer (Side panel)",
+      "properties": {
+        "Show Back#14294:18": {
+          "type": "BOOLEAN",
+          "default": true
+        }
+      },
+      "nestedComponents": [],
+      "guidelinesFile": null,
+      "variants": {
+        "App": [
+          "Studio",
+          "Explorer"
+        ]
+      }
+    },
+    "input-date": {
+      "name": "Input, date",
+      "key": "9eafdb6242837b591ba5f39959150b53e40ef02d",
+      "nodeId": "8194:7305",
+      "importMethod": "set",
+      "description": "Used for selecting a single date, a date range, or a specific point in time. Best for scheduling or historical data entry.",
+      "lastSynced": "2026-05-09T15:47:11.422Z",
+      "page": "✅ Calendar",
+      "properties": {
+        "Helper#458:9": {
+          "type": "BOOLEAN",
+          "default": true
+        },
+        "Label#458:13": {
+          "type": "BOOLEAN",
+          "default": true
+        },
+        "* (Asterisk)#7242:142": {
+          "type": "BOOLEAN",
+          "default": true
+        },
+        "Sub label#9716:0": {
+          "type": "BOOLEAN",
+          "default": true
+        }
+      },
+      "nestedComponents": [],
+      "guidelinesFile": null,
+      "variants": {
+        "Type": [
+          "Single date",
+          "Date range"
+        ],
+        "States": [
+          "Enabled",
+          "Hovered",
+          "Focused",
+          "Error",
+          "Disabled",
+          "Fille",
+          "Activ"
+        ]
+      }
+    },
+    "search": {
+      "name": "Search",
+      "key": "1b7cd9f309d84560098a2506089a77da8972d470",
+      "nodeId": "8589:11055",
+      "importMethod": "set",
+      "description": "A specialized text input designed to query a database or filter a page's content in real-time.",
+      "lastSynced": "2026-05-09T15:47:11.422Z",
+      "page": "✅ Search",
+      "properties": {
+        "AI icon#8589:0": {
+          "type": "BOOLEAN",
+          "default": true
+        }
+      },
+      "nestedComponents": [],
+      "guidelinesFile": null,
+      "variants": {
+        "Type": [
+          "Explorer home",
+          "Global header",
+          "Inline"
+        ],
+        "State": [
+          "Hovered",
+          "Focused",
+          "Filled",
+          "Active",
+          "Dsiabled",
+          "Default"
+        ]
+      }
+    },
+    "side-nav": {
+      "name": "✍️ Side nav",
+      "key": "3606cc19247f989332aac33953ffdf57c9d1bbdd",
+      "nodeId": "13599:20120",
+      "importMethod": "set",
+      "description": "Vertical navigation for primary application modules. Use when the app has many top-level sections or needs to show sub-navigation.",
+      "lastSynced": "2026-05-09T15:47:11.422Z",
+      "page": "✍️  Side nav",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null,
+      "variants": {
+        "App": [
+          "Admin",
+          "Studio"
+        ],
+        "View": [
+          "Collapsed",
+          "Expanded"
+        ]
+      }
+    },
+    "bar-graph": {
+      "name": "⛔️ Bar graph",
+      "key": "6ea07622a616f54b591da8eb26515332b9d02c31",
+      "nodeId": "15473:49489",
+      "importMethod": "set",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:11.422Z",
+      "page": "⛔️ Data viz: WIP all others",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null,
+      "variants": {
+        "Property 1": [
+          "Default"
+        ]
+      }
+    },
+    "loader-with-logo": {
+      "name": "Loader with logo",
+      "key": "688ff5c70f4d617faa022058078d47d6bafde817",
+      "nodeId": "14294:7650",
+      "importMethod": "set",
+      "description": "Indicates a background process is active. Use loader with logo in transition between apps or logging in or out to reduce perceived wait time",
+      "lastSynced": "2026-05-09T15:47:11.422Z",
+      "page": "✅ Loading (Loader, Spinner, Skeleton)",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null,
+      "variants": {
+        "App": [
+          "Actian Data Intelligence",
+          "Studio",
+          "Explorer",
+          "Admin"
+        ]
+      }
+    },
+    "calendar": {
+      "name": "Calendar",
+      "key": "6c61c1469d97020721267a3e1ad209f3cf4c12c3",
+      "nodeId": "8211:6664",
+      "importMethod": "set",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:11.422Z",
+      "page": "✅ Calendar",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null,
+      "variants": {
+        "Type": [
+          "Single date select",
+          "Date",
+          "Month",
+          "Single"
+        ],
+        "Selection": [
+          "Single",
+          "Range",
+          "Year"
+        ]
+      }
+    },
+    "dropdown-select-default": {
+      "name": "Dropdown, Select, default",
+      "key": "1140aec3d572e3fbda362723cd7137ac2f0ce9bd",
+      "nodeId": "13972:708",
+      "importMethod": "set",
+      "description": "Use when there are 5+ options or space is limited. Ideal for selecting one item from a pre-defined list (e.g., Country, State).",
+      "lastSynced": "2026-05-09T15:47:11.422Z",
+      "page": "✅ Dropdown / Select",
+      "properties": {
+        "Show description#13978:0": {
+          "type": "BOOLEAN",
+          "default": true
+        },
+        "Show asterisk #13978:8": {
+          "type": "BOOLEAN",
+          "default": true
+        },
+        "Show info icon#13978:16": {
+          "type": "BOOLEAN",
+          "default": true
+        },
+        "Show helper text#13978:24": {
+          "type": "BOOLEAN",
+          "default": true
+        },
+        "Show Label#14292:0": {
+          "type": "BOOLEAN",
+          "default": true
+        }
+      },
+      "nestedComponents": [],
+      "guidelinesFile": null,
+      "variants": {
+        "Type": [
+          "Default",
+          "Search/Multiple",
+          "With avatar",
+          "Compact/Custom"
+        ],
+        "State": [
+          "Default",
+          "Hovered",
+          "Focused",
+          "Active",
+          "Filled",
+          "Disabled"
+        ]
+      }
+    },
+    "search-dropdown-menu": {
+      "name": "Search dropdown menu",
+      "key": "9e267d055429c3f0e586f2fc787fd8b6fced1629",
+      "nodeId": "8756:9994",
+      "importMethod": "set",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:11.422Z",
+      "page": "✅ Search",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null,
+      "variants": {
+        "Type": [
+          "No result",
+          "Before typed",
+          "After typed",
+          "Explorer home"
+        ]
+      }
+    },
+    "digram-topic": {
+      "name": "Digram, Topic",
+      "key": "c5cccb155896a560523120f96888c1d64374b562",
+      "nodeId": "14128:3800",
+      "importMethod": "set",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:11.422Z",
+      "page": "✅ Digram",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null,
+      "variants": {
+        "Type": [
+          "Light purple",
+          "Dark purple",
+          "Light blue",
+          "Dark blue",
+          "Light green",
+          "Dark green",
+          "Yellow",
+          "Orange",
+          "Red",
+          "Dark orange"
+        ]
+      }
+    },
+    "tag-stage": {
+      "name": "✍️ Tag, Stage",
+      "key": "2f4ae1cc7f2d610179a68b2c1b6e25d4900bd8bc",
+      "nodeId": "8655:10279",
+      "importMethod": "set",
+      "description": "Use for data lifecycle stages. Can be interactive (removable) or static metadata.",
+      "lastSynced": "2026-05-09T15:47:11.422Z",
+      "page": "✍️ Tag (Identification key)",
+      "properties": {
+        "Trailing icon#13844:0": {
+          "type": "BOOLEAN",
+          "default": false
+        },
+        "Leading icon#13844:7": {
+          "type": "BOOLEAN",
+          "default": true
+        }
+      },
+      "nestedComponents": [],
+      "guidelinesFile": null,
+      "variants": {
+        "Color": [
+          "Gray",
+          "Orange",
+          "Indigo",
+          "Purple",
+          "Lime",
+          "Teal",
+          "Yellow",
+          "Pink"
+        ]
+      }
+    },
+    "tag-updated": {
+      "name": "✍️ Tag, Updated",
+      "key": "7a867b11eaec8c2cffd3a7cd21da62f66516e771",
+      "nodeId": "13812:22307",
+      "importMethod": "set",
+      "description": "Use for indicating something is recently updated. Can be interactive (removable) or static metadata.",
+      "lastSynced": "2026-05-09T15:47:11.422Z",
+      "page": "✍️ Tag (Identification key)",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null,
+      "variants": {
+        "Type": [
+          "Default"
+        ]
+      }
+    },
+    "maintenance-state": {
+      "name": "Maintenance state",
+      "key": "4c187d32a069682c44d5ccd8744b9fe0709c894a",
+      "nodeId": "13871:32311",
+      "importMethod": "set",
+      "description": "A placeholder shown when maintenance. Must include an illustration, a clear title, and a \"Call to Action\" button to help the user get started.",
+      "lastSynced": "2026-05-09T15:47:11.422Z",
+      "page": "✅ Empty state",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null,
+      "variants": {
+        "Size": [
+          "Large"
+        ]
+      }
+    },
+    "loader": {
+      "name": "Loader",
+      "key": "0cf73cc20fd0120418e60d904cff641ff38f4840",
+      "nodeId": "7372:2195",
+      "importMethod": "set",
+      "description": "Indicates a background process is active. Use loader for large components or large section within a page",
+      "lastSynced": "2026-05-09T15:47:11.422Z",
+      "page": "✅ Loading (Loader, Spinner, Skeleton)",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null,
+      "variants": {
+        "Percent": [
+          "99%",
+          "10%",
+          "Percent3"
+        ]
+      }
+    },
+    "link": {
+      "name": "Link",
+      "key": "433bc17e08514c14ee821f2b03421bad865e0a0e",
+      "nodeId": "8346:6897",
+      "importMethod": "set",
+      "description": "A Link visually represents clickable text or elements that navigate users to other pages, sections, or resources. It appears colored to indicate interactivity and follows accessibility and design stan",
+      "lastSynced": "2026-05-09T15:47:11.422Z",
+      "page": "✅ Link",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null,
+      "variants": {
+        "State": [
+          "Disabled",
+          "Enabled",
+          "Focused",
+          "Hovered",
+          "Once clicked",
+          "Pressed"
+        ]
+      }
+    },
+    "actian-data-observability": {
+      "name": "Actian Data Observability",
+      "key": "5f5d2ac2d74db9854ad09510d7b237090afd8a76",
+      "nodeId": "7764:7671",
+      "importMethod": "set",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:11.422Z",
+      "page": "Product logos",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null,
+      "variants": {
+        "Color": [
+          "Full colo",
+          "White"
+        ],
+        "Layout": [
+          "Vertical",
+          "Horizontal"
+        ]
+      }
+    },
+    "actian-pyramid": {
+      "name": "Actian pyramid",
+      "key": "84e6abe2e5b7dbe96a859397f557249922560413",
+      "nodeId": "7764:7688",
+      "importMethod": "set",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:11.422Z",
+      "page": "Product logos",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null,
+      "variants": {
+        "Color": [
+          "Full color",
+          "White"
+        ]
+      }
+    },
+    "spinner": {
+      "name": "Spinner",
+      "key": "c4958a4a5d7aaac4fd262e3609204e7c110e3129",
+      "nodeId": "7372:2170",
+      "importMethod": "set",
+      "description": "Indicates a background process is active. Use Spinner for small, localized actions like button clicks.",
+      "lastSynced": "2026-05-09T15:47:11.422Z",
+      "page": "✅ Loading (Loader, Spinner, Skeleton)",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null,
+      "variants": {
+        "Complete": [
+          "50%",
+          "75%",
+          "100%",
+          "25%"
+        ]
+      }
+    },
+    "badge": {
+      "name": "✍️ Badge",
+      "key": "e8d93a3432951bd42d9b0bb20287eb61262ae10e",
+      "nodeId": "12159:16447",
+      "importMethod": "set",
+      "description": "Small status or numerical indicator (e.g., \"Active\", \"New\", \"+5\"). Use for counts or short, non-interactive status labels.",
+      "lastSynced": "2026-05-09T15:47:11.422Z",
+      "page": "✍️ Badge",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null,
+      "variants": {
+        "Type": [
+          "Number",
+          "Dot"
+        ]
+      }
+    },
+    "modal": {
+      "name": "Modal",
+      "key": "2a2b287c2eb1c1c5e071d190e49f19891c937993",
+      "nodeId": "14175:14426",
+      "importMethod": "set",
+      "description": "A centered dialog that blocks the main content. Use for critical \"Stop and Think\" actions, confirmations, or complex data entry that must be completed or cancelled before moving on.",
+      "lastSynced": "2026-05-09T15:47:11.422Z",
+      "page": "✅ Modal",
+      "properties": {
+        "Body#16715:0": {
+          "type": "SLOT",
+          "default": {
+            "guid": {
+              "sessionID": -1,
+              "localID": -1
+            }
+          }
+        }
+      },
+      "nestedComponents": [],
+      "guidelinesFile": null,
+      "variants": {
+        "Size & Type": [
+          "700px setting",
+          "1200px",
+          "900px create",
+          "900px edit",
+          "700px create",
+          "450px warning",
+          "450px confirm"
+        ],
+        "Dev status": [
+          "🟢 Ready"
+        ]
+      }
+    },
+    "lineage-connecting-line": {
+      "name": "Lineage connecting line",
+      "key": "553bdc1ba26f3b30988997771dcf74f275eb12d3",
+      "nodeId": "14747:20085",
+      "importMethod": "set",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:11.422Z",
+      "page": "✅ Data viz: lineage",
+      "properties": {
+        "Show icon#14697:0": {
+          "type": "BOOLEAN",
+          "default": true
+        }
+      },
+      "nestedComponents": [],
+      "guidelinesFile": null,
+      "variants": {
+        "Direction": [
+          "Down",
+          "Straight",
+          "up",
+          "Up"
+        ],
+        "State": [
+          "Default",
+          "Selected",
+          "Disabled"
+        ]
+      }
+    },
+    "notification": {
+      "name": "Notification",
+      "key": "590d2373b688235e8da72732919d2f874eee6cda",
+      "nodeId": "13868:11595",
+      "importMethod": "set",
+      "description": "Small, temporary overlay that appears at the edge of the screen. Use for non-critical confirmations (e.g., \"Item saved\"). Automatically dismisses after 3–5 seconds.",
+      "lastSynced": "2026-05-09T15:47:11.422Z",
+      "page": "✅ Notification (Toast)",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null,
+      "variants": {
+        "Type": [
+          "Default",
+          "Critical"
+        ]
+      }
+    },
+    "table": {
+      "name": "✍️ Table",
+      "key": "62d235b35d44ddafd58cb1a060107b4f69ab234e",
+      "nodeId": "15295:14902",
+      "importMethod": "set",
+      "description": "Use for large datasets requiring comparison, sorting, and filtering. Supports complex rows with multi-type data (text, badges, actions).\n\n\"If data is null, display the 'Empty State' illustration varia",
+      "lastSynced": "2026-05-09T15:47:11.422Z",
+      "page": "✍️ Table",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null,
+      "variants": {
+        "Built type": [
+          "By columns",
+          "By rows"
+        ]
+      }
+    },
+    "search-filters": {
+      "name": "Search filters",
+      "key": "919ddc42563055f1d9f34b662fb806eb66763980",
+      "nodeId": "9660:49637",
+      "importMethod": "set",
+      "description": "A collection of inputs used to narrow down a dataset or search results. Should be placed above or to the left of the content it controls.",
+      "lastSynced": "2026-05-09T15:47:11.422Z",
+      "page": "✅ Filters",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null,
+      "variants": {
+        "Type": [
+          "Explorer",
+          "Studio"
+        ]
+      }
+    },
+    "input": {
+      "name": "Input",
+      "key": "9245f434d92d2a5d54962c51d7e374c87251fc4b",
+      "nodeId": "7238:2487",
+      "importMethod": "set",
+      "description": "Used for single-line alphanumeric data entry (e.g., Name, Email, Phone). Specify the \"type\" attribute if applicable.",
+      "lastSynced": "2026-05-09T15:47:11.422Z",
+      "page": "✅ Text input",
+      "properties": {
+        "Helper#458:9": {
+          "type": "BOOLEAN",
+          "default": true
+        },
+        "Trailing icon#458:10": {
+          "type": "BOOLEAN",
+          "default": true
+        },
+        "Label#458:13": {
+          "type": "BOOLEAN",
+          "default": true
+        },
+        "Info icon#7242:0": {
+          "type": "BOOLEAN",
+          "default": true
+        },
+        "* (Asterisk)#7242:142": {
+          "type": "BOOLEAN",
+          "default": true
+        },
+        "Description#7242:164": {
+          "type": "BOOLEAN",
+          "default": true
+        },
+        "Delete icon#9482:0": {
+          "type": "BOOLEAN",
+          "default": false
+        },
+        "Label text#9633:0": {
+          "type": "TEXT",
+          "default": "Label"
+        },
+        "Description text#9633:17": {
+          "type": "TEXT",
+          "default": "A description helps users to define and understand the purpose of the input."
+        },
+        "Placeholder text#9633:34": {
+          "type": "TEXT",
+          "default": "Placeholder text"
+        },
+        "Helper text#9633:51": {
+          "type": "TEXT",
+          "default": "Helper text goes here"
+        },
+        "Input text#9633:68": {
+          "type": "TEXT",
+          "default": "Typed"
+        },
+        "Show .Textfield buttons#14241:0": {
+          "type": "BOOLEAN",
+          "default": true
+        }
+      },
+      "nestedComponents": [],
+      "guidelinesFile": null,
+      "variants": {
+        "States": [
+          "Default",
+          "Hovered",
+          "Focused",
+          "Active",
+          "Filled",
+          "Error",
+          "Disabled",
+          "Read-only"
+        ]
+      }
+    },
+    "toolbar": {
+      "name": "Toolbar",
+      "key": "96683d78ad981aacc04a5b6c7c2b0f0f1d631516",
+      "nodeId": "14335:16907",
+      "importMethod": "set",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:11.422Z",
+      "page": "✅ Data viz: toolbar",
+      "properties": {
+        "Show View scale#14335:0": {
+          "type": "BOOLEAN",
+          "default": true
+        }
+      },
+      "nestedComponents": [],
+      "guidelinesFile": null,
+      "variants": {
+        "Type": [
+          "Single",
+          "Combined",
+          "Group"
+        ],
+        "Orientation": [
+          "Horizontal",
+          "Vertical"
+        ]
+      }
+    },
+    "alert-banner": {
+      "name": "✍️ Alert-banner",
+      "key": "9717f500f425975f63c0eb2f9c1e434ff010f24b",
+      "nodeId": "13732:3056",
+      "importMethod": "set",
+      "description": "Static, high-visibility message placed at the top of a page or section. Use for persistent system-level information (Success, Info, Warning, Error) that doesn't disappear automatically.",
+      "lastSynced": "2026-05-09T15:47:11.422Z",
+      "page": "✍️ Alert (banner)",
+      "properties": {
+        "Show Icon#14881:0": {
+          "type": "BOOLEAN",
+          "default": true
+        },
+        "Show close button#14881:5": {
+          "type": "BOOLEAN",
+          "default": true
+        },
+        "Show action#14907:5": {
+          "type": "BOOLEAN",
+          "default": true
+        }
+      },
+      "nestedComponents": [],
+      "guidelinesFile": null,
+      "variants": {
+        "Type": [
+          "Primary",
+          "Success",
+          "Warning",
+          "Danger"
+        ],
+        "Orientation'": [
+          "Horizontal",
+          "Vertical"
+        ]
+      }
+    },
+    "error-state": {
+      "name": "Error state",
+      "key": "a219aa99ab9712f911f391af8dd623c18b281ccb",
+      "nodeId": "13087:34544",
+      "importMethod": "set",
+      "description": "A placeholder shown when a container has an error. Must include an illustration, a clear title, and a \"Call to Action\" button to help the user get started.",
+      "lastSynced": "2026-05-09T15:47:11.422Z",
+      "page": "✅ Empty state",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null,
+      "variants": {
+        "Size": [
+          "Large",
+          "Medium"
+        ]
+      }
+    },
+    "sticky-footer": {
+      "name": "Sticky footer",
+      "key": "de36372be7d1532ee37fbfc43238aed444f6e7c9",
+      "nodeId": "14747:9839",
+      "importMethod": "set",
+      "description": "A persistent container at the bottom of the viewport used for high-priority global actions (e.g., Save, Cancel, Next) that must remain visible while scrolling.",
+      "lastSynced": "2026-05-09T15:47:11.422Z",
+      "page": "✅ Sticky footer",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null,
+      "variants": {
+        "Property 1": [
+          "Default"
+        ]
+      }
+    },
+    "line-graph": {
+      "name": "⛔️ Line graph",
+      "key": "e365ff8c88faf24f3cadf6166127e97dbc8771fb",
+      "nodeId": "15473:49490",
+      "importMethod": "set",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:11.422Z",
+      "page": "⛔️ Data viz: WIP all others",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null,
+      "variants": {
+        "Property 1": [
+          "Default"
+        ]
+      }
+    },
+    "page-header": {
+      "name": "Page header",
+      "key": "ec2418807ba81bd52ab103d34c1bffd82fc0b92c",
+      "nodeId": "12923:2794",
+      "importMethod": "set",
+      "description": "The title area of a specific page. Should include the Page Title, optional Breadcrumbs, and page-specific primary actions.",
+      "lastSynced": "2026-05-09T15:47:11.422Z",
+      "page": "✅ Page header",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null,
+      "variants": {
+        "Type": [
+          "Default",
+          "Details page",
+          "Explorer home",
+          "Explorer detail"
+        ]
+      }
+    },
+    "lineage-grouped-node": {
+      "name": "Lineage grouped node",
+      "key": "f1cafad1f47132058587042da7ec1e46e4eeffdd",
+      "nodeId": "15634:17895",
+      "importMethod": "set",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:11.422Z",
+      "page": "✅ Data viz: lineage",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null,
+      "variants": {
+        "State": [
+          "Default",
+          "Expanded"
+        ],
+        "Type": [
+          "Main item",
+          "Sub item"
+        ]
+      }
+    },
+    "empty-state": {
+      "name": "Empty state",
+      "key": "0adc6b54a212315ebb16db7f5eea388276a1587b",
+      "nodeId": "9230:22073",
+      "importMethod": "set",
+      "description": "A placeholder shown when a container has no content (e.g., empty search, no messages). Must include an illustration, a clear title, and a \"Call to Action\" button to help the user get started.",
+      "lastSynced": "2026-05-09T15:47:11.422Z",
+      "page": "✅ Empty state",
+      "properties": {
+        "Medium illustration#9230:4": {
+          "type": "INSTANCE_SWAP",
+          "default": "8991:11401"
+        },
+        "Tertiary button#10964:0": {
+          "type": "BOOLEAN",
+          "default": true
+        },
+        "Primary button#10964:4": {
+          "type": "BOOLEAN",
+          "default": true
+        },
+        "Title#10964:8": {
+          "type": "BOOLEAN",
+          "default": true
+        },
+        "Body#10964:12": {
+          "type": "BOOLEAN",
+          "default": true
+        },
+        "Large illustration#10964:20": {
+          "type": "INSTANCE_SWAP",
+          "default": "8837:9944"
+        },
+        "Title content#10964:24": {
+          "type": "TEXT",
+          "default": "No policies available"
+        },
+        "Body content#10964:28": {
+          "type": "TEXT",
+          "default": "Create policies to define how your platform operates."
+        },
+        "Small Illustration#10966:0": {
+          "type": "INSTANCE_SWAP",
+          "default": "10966:18012"
+        }
+      },
+      "nestedComponents": [],
+      "guidelinesFile": null,
+      "variants": {
+        "Size": [
+          "Large",
+          "Medium",
+          "Small"
+        ]
+      }
+    },
+    "button": {
+      "name": "Button",
+      "key": "5a6d10d26bef3cc83955bf32a318c6b4682f25d3",
+      "nodeId": "7206:2643",
+      "importMethod": "set",
+      "description": "Primary trigger for a specific action or form submission. Use \"Primary\" for the main task, \"Secondary\" for alternative actions, and \"Ghost/Tertiary\" for low-priority tasks.\n\nPrimary: \"Use as the singl",
+      "lastSynced": "2026-05-09T15:47:11.422Z",
+      "page": "✍️ Button",
+      "properties": {
+        "Leading icon#724:0": {
+          "type": "INSTANCE_SWAP",
+          "default": "17171:66073"
+        },
+        "Label#724:10": {
+          "type": "TEXT",
+          "default": "Button"
+        },
+        "Show leading icon#809:73": {
+          "type": "BOOLEAN",
+          "default": true
+        },
+        "Trailing icon#13805:43": {
+          "type": "INSTANCE_SWAP",
+          "default": "17172:66154"
+        },
+        "Show trailing icon#13807:82": {
+          "type": "BOOLEAN",
+          "default": true
+        },
+        "Show label#15988:3": {
+          "type": "BOOLEAN",
+          "default": true
+        }
+      },
+      "nestedComponents": [],
+      "guidelinesFile": null,
+      "variants": {
+        "Type": [
+          "Primary",
+          "Secondary",
+          "Tertiary",
+          "Icon",
+          "Critical primary",
+          "Critical secondary"
+        ],
+        "Size": [
+          "Default",
+          "Small"
+        ],
+        "State": [
+          "Default",
+          "Hovered",
+          "Focused",
+          "Pressed",
+          "Selected",
+          "Disabled"
+        ]
+      }
+    },
+    "collapse-accordion": {
+      "name": "✍️ Collapse-accordion",
+      "key": "8253d19d70a3b835653049d90b4fdf97b26a31c8",
+      "nodeId": "8292:80",
+      "importMethod": "set",
+      "description": "Use to hide/show secondary information to reduce vertical clutter. Best for FAQs or detailed settings sections.",
+      "lastSynced": "2026-05-09T15:47:11.422Z",
+      "page": "✍️ Collapse (Accordion)",
+      "properties": {
+        "Slot#15956:0": {
+          "type": "SLOT",
+          "default": {
+            "guid": {
+              "sessionID": -1,
+              "localID": -1
+            }
+          }
+        }
+      },
+      "nestedComponents": [],
+      "guidelinesFile": null,
+      "variants": {
+        "State": [
+          "Collapsed",
+          "Expanede"
+        ]
+      }
+    },
+    "tile-item": {
+      "name": "Tile, Item",
+      "key": "95764c702b7dcb1dc2e2aef2cd5ee46b27a5cf30",
+      "nodeId": "7613:7853",
+      "importMethod": "set",
+      "description": "A flexible container for grouping related information. Use for dashboard summaries or items in a grid that require an overview.",
+      "lastSynced": "2026-05-09T15:47:11.422Z",
+      "page": "✅ Card",
+      "properties": {
+        "Show AI ready#14853:0": {
+          "type": "BOOLEAN",
+          "default": true
+        }
+      },
+      "nestedComponents": [],
+      "guidelinesFile": null,
+      "variants": {
+        "Type": [
+          "Catalog",
+          "Item",
+          "item type",
+          "Glossary type",
+          "Topic"
+        ],
+        "State": [
+          "Default",
+          "Hover",
+          "Focus",
+          "Pressed",
+          "Selected"
+        ]
+      }
+    },
+    "matillion": {
+      "name": "matillion",
+      "key": "573cc53c470e350189a4d086626ac5793c6930cf",
+      "nodeId": "8400:25103",
+      "importMethod": "single",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:11.422Z",
+      "page": "✅ Icons",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null
+    },
+    "kafka": {
+      "name": "kafka",
+      "key": "7a1a2ec3308c062ff10e03a345a30006eca88716",
+      "nodeId": "8400:25091",
+      "importMethod": "single",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:11.422Z",
+      "page": "✅ Icons",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null
+    },
+    "dataiku": {
+      "name": "dataiku",
+      "key": "7cf3d9f654cc100cd73c2f57aa5aebfbf6787ded",
+      "nodeId": "8400:25051",
+      "importMethod": "single",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:11.422Z",
+      "page": "✅ Icons",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null
+    },
+    "mysql": {
+      "name": "mysql",
+      "key": "922921454de5a5943c3cebc212f93f6ec36ea114",
+      "nodeId": "8400:25109",
+      "importMethod": "single",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:11.422Z",
+      "page": "✅ Icons",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null
+    },
+    "thumbs-down": {
+      "name": "thumbs-down",
+      "key": "93686ddb00e20fd0a150c2a9f56986d47abf5db0",
+      "nodeId": "10089:786",
+      "importMethod": "single",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:11.422Z",
+      "page": "✅ Icons",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null
+    },
+    "use-with-care": {
+      "name": "use-with-care",
+      "key": "946ad814c46b04b4a689b3d09f82bb572af76f36",
+      "nodeId": "14703:19805",
+      "importMethod": "single",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:11.422Z",
+      "page": "✅ Icons",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null
+    },
+    "safyr-sap-bw": {
+      "name": "safyr-sap-bw",
+      "key": "bfb97def8d0dc7548016b3fe326c75ecdd60c09f",
+      "nodeId": "8504:23906",
+      "importMethod": "single",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:11.422Z",
+      "page": "✅ Icons",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null
+    },
+    "zoom-to-fit": {
+      "name": "zoom-to-fit",
+      "key": "daac1ce452877e634fcd4d81a9880be63946816a",
+      "nodeId": "7378:5032",
+      "importMethod": "single",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:11.422Z",
+      "page": "✅ Icons",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null
+    },
+    "orc": {
+      "name": "orc",
+      "key": "c7cfce05b00f904438450b13149512599d244ba8",
+      "nodeId": "8400:25132",
+      "importMethod": "single",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:11.422Z",
+      "page": "✅ Icons",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null
+    },
+    "postgresql": {
+      "name": "PostgreSQL",
+      "key": "cbc2bc0a266fabdfb26be4bc406413846501248d",
+      "nodeId": "7173:1882",
+      "importMethod": "single",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:11.422Z",
+      "page": "✅ Icons",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null
+    },
+    "splunk": {
+      "name": "splunk",
+      "key": "cf043dbcd552d71a4a6a3f0aa7a247038c53926a",
+      "nodeId": "8400:25172",
+      "importMethod": "single",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:11.422Z",
+      "page": "✅ Icons",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null
+    },
+    "azure-purview": {
+      "name": "azure-purview",
+      "key": "cfa72ef29d4b52b47af23c07b24301003e1a97b9",
+      "nodeId": "8400:25214",
+      "importMethod": "single",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:11.422Z",
+      "page": "✅ Icons",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null
+    },
+    "adobe-analytics": {
+      "name": "adobe-analytics",
+      "key": "dbbd381b0a1be15cf5f3c68aa1348c5fda1fbb1c",
+      "nodeId": "8400:25195",
+      "importMethod": "single",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:11.422Z",
+      "page": "✅ Icons",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null
+    },
+    "process": {
+      "name": "process",
+      "key": "dc941ab8d4a5da501b15ec3ebba7f97cce7c4cc4",
+      "nodeId": "7378:5603",
+      "importMethod": "single",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:11.422Z",
+      "page": "✅ Icons",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null
+    },
+    "cognos-bi": {
+      "name": "cognos-bi",
+      "key": "ee8c45ab057d92ce74a177352d4a9efbd18c6aec",
+      "nodeId": "8400:25224",
+      "importMethod": "single",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:11.422Z",
+      "page": "✅ Icons",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null
+    },
+    "bigquery": {
+      "name": "bigquery",
+      "key": "f2105b90a8f205ee78b02428b71cc2720fc451f6",
+      "nodeId": "8400:25218",
+      "importMethod": "single",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:11.422Z",
+      "page": "✅ Icons",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null
+    },
+    "elasticsearch": {
+      "name": "elasticsearch",
+      "key": "f891e01a197b6befba71d802e4461f512211dbe1",
+      "nodeId": "8400:25063",
+      "importMethod": "single",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:11.422Z",
+      "page": "✅ Icons",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null
+    },
+    "hbase": {
+      "name": "hbase",
+      "key": "f8fc1e18fe0008cc9ab4c1d4522d349a8c8a4470",
+      "nodeId": "8400:25075",
+      "importMethod": "single",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:11.422Z",
+      "page": "✅ Icons",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null
+    },
+    "zoom-out": {
+      "name": "zoom-out",
+      "key": "fe8ce8b1dc8f249bb19bbfb2304e20431984452f",
+      "nodeId": "7378:5026",
+      "importMethod": "single",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:11.422Z",
+      "page": "✅ Icons",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null
+    },
+    "zoom-in": {
+      "name": "zoom-in",
+      "key": "8743ba1b2c9fa86034a0e389b283e9da6e56d6fd",
+      "nodeId": "7378:5055",
+      "importMethod": "single",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:11.422Z",
+      "page": "✅ Icons",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null
+    },
+    "csv-custom-item": {
+      "name": "csv-custom-item",
+      "key": "b586b682af40afee24332f84fcdf266054c40e9d",
+      "nodeId": "8400:25232",
+      "importMethod": "single",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:11.422Z",
+      "page": "✅ Icons",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null
+    },
+    "more": {
+      "name": "more",
+      "key": "bfa5a189503a3916f7196a5acc18ebef6466a009",
+      "nodeId": "14335:17217",
+      "importMethod": "single",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:11.422Z",
+      "page": "✅ Icons",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null
+    },
+    "db2": {
+      "name": "db2",
+      "key": "0b899d3557aad4e25d5153edc1bd7476eddb89ee",
+      "nodeId": "8400:25055",
+      "importMethod": "single",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:11.422Z",
+      "page": "✅ Icons",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null
+    },
+    "aws-glue-etl": {
+      "name": "Aws-glue-etl",
+      "key": "24387b65e7be808a58716cf4ba7d0efcde7835b9",
+      "nodeId": "7173:1782",
+      "importMethod": "single",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:11.422Z",
+      "page": "✅ Icons",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null
+    },
+    "help-circle": {
+      "name": "help-circle",
+      "key": "2e8edce02b9198b99fe770fab00b636fb20d2f48",
+      "nodeId": "8504:23049",
+      "importMethod": "single",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:11.422Z",
+      "page": "✅ Icons",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null
+    },
+    "jdbc": {
+      "name": "jdbc",
+      "key": "2eab8c23231f3114d9e6f807aa2c7af59096760b",
+      "nodeId": "8400:25087",
+      "importMethod": "single",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:11.422Z",
+      "page": "✅ Icons",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null
+    },
+    "export": {
+      "name": "export",
+      "key": "30f1a5a8b08475a4f5a39757da5417cae238f3c1",
+      "nodeId": "7378:5538",
+      "importMethod": "single",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:11.422Z",
+      "page": "✅ Icons",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null
+    },
+    "atlas": {
+      "name": "atlas",
+      "key": "34094ec015b8f74b80ea36bdeb8a42621b1ba85f",
+      "nodeId": "8400:25203",
+      "importMethod": "single",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:11.422Z",
+      "page": "✅ Icons",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null
+    },
+    "data-model": {
+      "name": "data-model",
+      "key": "0fcfb9923b572949f296c019646f8ec17d6297b9",
+      "nodeId": "7294:705",
+      "importMethod": "single",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:11.422Z",
+      "page": "✅ Icons",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null
+    },
+    "avro": {
+      "name": "avro",
+      "key": "0befe2863bac449e778bf81429105d046babd9b8",
+      "nodeId": "8400:25205",
+      "importMethod": "single",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:11.422Z",
+      "page": "✅ Icons",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null
+    },
+    "process-csv": {
+      "name": "process csv",
+      "key": "115c254d8901c11f5dfc8c8575e0a483cb798d51",
+      "nodeId": "8400:25144",
+      "importMethod": "single",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:11.422Z",
+      "page": "✅ Icons",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null
+    },
+    "snowflake": {
+      "name": "Snowflake",
+      "key": "14abdd5e317e35b558549d54270c9f7024dc64ed",
+      "nodeId": "8504:23447",
+      "importMethod": "single",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:11.422Z",
+      "page": "✅ Icons",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null
+    },
+    "powerbi": {
+      "name": "Powerbi",
+      "key": "0303355bb9f628d8908b8a6b5ea5ccdae0826310",
+      "nodeId": "7168:767",
+      "importMethod": "single",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:11.422Z",
+      "page": "✅ Icons",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null
+    },
+    "cognos": {
+      "name": "cognos",
+      "key": "0b730d656419391189e409335af5a9c6a8019eb3",
+      "nodeId": "8400:25226",
+      "importMethod": "single",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:11.422Z",
+      "page": "✅ Icons",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null
+    },
+    "palantir": {
+      "name": "palantir",
+      "key": "1eed846e38780486f829603992558032bb091d72",
+      "nodeId": "8400:25134",
+      "importMethod": "single",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:11.422Z",
+      "page": "✅ Icons",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null
+    },
+    "opendatagouv": {
+      "name": "opendatagouv",
+      "key": "1f9939148afb1d1de4a5b30424c5c3cb65fc43a3",
+      "nodeId": "8400:25128",
+      "importMethod": "single",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:11.422Z",
+      "page": "✅ Icons",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null
+    },
+    "sqlserver": {
+      "name": "sqlserver",
+      "key": "3fb27f1d5613379dcf8ed3d8d28e233cf83b4ed0",
+      "nodeId": "8400:25174",
+      "importMethod": "single",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:11.422Z",
+      "page": "✅ Icons",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null
+    },
+    "mapr": {
+      "name": "mapr",
+      "key": "441ba64eaf7ec1455c161e9a521f4bbbc58883c7",
+      "nodeId": "8400:25099",
+      "importMethod": "single",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:11.422Z",
+      "page": "✅ Icons",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null
+    },
+    "spline": {
+      "name": "spline",
+      "key": "3dbdcd386e7f39274d56e389f76170660477ac42",
+      "nodeId": "8400:25170",
+      "importMethod": "single",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:11.422Z",
+      "page": "✅ Icons",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null
+    },
+    "microstrategy": {
+      "name": "microstrategy",
+      "key": "5c6ddb092e57ebb317f35d12911c102a02e1e6d8",
+      "nodeId": "8400:25105",
+      "importMethod": "single",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:11.422Z",
+      "page": "✅ Icons",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null
+    },
+    "openapi": {
+      "name": "openapi",
+      "key": "5ea85665e7f62e75c15adad3e5d664d1cf8cc059",
+      "nodeId": "8400:25126",
+      "importMethod": "single",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:11.422Z",
+      "page": "✅ Icons",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null
+    },
+    "safyr-ebs": {
+      "name": "safyr-ebs",
+      "key": "4f5e070ee223b4d48d5258f4464312cbf5770530",
+      "nodeId": "8400:25152",
+      "importMethod": "single",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:11.422Z",
+      "page": "✅ Icons",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null
+    },
+    "powerbireportserver": {
+      "name": "powerbireportserver",
+      "key": "4f905bd3d9625c8ef3c115a421ec22035a700283",
+      "nodeId": "8400:25142",
+      "importMethod": "single",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:11.422Z",
+      "page": "✅ Icons",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null
+    },
+    "impala": {
+      "name": "impala",
+      "key": "509d80540cc3f4f98eaadecd7d3fce23156c0a3b",
+      "nodeId": "8400:25081",
+      "importMethod": "single",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:11.422Z",
+      "page": "✅ Icons",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null
+    },
+    "mariadb": {
+      "name": "mariadb",
+      "key": "540d66058ac4d43e6ef391db84fd60e1024a7114",
+      "nodeId": "8400:25101",
+      "importMethod": "single",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:11.422Z",
+      "page": "✅ Icons",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null
+    },
+    "thumbs-up": {
+      "name": "thumbs-up",
+      "key": "5ab3cbd59dee68fabb404966d3be7aa87ed761a5",
+      "nodeId": "10089:787",
+      "importMethod": "single",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:11.422Z",
+      "page": "✅ Icons",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null
+    },
+    "adlsgen1": {
+      "name": "adlsgen1",
+      "key": "7a4697cd3f8b40eec2dd6122528b4b7d6ef0a57c",
+      "nodeId": "8400:25193",
+      "importMethod": "single",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:11.422Z",
+      "page": "✅ Icons",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null
+    },
+    "paragraph-justify": {
+      "name": "paragraph-justify",
+      "key": "7dbcda5b9d1a14cd7205b1a1a5faf3b34f9ab22f",
+      "nodeId": "7378:5049",
+      "importMethod": "single",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:11.422Z",
+      "page": "✅ Icons",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null
+    },
+    "awsredshift": {
+      "name": "awsredshift",
+      "key": "649bf64d3b0e9c773340edb70013935d1a8bd275",
+      "nodeId": "8400:25209",
+      "importMethod": "single",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:11.422Z",
+      "page": "✅ Icons",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null
+    },
+    "qlik-sense": {
+      "name": "qlik-sense",
+      "key": "651160c6a9ac69ff73c400920218e736e72661a4",
+      "nodeId": "8400:25146",
+      "importMethod": "single",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:11.422Z",
+      "page": "✅ Icons",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null
+    },
+    "mail": {
+      "name": "mail",
+      "key": "6db8438579e807864e92cd7f61d5dfe1db9dd841",
+      "nodeId": "8012:1308",
+      "importMethod": "single",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:11.422Z",
+      "page": "✅ Icons",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null
+    },
+    "user-single": {
+      "name": "user-single",
+      "key": "719b2cace9669955bbf05111ee8151ac6b50d3f5",
+      "nodeId": "7378:5029",
+      "importMethod": "single",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:11.422Z",
+      "page": "✅ Icons",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null
+    },
+    "talend": {
+      "name": "talend",
+      "key": "73fddb359e840a1309191c6fee240bf4749cba0c",
+      "nodeId": "8400:25180",
+      "importMethod": "single",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:11.422Z",
+      "page": "✅ Icons",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null
+    },
+    "azure-cosmosdb": {
+      "name": "azure-cosmosdb",
+      "key": "8fee2e9541d05300c5e325040c728e1cdb1553af",
+      "nodeId": "8400:25211",
+      "importMethod": "single",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:11.422Z",
+      "page": "✅ Icons",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null
+    },
+    "greenplum": {
+      "name": "greenplum",
+      "key": "7f6e32e201a4930cebf3e0daf022b615c8ff2a74",
+      "nodeId": "8400:25073",
+      "importMethod": "single",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:11.422Z",
+      "page": "✅ Icons",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null
+    },
+    "soda": {
+      "name": "soda",
+      "key": "8b70ba34455ff58757feaa057cb3285e95a2914f",
+      "nodeId": "8400:25188",
+      "importMethod": "single",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:11.422Z",
+      "page": "✅ Icons",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null
+    },
+    "safyr-peoplesoft": {
+      "name": "safyr-peoplesoft",
+      "key": "95920b8206501203714ab6df215cfe9ab33a7a96",
+      "nodeId": "8400:25156",
+      "importMethod": "single",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:11.422Z",
+      "page": "✅ Icons",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null
+    },
+    "simple-check": {
+      "name": "simple-check",
+      "key": "a660b57404739aba1621b29bbe22ba70f81f4346",
+      "nodeId": "7271:6256",
+      "importMethod": "single",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:11.422Z",
+      "page": "✅ Icons",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null
+    },
+    "xml": {
+      "name": "xml",
+      "key": "9c83547b7ddb33399a84faf6bea7da6fc8411f7a",
+      "nodeId": "8400:25191",
+      "importMethod": "single",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:11.422Z",
+      "page": "✅ Icons",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null
+    },
+    "safyr-salesforce": {
+      "name": "safyr-salesforce",
+      "key": "9d0eae6d7c1c69297306087bc20bea26ad048f66",
+      "nodeId": "8400:25158",
+      "importMethod": "single",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:11.422Z",
+      "page": "✅ Icons",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null
+    },
+    "looker": {
+      "name": "looker",
+      "key": "af489ca915a8382cd9f9681d53397544ba3e031a",
+      "nodeId": "8400:25097",
+      "importMethod": "single",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:11.422Z",
+      "page": "✅ Icons",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null
+    },
+    "mongodb": {
+      "name": "mongodb",
+      "key": "a7e4c3250458b92b70085dd66d67f00a3d469c6d",
+      "nodeId": "8400:25107",
+      "importMethod": "single",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:11.422Z",
+      "page": "✅ Icons",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null
+    },
+    "erwin-data-modeler": {
+      "name": "erwin-data-modeler",
+      "key": "aeb340980e131eb2396223b512cf707231dc4186",
+      "nodeId": "8400:25065",
+      "importMethod": "single",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:11.422Z",
+      "page": "✅ Icons",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null
+    },
+    "denodo": {
+      "name": "denodo",
+      "key": "b2c1c1149efbd4f9da9aa7f0598e494e2a5f94bf",
+      "nodeId": "8400:25059",
+      "importMethod": "single",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:11.422Z",
+      "page": "✅ Icons",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null
+    },
+    "safyr-dynamicsax": {
+      "name": "safyr-dynamicsax",
+      "key": "c0b105d3e987838f8ecc44b4b7ea7139a968bb79",
+      "nodeId": "8400:25150",
+      "importMethod": "single",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:11.422Z",
+      "page": "✅ Icons",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null
+    },
+    "azure-datafactory": {
+      "name": "azure-datafactory",
+      "key": "b93938019c6aa4c9e65b5baa21449fdab334b366",
+      "nodeId": "8400:25212",
+      "importMethod": "single",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:11.422Z",
+      "page": "✅ Icons",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null
+    },
+    "safyr-siebel": {
+      "name": "safyr-siebel",
+      "key": "c653020fdba9ed36178f4b8f95f7cc6f9eb79b4c",
+      "nodeId": "8400:25162",
+      "importMethod": "single",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:11.422Z",
+      "page": "✅ Icons",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null
+    },
+    "tibco-datavirtualization": {
+      "name": "tibco-datavirtualization",
+      "key": "c6b80e098e699b0ff94f5722b20ce61170ae7c75",
+      "nodeId": "8400:25186",
+      "importMethod": "single",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:11.422Z",
+      "page": "✅ Icons",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null
+    },
+    "oracle": {
+      "name": "oracle",
+      "key": "ff67de75ab0fb3d8f723920383ca5e1c0f814a68",
+      "nodeId": "8400:25130",
+      "importMethod": "single",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:11.422Z",
+      "page": "✅ Icons",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null
+    },
+    "data-structured": {
+      "name": "data--structured",
+      "key": "b5370a64062dc0d1ed1f42a936ef87023738f284",
+      "nodeId": "8504:23301",
+      "importMethod": "single",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:11.422Z",
+      "page": "✅ Icons",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null
+    },
+    "catalogs": {
+      "name": "catalogs",
+      "key": "bf59f59271f2a5fb0945e406629aefeb72775468",
+      "nodeId": "14115:8084",
+      "importMethod": "single",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:11.422Z",
+      "page": "✅ Icons",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null
+    },
+    "arrow-alt": {
+      "name": "arrow-alt",
+      "key": "3a4fe9f03c3754d97f2fc5e8a472052a9fd4c9d7",
+      "nodeId": "8504:23323",
+      "importMethod": "single",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:11.422Z",
+      "page": "✅ Icons",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null
+    },
+    "user-add": {
+      "name": "user-add",
+      "key": "48c0ce663827e3dddb050be67302b9af9ceb74c0",
+      "nodeId": "7378:5027",
+      "importMethod": "single",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:11.422Z",
+      "page": "✅ Icons",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null
+    },
+    "award-04": {
+      "name": "award-04",
+      "key": "9c4aea9aed18f57b7ed4bf55bc71d6910d2d0109",
+      "nodeId": "8655:10107",
+      "importMethod": "single",
+      "description": "award, medal, certification, certificate, badge",
+      "lastSynced": "2026-05-09T15:47:11.422Z",
+      "page": "✅ Icons",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null
+    },
+    "image": {
+      "name": "image",
+      "key": "b3f1a7f5ef3d50822c84ce0f6d745428607d9023",
+      "nodeId": "7908:5402",
+      "importMethod": "single",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:11.422Z",
+      "page": "✅ Icons",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null
+    },
+    "list-bullets": {
+      "name": "list-bullets",
+      "key": "69ddc5d1660da5b9f5ae1eac95b5dda1e1299b37",
+      "nodeId": "7622:5395",
+      "importMethod": "single",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:11.422Z",
+      "page": "✅ Icons",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null
+    },
+    "map": {
+      "name": "map",
+      "key": "c79f5921936c1c9b69477d09ce5c1d7ae7d24863",
+      "nodeId": "7378:5048",
+      "importMethod": "single",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:11.422Z",
+      "page": "✅ Icons",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null
+    },
+    "teradata": {
+      "name": "teradata",
+      "key": "5a448c2ada63a64ef111d4d2e6a833dc3e7940b8",
+      "nodeId": "8400:25182",
+      "importMethod": "single",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:11.422Z",
+      "page": "✅ Icons",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null
+    },
+    "safyr-jdedwards": {
+      "name": "safyr-jdedwards",
+      "key": "fb1a310b1c960225e7ff6e8a1681a580f4545bc2",
+      "nodeId": "8400:25154",
+      "importMethod": "single",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:11.422Z",
+      "page": "✅ Icons",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null
+    },
+    "content-checklist": {
+      "name": "Content Checklist",
+      "key": "0bb0c240447d3cdb04072e7f65b60fe0bb9b8e47",
+      "nodeId": "7651:6637",
+      "importMethod": "single",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:11.422Z",
+      "page": "✅ Content guidelines",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null
+    },
+    "account-dropdown": {
+      "name": "Account dropdown",
+      "key": "487b25247d05a6f9d36a4c7b9f5177ca2017348e",
+      "nodeId": "9118:17382",
+      "importMethod": "single",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:11.422Z",
+      "page": "✅ Global header",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null
+    },
+    "stepper-buttons": {
+      "name": "Stepper buttons",
+      "key": "8e1f6f072c44845ca6f1b562c3d6196f78312c36",
+      "nodeId": "15946:885",
+      "importMethod": "single",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:11.422Z",
+      "page": "✅ Stepper",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null
+    },
+    "couchbase": {
+      "name": "couchbase",
+      "key": "18d92d20e28ab07a7fabb9c77b7a051a5281c7f2",
+      "nodeId": "8400:25230",
+      "importMethod": "single",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:11.422Z",
+      "page": "✅ Icons",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null
+    },
+    "parquet": {
+      "name": "parquet",
+      "key": "4f9256edece6ebcead263d5c3c0e55354febaefb",
+      "nodeId": "8400:25136",
+      "importMethod": "single",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:11.422Z",
+      "page": "✅ Icons",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null
+    },
+    "azure": {
+      "name": "Azure",
+      "key": "6edb5b6d977105b79bc5582de729ba6c74bb64bf",
+      "nodeId": "7173:1783",
+      "importMethod": "single",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:11.422Z",
+      "page": "✅ Icons",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null
+    },
+    "ms-teams": {
+      "name": "ms-teams",
+      "key": "81a01c66cbe81c13afecfa19f590d503a1b1bbf6",
+      "nodeId": "8784:159680",
+      "importMethod": "single",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:11.422Z",
+      "page": "✅ Icons",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null
+    },
+    "hive": {
+      "name": "hive",
+      "key": "d7bd860c86c5152462817fa348a5a95b31349596",
+      "nodeId": "8400:25079",
+      "importMethod": "single",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:11.422Z",
+      "page": "✅ Icons",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null
+    },
+    "cosmosdb": {
+      "name": "cosmosdb",
+      "key": "0472d1847ae41798e082c2e92e67a89b9b7b3a70",
+      "nodeId": "8400:25228",
+      "importMethod": "single",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:11.422Z",
+      "page": "✅ Icons",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null
+    },
+    "dbt": {
+      "name": "dbt",
+      "key": "120f28794fbc5ce6b7a8f0e405a3c8d58ab3cdaf",
+      "nodeId": "8400:25057",
+      "importMethod": "single",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:11.422Z",
+      "page": "✅ Icons",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null
+    },
+    "amazons3": {
+      "name": "amazons3",
+      "key": "1e44db8dac0e0e37e46dea409150cc762967166f",
+      "nodeId": "8400:25199",
+      "importMethod": "single",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:11.422Z",
+      "page": "✅ Icons",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null
+    },
+    "dictionnary": {
+      "name": "dictionnary",
+      "key": "391bd61cec5cb74f9db7c92fab0afc483c75db5b",
+      "nodeId": "8400:25061",
+      "importMethod": "single",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:11.422Z",
+      "page": "✅ Icons",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null
+    },
+    "db2-database-1": {
+      "name": "db2--database 1",
+      "key": "54d6a72ebdceefca172f85fa0b25279e58c99636",
+      "nodeId": "9907:9511",
+      "importMethod": "single",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:11.422Z",
+      "page": "✅ Icons",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null
+    },
+    "netezza": {
+      "name": "netezza",
+      "key": "5a04491296f24a38a3364f6650782d09e2658fca",
+      "nodeId": "8400:25111",
+      "importMethod": "single",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:11.422Z",
+      "page": "✅ Icons",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null
+    },
+    "json": {
+      "name": "json",
+      "key": "5eb160e5222aef02c4a1b58cded4b59ac01461d3",
+      "nodeId": "8400:25089",
+      "importMethod": "single",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:11.422Z",
+      "page": "✅ Icons",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null
+    },
+    "tableau": {
+      "name": "Tableau",
+      "key": "a45329ba671776415a9627ec9eb838052799ede6",
+      "nodeId": "7168:748",
+      "importMethod": "single",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:11.422Z",
+      "page": "✅ Icons",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null
+    },
+    "databricks": {
+      "name": "databricks",
+      "key": "cd02bd7ff749c214daaa1784989449d469923b64",
+      "nodeId": "8400:25049",
+      "importMethod": "single",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:11.422Z",
+      "page": "✅ Icons",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null
+    },
+    "alteryx": {
+      "name": "alteryx",
+      "key": "d3e7905afc2b7bb22a7ecc47cad59047ae0a5f5b",
+      "nodeId": "8400:25197",
+      "importMethod": "single",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:11.422Z",
+      "page": "✅ Icons",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null
+    },
+    "cloud-upload": {
+      "name": "cloud--upload",
+      "key": "3b7f9b2a31b3cabd34d954ee87fda44ea7e1713f",
+      "nodeId": "7908:5403",
+      "importMethod": "single",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:11.422Z",
+      "page": "✅ Icons",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null
+    },
+    "chevron-left": {
+      "name": "chevron--left",
+      "key": "7940e22ca8c7fb72312b009bbc5d622c45dfc58f",
+      "nodeId": "7207:2837",
+      "importMethod": "single",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:11.422Z",
+      "page": "✅ Icons",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null
+    },
+    "notes-feedback": {
+      "name": "Notes/Feedback",
+      "key": "4f1fba9d4ba4dd56ef8f60b7190456bf824a2089",
+      "nodeId": "8662:6474",
+      "importMethod": "single",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:11.422Z",
+      "page": "Local components",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null
+    },
+    "upload-file": {
+      "name": "upload-file",
+      "key": "ef39179dc6dda4a55166931b2f11f8b60460d58d",
+      "nodeId": "7439:4678",
+      "importMethod": "single",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:11.422Z",
+      "page": "✅ Icons",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null
+    },
+    "history": {
+      "name": "history",
+      "key": "aaf85298722d8df888197a9174f219b7848cc013",
+      "nodeId": "8742:13219",
+      "importMethod": "single",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:11.422Z",
+      "page": "✅ Icons",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null
+    },
+    "arrow-down": {
+      "name": "arrow-down",
+      "key": "43009d0b38b304e97c5716c0a32ccc3951851872",
+      "nodeId": "7207:2839",
+      "importMethod": "single",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:11.422Z",
+      "page": "✅ Icons",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null
+    },
+    "suggestion": {
+      "name": "suggestion",
+      "key": "b0fdb7c7eb45f51182647cc89b12a5fd6989cafb",
+      "nodeId": "7279:3164",
+      "importMethod": "single",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:11.422Z",
+      "page": "✅ Icons",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null
+    },
+    "info": {
+      "name": "info",
+      "key": "01923eb6557a8612cf500c74a0ba5b32e37317e3",
+      "nodeId": "7207:2838",
+      "importMethod": "single",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:11.422Z",
+      "page": "✅ Icons",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null
+    },
+    "error-filled": {
+      "name": "error-filled",
+      "key": "53bac27f6b0e802b7f07de2c4a853502c6e93475",
+      "nodeId": "7378:5468",
+      "importMethod": "single",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:11.422Z",
+      "page": "✅ Icons",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null
+    },
+    "cursor-hand": {
+      "name": "cursor-hand",
+      "key": "90e85e25cda17c3f4967ef87bffa50a3daba7325",
+      "nodeId": "8404:1949",
+      "importMethod": "single",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:11.422Z",
+      "page": "✅ Icons",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null
+    },
+    "api-key": {
+      "name": "api-key",
+      "key": "f0f6ca388b8ac7bb5a0b3dea5b3d5ec30c6d0293",
+      "nodeId": "7378:3969",
+      "importMethod": "single",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:11.422Z",
+      "page": "✅ Icons",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null
+    },
+    "open": {
+      "name": "open",
+      "key": "f0af6e82dbffbc929018959ff7fbb609226fecaf",
+      "nodeId": "7293:667",
+      "importMethod": "single",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:11.422Z",
+      "page": "✅ Icons",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null
+    },
+    "background-explore": {
+      "name": "background-explore",
+      "key": "5167be1b2727b54509c3c10a770545b04972d16c",
+      "nodeId": "16494:19414",
+      "importMethod": "single",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:11.422Z",
+      "page": "Illustrations & graphics",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null
+    },
+    "app-switcher-dropdown": {
+      "name": "App switcher dropdown",
+      "key": "09baf67bef9191d0b5303b52c1c3159eefba3843",
+      "nodeId": "9118:17666",
+      "importMethod": "single",
+      "description": "Menu: -4 Density \nMenus display a list of choices on a temporary surface. They appear when users interact with a button, action, or other control.\n\n🛠 Additional options \nMenu list item - can be edite",
+      "lastSynced": "2026-05-09T15:47:11.422Z",
+      "page": "✅ Global header",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null
+    },
+    "server-search": {
+      "name": "server-search",
+      "key": "4b21aa187b1559d7c4ad33b31e477f7fcfc9975a",
+      "nodeId": "8576:4926",
+      "importMethod": "single",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:11.422Z",
+      "page": "✅ Icons",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null
+    },
+    "view": {
+      "name": "view",
+      "key": "4e86d04da3c537ed576f6ac221e8a1353b2b4475",
+      "nodeId": "14697:19193",
+      "importMethod": "single",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:11.422Z",
+      "page": "✅ Icons",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null
+    },
+    "output": {
+      "name": "output",
+      "key": "e16258e8231434bb180aa71804bdb92dfbffce77",
+      "nodeId": "8504:23029",
+      "importMethod": "single",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:11.422Z",
+      "page": "✅ Icons",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null
+    },
+    "directory": {
+      "name": "directory",
+      "key": "c97a2b5506aafe95c2e4964752e4522b247e609b",
+      "nodeId": "8189:4595",
+      "importMethod": "single",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:11.422Z",
+      "page": "✅ Icons",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null
+    },
+    "filter": {
+      "name": "filter",
+      "key": "ce37c828e8be322438e3530c7680d1eee95af253",
+      "nodeId": "14335:17202",
+      "importMethod": "single",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:11.422Z",
+      "page": "✅ Icons",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null
+    },
+    "view-details": {
+      "name": "view-details",
+      "key": "cf1033712c94e4f740ae4c8de3f907004dc9380f",
+      "nodeId": "12222:5799",
+      "importMethod": "single",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:11.422Z",
+      "page": "✅ Icons",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null
+    },
+    "event-time-type": {
+      "name": "event--time-type",
+      "key": "d056a594413fcd44887aca52b86d9df25f0cbd0c",
+      "nodeId": "8504:23298",
+      "importMethod": "single",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:11.422Z",
+      "page": "✅ Icons",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null
+    },
+    "view-card": {
+      "name": "view-card",
+      "key": "d1361c8bdc2347790fcedb0399598585fa4d7054",
+      "nodeId": "7622:5375",
+      "importMethod": "single",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:11.422Z",
+      "page": "✅ Icons",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null
+    },
+    "dots": {
+      "name": "dots",
+      "key": "d4bf02099fcf80e9f1956149da15460fe1ae13a7",
+      "nodeId": "7378:3729",
+      "importMethod": "single",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:11.422Z",
+      "page": "✅ Icons",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null
+    },
+    "database-check": {
+      "name": "database-check",
+      "key": "d94160526fbf06fff8a2be78f3449d5711a1f15e",
+      "nodeId": "8504:23088",
+      "importMethod": "single",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:11.422Z",
+      "page": "✅ Icons",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null
+    },
+    "user-group": {
+      "name": "user-group",
+      "key": "db200734daac36815be3bf52f078c9e528b15da4",
+      "nodeId": "7378:5131",
+      "importMethod": "single",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:11.422Z",
+      "page": "✅ Icons",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null
+    },
+    "chart-bar": {
+      "name": "chart--bar",
+      "key": "dde572f16c897c96ae7bc7a82532276fe87b7410",
+      "nodeId": "9246:14002",
+      "importMethod": "single",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:11.422Z",
+      "page": "✅ Icons",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null
+    },
+    "icon-query-queue": {
+      "name": "Icon/query-queue",
+      "key": "dfc61677c57161b2031bdce8733cb4bf6fcfd6fa",
+      "nodeId": "7311:2825",
+      "importMethod": "single",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:11.422Z",
+      "page": "✅ Icons",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null
+    },
+    "exit": {
+      "name": "exit",
+      "key": "e0ea887336f377ba397b25d988a54cf79eec6e4e",
+      "nodeId": "7301:2777",
+      "importMethod": "single",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:11.422Z",
+      "page": "✅ Icons",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null
+    },
+    "boolean-type": {
+      "name": "boolean-type",
+      "key": "e3dffdffb222be75a098c850a0ad155e1ad47eef",
+      "nodeId": "8504:23295",
+      "importMethod": "single",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:11.422Z",
+      "page": "✅ Icons",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null
+    },
+    "rotate-back": {
+      "name": "rotate-back",
+      "key": "e428e49c8dc1b6772d7b569e58fd6fa8a960b85f",
+      "nodeId": "7378:5031",
+      "importMethod": "single",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:11.422Z",
+      "page": "✅ Icons",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null
+    },
+    "glossary": {
+      "name": "glossary",
+      "key": "e47a036e8d2cce3968395f79cc96fdcc70bcf275",
+      "nodeId": "10613:30347",
+      "importMethod": "single",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:11.422Z",
+      "page": "✅ Icons",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null
+    },
+    "checkmark-outline": {
+      "name": "checkmark--outline",
+      "key": "e5b3de9a4f7a367b4ef924486daa999145e62f46",
+      "nodeId": "7310:2896",
+      "importMethod": "single",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:11.422Z",
+      "page": "✅ Icons",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null
+    },
+    "layers-front-curator-indicator": {
+      "name": "layers-front (Curator indicator)",
+      "key": "e7e0adbbf7e0f8b9b3fc45c839f381b029859715",
+      "nodeId": "8820:13322",
+      "importMethod": "single",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:11.422Z",
+      "page": "✅ Icons",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null
+    },
+    "help-bubble": {
+      "name": "help-bubble",
+      "key": "e842d2ce342d70cf02719cd42d5243744345c402",
+      "nodeId": "7207:2832",
+      "importMethod": "single",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:11.422Z",
+      "page": "✅ Icons",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null
+    },
+    "database": {
+      "name": "database",
+      "key": "eb4d7d43a2ef5bae16611e36a2da213bd07e27ba",
+      "nodeId": "7378:3700",
+      "importMethod": "single",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:11.422Z",
+      "page": "✅ Icons",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null
+    },
+    "minimize": {
+      "name": "minimize",
+      "key": "ed365ef9760849fa471fb84b4d7603c1052399bf",
+      "nodeId": "8298:5067",
+      "importMethod": "single",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:11.422Z",
+      "page": "✅ Icons",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null
+    },
+    "filter-text": {
+      "name": "filter-text",
+      "key": "eeb978ec0554b3df748891134e68c1c98137b480",
+      "nodeId": "7378:5053",
+      "importMethod": "single",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:11.422Z",
+      "page": "✅ Icons",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null
+    },
+    "pending": {
+      "name": "pending",
+      "key": "f312fc0c5b45f54eb9081e0b0878f346801af1a4",
+      "nodeId": "7996:5346",
+      "importMethod": "single",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:11.422Z",
+      "page": "✅ Icons",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null
+    },
+    "favorite-filled": {
+      "name": "favorite-filled",
+      "key": "f356489882aa4ddfc7e099e006510d6fdda704df",
+      "nodeId": "7378:3696",
+      "importMethod": "single",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:11.422Z",
+      "page": "✅ Icons",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null
+    },
+    "drag": {
+      "name": "drag",
+      "key": "f4dd4a86dfd0f91cce381eaa51abaa14a84785d3",
+      "nodeId": "7378:5050",
+      "importMethod": "single",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:11.422Z",
+      "page": "✅ Icons",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null
+    },
+    "menu": {
+      "name": "menu",
+      "key": "f55f4bc6e00be7b6c3dabbc2e426c9660964a1d4",
+      "nodeId": "7893:4605",
+      "importMethod": "single",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:11.422Z",
+      "page": "✅ Icons",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null
+    },
+    "brightness-contrast": {
+      "name": "brightness-contrast",
+      "key": "f6cb9d9b6a1a428237a5d845543c565524cd4eb0",
+      "nodeId": "7537:1569",
+      "importMethod": "single",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:11.422Z",
+      "page": "✅ Icons",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null
+    },
+    "data-product-output-port": {
+      "name": "data-product-output-port",
+      "key": "f74e10a2fe4608a484e1c40f1c1bdf2ad96ead1f",
+      "nodeId": "8504:23087",
+      "importMethod": "single",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:11.422Z",
+      "page": "✅ Icons",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null
+    },
+    "schema": {
+      "name": "schema",
+      "key": "f8fffb1cbe411321f66142c020a208b000d15e9d",
+      "nodeId": "7378:5038",
+      "importMethod": "single",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:11.422Z",
+      "page": "✅ Icons",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null
+    },
+    "settings": {
+      "name": "settings",
+      "key": "fa49ba4ce11934ea568dc702f402f52207703e97",
+      "nodeId": "7378:4812",
+      "importMethod": "single",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:11.422Z",
+      "page": "✅ Icons",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null
+    },
+    "task-list-multiple": {
+      "name": "task-list-multiple",
+      "key": "fb486ea7bd5611848f79a84fd04ede0cc78869a9",
+      "nodeId": "8504:23376",
+      "importMethod": "single",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:11.422Z",
+      "page": "✅ Icons",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null
+    },
+    "bin-type": {
+      "name": "bin-type",
+      "key": "fe0c2ab0c4128c555979c33682a6f3df40fb0b76",
+      "nodeId": "14292:5730",
+      "importMethod": "single",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:11.422Z",
+      "page": "✅ Icons",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null
+    },
+    "close": {
+      "name": "close",
+      "key": "09bac5a4cba0cbd89819dbe34afadc5db046f29d",
+      "nodeId": "7293:24",
+      "importMethod": "single",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:11.422Z",
+      "page": "✅ Icons",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null
+    },
+    "trash": {
+      "name": "trash",
+      "key": "09df4020b9f8d306843fca4159658c8ed4b5e323",
+      "nodeId": "7378:5056",
+      "importMethod": "single",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:11.422Z",
+      "page": "✅ Icons",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null
+    },
+    "target-type": {
+      "name": "target-type",
+      "key": "131e2264fa0b24b4715953951f3a50677c6c299a",
+      "nodeId": "8504:23302",
+      "importMethod": "single",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:11.422Z",
+      "page": "✅ Icons",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null
+    },
+    "add-circle": {
+      "name": "add-circle",
+      "key": "1aa9aeb58cfd76045aef34c67c9137a659eb4c5d",
+      "nodeId": "14703:19709",
+      "importMethod": "single",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:11.422Z",
+      "page": "✅ Icons",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null
+    },
+    "arrow": {
+      "name": "arrow",
+      "key": "1c31323fdcdaafe18878eb8206c3300f36bd6274",
+      "nodeId": "7207:2841",
+      "importMethod": "single",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:11.422Z",
+      "page": "✅ Icons",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null
+    },
+    "user-lock": {
+      "name": "user-lock",
+      "key": "1c3ea13966867002325327b01b9c5942ebe8d856",
+      "nodeId": "8820:13324",
+      "importMethod": "single",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:11.422Z",
+      "page": "✅ Icons",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null
+    },
+    "warning-filled": {
+      "name": "warning-filled",
+      "key": "1ca9ea45ed67eb11a5f1b4ff9027aaa9b8526073",
+      "nodeId": "14719:1075",
+      "importMethod": "single",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:11.422Z",
+      "page": "✅ Icons",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null
+    },
+    "calendar-2": {
+      "name": "calendar 2",
+      "key": "1d990e9286ab35da2957194c28722e72873aec3b",
+      "nodeId": "7313:3194",
+      "importMethod": "single",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:11.422Z",
+      "page": "✅ Icons",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null
+    },
+    "catalog-design": {
+      "name": "catalog-design",
+      "key": "1e008db8c2582d72bc8688a4eec84b2da83506c1",
+      "nodeId": "7439:4619",
+      "importMethod": "single",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:11.422Z",
+      "page": "✅ Icons",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null
+    },
+    "misuse-outline": {
+      "name": "misuse--outline",
+      "key": "c7ecb9c454db552f8ca3630707c86a877e13e32c",
+      "nodeId": "8415:1389",
+      "importMethod": "single",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:11.422Z",
+      "page": "✅ Icons",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null
+    },
+    "shield-lock": {
+      "name": "shield-lock",
+      "key": "20d03d16f42b9cb4d84c5ea07f6845c99b8fe7b6",
+      "nodeId": "7378:3967",
+      "importMethod": "single",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:11.422Z",
+      "page": "✅ Icons",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null
+    },
+    "tools": {
+      "name": "tools",
+      "key": "2a497ba6f8e5040d5654e86cdc32b90f51eb6849",
+      "nodeId": "7311:2826",
+      "importMethod": "single",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:11.422Z",
+      "page": "✅ Icons",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null
+    },
+    "add": {
+      "name": "add",
+      "key": "2b10108613a16fe36ada2420f992f0240b076804",
+      "nodeId": "7378:3994",
+      "importMethod": "single",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:11.422Z",
+      "page": "✅ Icons",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null
+    },
+    "analytics": {
+      "name": "analytics",
+      "key": "2cd31a798fd279626c6235902e21b17d6850db19",
+      "nodeId": "7378:3747",
+      "importMethod": "single",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:11.422Z",
+      "page": "✅ Icons",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null
+    },
+    "text-type": {
+      "name": "text-type",
+      "key": "2cd429a5df61f046748fc20c9e22aea14db8f9c0",
+      "nodeId": "8504:23299",
+      "importMethod": "single",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:11.422Z",
+      "page": "✅ Icons",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null
+    },
+    "edit": {
+      "name": "edit",
+      "key": "2f0c909fda47237325e20a1fc1c3d6eea2b05cd6",
+      "nodeId": "7207:2827",
+      "importMethod": "single",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:11.422Z",
+      "page": "✅ Icons",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null
+    },
+    "link-type": {
+      "name": "link-type",
+      "key": "30958f1f13ddf3866556b37ab570a09de2b2a26c",
+      "nodeId": "7378:5042",
+      "importMethod": "single",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:11.422Z",
+      "page": "✅ Icons",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null
+    },
+    "relation": {
+      "name": "relation",
+      "key": "328e40cf262d88c868275a408b432b445bf34888",
+      "nodeId": "8587:44312",
+      "importMethod": "single",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:11.422Z",
+      "page": "✅ Icons",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null
+    },
+    "lineage": {
+      "name": "lineage",
+      "key": "32f4f89b2ced8ccc35f19f9f68b4b7b3a4386119",
+      "nodeId": "7378:5706",
+      "importMethod": "single",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:11.422Z",
+      "page": "✅ Icons",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null
+    },
+    "local-filesystem": {
+      "name": "local-filesystem",
+      "key": "333ebe2a0ef4ef3a276b457ef37c1b015c43630e",
+      "nodeId": "7173:1784",
+      "importMethod": "single",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:11.422Z",
+      "page": "✅ Icons",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null
+    },
+    "back": {
+      "name": "back",
+      "key": "3626cb4ae78e5ad1bbc79bb3b04ef9d0323dbf9f",
+      "nodeId": "8504:23035",
+      "importMethod": "single",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:11.422Z",
+      "page": "✅ Icons",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null
+    },
+    "task-list": {
+      "name": "task-list",
+      "key": "371f35da773bc12bc441d4c36acd98ba8ac23e6e",
+      "nodeId": "8504:23375",
+      "importMethod": "single",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:11.422Z",
+      "page": "✅ Icons",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null
+    },
+    "tags-add": {
+      "name": "tags-add",
+      "key": "3736725d4f34af19d9cadeacbac382af2aa4685e",
+      "nodeId": "14691:426",
+      "importMethod": "single",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:11.422Z",
+      "page": "✅ Icons",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null
+    },
+    "book-bookmark": {
+      "name": "book-bookmark",
+      "key": "37bb27238ac422fd734919a3193c3c7564f1ce7c",
+      "nodeId": "7378:5700",
+      "importMethod": "single",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:11.422Z",
+      "page": "✅ Icons",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null
+    },
+    "download": {
+      "name": "download",
+      "key": "3a3acebe888e3a87c03831ab720ad5639c358af6",
+      "nodeId": "7439:4645",
+      "importMethod": "single",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:11.422Z",
+      "page": "✅ Icons",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null
+    },
+    "user-info": {
+      "name": "user-info",
+      "key": "3b2848d77b98a22dfa31033342ae67f84dee3c0b",
+      "nodeId": "8820:13334",
+      "importMethod": "single",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:11.422Z",
+      "page": "✅ Icons",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null
+    },
+    "applications": {
+      "name": "applications",
+      "key": "3ba99b342a17c51b99638e6b4aea3a91948ff578",
+      "nodeId": "7378:5025",
+      "importMethod": "single",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:11.422Z",
+      "page": "✅ Icons",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null
+    },
+    "alert": {
+      "name": "alert",
+      "key": "3ef4d9930695bc99abbbf055d853f986227ae5c5",
+      "nodeId": "7207:2820",
+      "importMethod": "single",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:11.422Z",
+      "page": "✅ Icons",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null
+    },
+    "pii": {
+      "name": "pii",
+      "key": "442a010032d021c1bc2cd198f611f49466623430",
+      "nodeId": "8517:23021",
+      "importMethod": "single",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:11.422Z",
+      "page": "✅ Icons",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null
+    },
+    "pin": {
+      "name": "pin",
+      "key": "4433057ddb2e2a901f12781f99e3a64b9db47cac",
+      "nodeId": "7378:5040",
+      "importMethod": "single",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:11.422Z",
+      "page": "✅ Icons",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null
+    },
+    "discussion": {
+      "name": "discussion",
+      "key": "4544a1b4ee7ecc05c3c18662aabb8b1aa0abebe0",
+      "nodeId": "7378:5054",
+      "importMethod": "single",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:11.422Z",
+      "page": "✅ Icons",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null
+    },
+    "home": {
+      "name": "home",
+      "key": "4a8ee163ef4f785c846a3a71344af13b834e02f0",
+      "nodeId": "7378:5034",
+      "importMethod": "single",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:11.422Z",
+      "page": "✅ Icons",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null
+    },
+    "book-edit": {
+      "name": "book-edit",
+      "key": "5375571bf48c287ec6f4c68bc4323db53466cf36",
+      "nodeId": "8504:23324",
+      "importMethod": "single",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:11.422Z",
+      "page": "✅ Icons",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null
+    },
+    "layers-front": {
+      "name": "layers-front",
+      "key": "548f9b5398eaff3804a4912550fc4c944881b465",
+      "nodeId": "8504:23326",
+      "importMethod": "single",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:11.422Z",
+      "page": "✅ Icons",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null
+    },
+    "help-laptop": {
+      "name": "help-laptop",
+      "key": "54a1684fcc8cba3210f64e17f66d7ef3cbabc737",
+      "nodeId": "14691:457",
+      "importMethod": "single",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:11.422Z",
+      "page": "✅ Icons",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null
+    },
+    "chevron-sort": {
+      "name": "chevron--sort",
+      "key": "5687e6bce59274d7ad7e3f2c17a3c2dabb78288d",
+      "nodeId": "7207:2836",
+      "importMethod": "single",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:11.422Z",
+      "page": "✅ Icons",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null
+    },
+    "null-sign": {
+      "name": "null-sign",
+      "key": "585087e1ea2d421dcaec6ac1db468c8f502ad6d2",
+      "nodeId": "8504:23300",
+      "importMethod": "single",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:11.422Z",
+      "page": "✅ Icons",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null
+    },
+    "favorite": {
+      "name": "favorite",
+      "key": "5ab08e77426cace71669963cfecc7164391598b3",
+      "nodeId": "7378:3698",
+      "importMethod": "single",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:11.422Z",
+      "page": "✅ Icons",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null
+    },
+    "chevron-up": {
+      "name": "chevron--up",
+      "key": "5b4eaa7ccb12d95aad45cc332dfb5633dd5ce9b4",
+      "nodeId": "7207:2842",
+      "importMethod": "single",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:11.422Z",
+      "page": "✅ Icons",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null
+    },
+    "dashboard": {
+      "name": "dashboard",
+      "key": "5d18c47639d77f1042c9e0bc2ccde8fcab2156d6",
+      "nodeId": "7439:4602",
+      "importMethod": "single",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:11.422Z",
+      "page": "✅ Icons",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null
+    },
+    "move": {
+      "name": "move",
+      "key": "62e026e024bd84bf9bcdd4cba5ec039616e6cca8",
+      "nodeId": "7378:5154",
+      "importMethod": "single",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:11.422Z",
+      "page": "✅ Icons",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null
+    },
+    "dataset": {
+      "name": "dataset",
+      "key": "63e281850a887cc85989c9fad99761493790915f",
+      "nodeId": "8504:23086",
+      "importMethod": "single",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:11.422Z",
+      "page": "✅ Icons",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null
+    },
+    "chevron-sort-down": {
+      "name": "chevron--sort--down",
+      "key": "666ef728fee0b8d31fd69757fdd75b2426abf2c6",
+      "nodeId": "7207:2833",
+      "importMethod": "single",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:11.422Z",
+      "page": "✅ Icons",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null
+    },
+    "warning-alt": {
+      "name": "warning--alt",
+      "key": "675e323d57c331b8b9936f39687cf68450fd105b",
+      "nodeId": "7310:2892",
+      "importMethod": "single",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:11.422Z",
+      "page": "✅ Icons",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null
+    },
+    "task-list-settings": {
+      "name": "task-list-settings",
+      "key": "6d75371c1dd77bd21889e1519f9281dd134dca23",
+      "nodeId": "8504:23325",
+      "importMethod": "single",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:11.422Z",
+      "page": "✅ Icons",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null
+    },
+    "float-type": {
+      "name": "float-type",
+      "key": "6db7c938fc9015d08e43e7b1de61438c6fb3534a",
+      "nodeId": "8504:23304",
+      "importMethod": "single",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:11.422Z",
+      "page": "✅ Icons",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null
+    },
+    "maintenance": {
+      "name": "maintenance",
+      "key": "71d837e04ce0a29b69d9e5c67362bbcf0b896e19",
+      "nodeId": "7378:4004",
+      "importMethod": "single",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:11.422Z",
+      "page": "✅ Icons",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null
+    },
+    "chevron-sort-up": {
+      "name": "chevron--sort--up",
+      "key": "749e5cda3c174a61f8dad42b2f9466b1f08325c4",
+      "nodeId": "7207:2835",
+      "importMethod": "single",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:11.422Z",
+      "page": "✅ Icons",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null
+    },
+    "exploration": {
+      "name": "exploration",
+      "key": "8220d30e69ebd1f255417f5871137cff0bcd7f99",
+      "nodeId": "7294:702",
+      "importMethod": "single",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:11.422Z",
+      "page": "✅ Icons",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null
+    },
+    "geo-point-type": {
+      "name": "geo-point-type",
+      "key": "8260b27df19484714fd96a17eef967ad126b8266",
+      "nodeId": "8504:23303",
+      "importMethod": "single",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:11.422Z",
+      "page": "✅ Icons",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null
+    },
+    "integer-type": {
+      "name": "integer-type",
+      "key": "8b6d13a33e18de3483b3b330d23abc5e69aefe56",
+      "nodeId": "8504:23296",
+      "importMethod": "single",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:11.422Z",
+      "page": "✅ Icons",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null
+    },
+    "text-file": {
+      "name": "text-file",
+      "key": "8f09539f181a4dbe90a86d6ccfe73ac4d41dd8c8",
+      "nodeId": "7378:5045",
+      "importMethod": "single",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:11.422Z",
+      "page": "✅ Icons",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null
+    },
+    "scanner": {
+      "name": "scanner",
+      "key": "92eba2ab6095c5b95bf4b86d1c056f5e1e39e232",
+      "nodeId": "7378:3979",
+      "importMethod": "single",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:11.422Z",
+      "page": "✅ Icons",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null
+    },
+    "data-file-question": {
+      "name": "data-file-question",
+      "key": "952165dd5316a81b1e8ee351e98c9cc489a3b863",
+      "nodeId": "8820:13520",
+      "importMethod": "single",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:11.422Z",
+      "page": "✅ Icons",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null
+    },
+    "security-services": {
+      "name": "security-services",
+      "key": "99137e55f852dc4f26cf9aa63f1bb560d4f28a2f",
+      "nodeId": "7378:3968",
+      "importMethod": "single",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:11.422Z",
+      "page": "✅ Icons",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null
+    },
+    "data-access-request": {
+      "name": "data-access-request",
+      "key": "9c4bda0c1c0521899b4019980ff9d248850fa215",
+      "nodeId": "13315:9277",
+      "importMethod": "single",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:11.422Z",
+      "page": "✅ Icons",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null
+    },
+    "info-filled": {
+      "name": "info-filled",
+      "key": "a593edf42eb81c2dfa8c4b0be8eac76b14cdffeb",
+      "nodeId": "7471:3918",
+      "importMethod": "single",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:11.422Z",
+      "page": "✅ Icons",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null
+    },
+    "chart-pie": {
+      "name": "chart--pie",
+      "key": "a88e1c87f86fa2dc376dfa5b0b890e5a6d3d50f5",
+      "nodeId": "9246:14001",
+      "importMethod": "single",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:11.422Z",
+      "page": "✅ Icons",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null
+    },
+    "stop-outline": {
+      "name": "stop--outline",
+      "key": "aca6ed16c1e6d21fe112ab5619570e5a11f1d5e0",
+      "nodeId": "7310:2895",
+      "importMethod": "single",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:11.422Z",
+      "page": "✅ Icons",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null
+    },
+    "relation-incoming": {
+      "name": "relation_incoming",
+      "key": "acc0d738122fb3dae02b1941b9909a3d15c0e0f1",
+      "nodeId": "8504:23150",
+      "importMethod": "single",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:11.422Z",
+      "page": "✅ Icons",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null
+    },
+    "relation-outgoing": {
+      "name": "relation_outgoing",
+      "key": "af3df33d230376a5bb016435dbb7ddecb9d42448",
+      "nodeId": "8504:23151",
+      "importMethod": "single",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:11.422Z",
+      "page": "✅ Icons",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null
+    },
+    "maximize": {
+      "name": "maximize",
+      "key": "b06f115e9d2e0d3544b1b319cc96e501449e5d5f",
+      "nodeId": "8483:1558",
+      "importMethod": "single",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:11.422Z",
+      "page": "✅ Icons",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null
+    },
+    "unknown-type": {
+      "name": "unknown-type",
+      "key": "b120c4277b392ad79c9b1bfc21015fc8d55453e5",
+      "nodeId": "8504:23297",
+      "importMethod": "single",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:11.422Z",
+      "page": "✅ Icons",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null
+    },
+    "lifecycle-policy": {
+      "name": "lifecycle-policy",
+      "key": "b1f0c9b1baad043881f1d2401a93aa1c8cce4791",
+      "nodeId": "13315:9276",
+      "importMethod": "single",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:11.422Z",
+      "page": "✅ Icons",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null
+    },
+    "circle-dash": {
+      "name": "circle-dash",
+      "key": "b317fa0913e7862fe3f7dbd2e0d8f5f49758c234",
+      "nodeId": "7310:2897",
+      "importMethod": "single",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:11.422Z",
+      "page": "✅ Icons",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null
+    },
+    "graph-merge": {
+      "name": "graph-merge",
+      "key": "b715dbd163131f360146e6044d9f8743045a973b",
+      "nodeId": "8576:4931",
+      "importMethod": "single",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:11.422Z",
+      "page": "✅ Icons",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null
+    },
+    "list-numbers": {
+      "name": "list-numbers",
+      "key": "b731322950354840772eadaac3abb71d45aca649",
+      "nodeId": "7378:5046",
+      "importMethod": "single",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:11.422Z",
+      "page": "✅ Icons",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null
+    },
+    "rocket-1": {
+      "name": "rocket 1",
+      "key": "b781fde18c452c199f8b699ed092b26d683f9f45",
+      "nodeId": "9085:20152",
+      "importMethod": "single",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:11.422Z",
+      "page": "✅ Icons",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null
+    },
+    "stars": {
+      "name": "stars",
+      "key": "bdea9d42922a4619f8a317ef616d30055eb789ee",
+      "nodeId": "7220:3430",
+      "importMethod": "single",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:11.422Z",
+      "page": "✅ Icons",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null
+    },
+    "view-table": {
+      "name": "view-table",
+      "key": "bfc87e123e2bab1aec590bdfa5799649b37f756a",
+      "nodeId": "7622:5374",
+      "importMethod": "single",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:11.422Z",
+      "page": "✅ Icons",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null
+    },
+    "asleep": {
+      "name": "asleep",
+      "key": "c0411afed99b56a1af98f59d40aec05db7c5fb95",
+      "nodeId": "7310:2900",
+      "importMethod": "single",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:11.422Z",
+      "page": "✅ Icons",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null
+    },
+    "undo": {
+      "name": "undo",
+      "key": "c4b92f77c463b26299c2eaf52aff41973aaf4b21",
+      "nodeId": "7469:5248",
+      "importMethod": "single",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:11.422Z",
+      "page": "✅ Icons",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null
+    },
+    "cursor-arrow": {
+      "name": "cursor-arrow",
+      "key": "c65a6ebe918fb33c8b6d0c9fa986dad1d62abbd6",
+      "nodeId": "8404:1905",
+      "importMethod": "single",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:11.422Z",
+      "page": "✅ Icons",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null
+    },
+    "connected": {
+      "name": "connected",
+      "key": "1af7f48fd97a924fbefe8516b1f41bc63c25a5dc",
+      "nodeId": "7378:5604",
+      "importMethod": "single",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:11.422Z",
+      "page": "✅ Icons",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null
+    },
+    "hdfs": {
+      "name": "hdfs",
+      "key": "0a110a850bce8693871a43820aa97c75a4d50dbe",
+      "nodeId": "8400:25077",
+      "importMethod": "single",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:11.422Z",
+      "page": "✅ Icons",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null
+    },
+    "informatica": {
+      "name": "informatica",
+      "key": "181f865b3a16ad0c0846ec99c3d247c7e00c6541",
+      "nodeId": "8400:25085",
+      "importMethod": "single",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:11.422Z",
+      "page": "✅ Icons",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null
+    },
+    "sybaseiq": {
+      "name": "sybaseiq",
+      "key": "1a1c77af7989eeaf683601efd8f4a6110524bff2",
+      "nodeId": "8400:25176",
+      "importMethod": "single",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:11.422Z",
+      "page": "✅ Icons",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null
+    },
+    "azure-synapse": {
+      "name": "azure-synapse",
+      "key": "27569cb7f6fc253c56855b733654a6848381ccce",
+      "nodeId": "8400:25216",
+      "importMethod": "single",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:11.422Z",
+      "page": "✅ Icons",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null
+    },
+    "gcp": {
+      "name": "GCP",
+      "key": "284e1f84d23761db66c0b103e33d39dd6ce705cf",
+      "nodeId": "7692:5000",
+      "importMethod": "single",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:11.422Z",
+      "page": "✅ Icons",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null
+    },
+    "sparkdb": {
+      "name": "sparkdb",
+      "key": "2b72bcb632f5072df86561f5d01e65ecf65da80b",
+      "nodeId": "8400:25168",
+      "importMethod": "single",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:11.422Z",
+      "page": "✅ Icons",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null
+    },
+    "gcpcloudstorage": {
+      "name": "gcpcloudstorage",
+      "key": "3c8a16f6928da03e6cf20f4d642622738adf0e30",
+      "nodeId": "8400:25067",
+      "importMethod": "single",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:11.422Z",
+      "page": "✅ Icons",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null
+    },
+    "sas-database": {
+      "name": "sas-database",
+      "key": "53658ce507819f58078a5ecf3bfb9cfba14cc599",
+      "nodeId": "8400:25164",
+      "importMethod": "single",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:11.422Z",
+      "page": "✅ Icons",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null
+    },
+    "zoom-reset": {
+      "name": "zoom-reset",
+      "key": "61225ecdbe8c2577297b8f190c86ccc3dc874641",
+      "nodeId": "7378:5606",
+      "importMethod": "single",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:11.422Z",
+      "page": "✅ Icons",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null
+    },
+    "influxdb": {
+      "name": "influxdb",
+      "key": "6230a2f34af32a060501ea1dd427519c42f1544c",
+      "nodeId": "8400:25083",
+      "importMethod": "single",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:11.422Z",
+      "page": "✅ Icons",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null
+    },
+    "cassandra": {
+      "name": "cassandra",
+      "key": "64f0499f24c5111550584447b3de34a9c84a87ae",
+      "nodeId": "8400:25220",
+      "importMethod": "single",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:11.422Z",
+      "page": "✅ Icons",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null
+    },
+    "generic-jdbc": {
+      "name": "generic-jdbc",
+      "key": "77e6d3ce1ac243842e028983ebeb9735ad5a5e31",
+      "nodeId": "8400:25069",
+      "importMethod": "single",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:11.422Z",
+      "page": "✅ Icons",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null
+    },
+    "alert-circle": {
+      "name": "alert-circle",
+      "key": "750fb2b2080f030bcf753f1c2c18c811c5aeaa8a",
+      "nodeId": "14719:551",
+      "importMethod": "single",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:11.422Z",
+      "page": "✅ Icons",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null
+    },
+    "thoughtspot": {
+      "name": "thoughtspot",
+      "key": "9ed31a542256e1d255e30e00bae6c625d8688b00",
+      "nodeId": "8400:25184",
+      "importMethod": "single",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:11.422Z",
+      "page": "✅ Icons",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null
+    },
+    "safyr-dynamics365": {
+      "name": "safyr-dynamics365",
+      "key": "a2a71b29edfd47b1f9eaa1a6e4d529da5586e4b6",
+      "nodeId": "8400:25148",
+      "importMethod": "single",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:11.422Z",
+      "page": "✅ Icons",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null
+    },
+    "disconnected": {
+      "name": "disconnected",
+      "key": "a5726c79041ba23ea9615c4c8af7a7dedde9eb4f",
+      "nodeId": "7378:5601",
+      "importMethod": "single",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:11.422Z",
+      "page": "✅ Icons",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null
+    },
+    "google-cloud": {
+      "name": "google-cloud",
+      "key": "d12a8061cfd85561bfea6763765c06144bf6e985",
+      "nodeId": "8400:25071",
+      "importMethod": "single",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:11.422Z",
+      "page": "✅ Icons",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null
+    },
+    "api": {
+      "name": "api",
+      "key": "d7bfb59b3cc1a6b3adccab62c95f2a39fa6b75e7",
+      "nodeId": "8400:25201",
+      "importMethod": "single",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:11.422Z",
+      "page": "✅ Icons",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null
+    },
+    "csv": {
+      "name": "csv",
+      "key": "d8466fafc7cf179f5440b19a5579b0771268e766",
+      "nodeId": "8400:25047",
+      "importMethod": "single",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:11.422Z",
+      "page": "✅ Icons",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null
+    },
+    "success-filled": {
+      "name": "success-filled",
+      "key": "d864426ee65112314a7925eaa9b5bd883a677100",
+      "nodeId": "7378:5490",
+      "importMethod": "single",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:11.422Z",
+      "page": "✅ Icons",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null
+    },
+    "ckan": {
+      "name": "ckan",
+      "key": "f9c6c20e5ac993e4b8076f57b60fb1e73f1a159b",
+      "nodeId": "8400:25222",
+      "importMethod": "single",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:11.422Z",
+      "page": "✅ Icons",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null
+    },
+    "expand": {
+      "name": "expand",
+      "key": "b92ca711225ff8cc4b1068893831456c40e3bc3f",
+      "nodeId": "15563:24467",
+      "importMethod": "single",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:11.422Z",
+      "page": "✅ Icons",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null
+    }
+  }
+}

--- a/plugins/actian-design-system/vendor/components/registries/fmkit.json
+++ b/plugins/actian-design-system/vendor/components/registries/fmkit.json
@@ -1,0 +1,3940 @@
+{
+  "library": "fm",
+  "fileKey": "X2JSEUyLvxyNCx22ucOexn",
+  "lastSynced": "2026-05-09T15:47:14.615Z",
+  "componentCount": 287,
+  "components": {
+    "fm-search-input": {
+      "name": "FM Search input",
+      "key": "443e232d5454f06dbd5bc06c2cacf21e80a20e4a",
+      "nodeId": "8:21302",
+      "importMethod": "set",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:14.615Z",
+      "page": "Fat Marker",
+      "properties": {
+        "Show label#176:9": {
+          "type": "BOOLEAN",
+          "default": true
+        },
+        "Input Text#1411:57": {
+          "type": "TEXT",
+          "default": "my search terms"
+        }
+      },
+      "nestedComponents": [],
+      "guidelinesFile": null,
+      "variants": {
+        "Type": [
+          "Empty",
+          "Placeholder",
+          "Filled"
+        ]
+      }
+    },
+    "fm-text-area": {
+      "name": "FM Text Area",
+      "key": "bba14eea66edb3871ea389afeb4e1a07585e5733",
+      "nodeId": "8:21882",
+      "importMethod": "set",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:14.615Z",
+      "page": "Fat Marker",
+      "properties": {
+        "Show label#176:5": {
+          "type": "BOOLEAN",
+          "default": true
+        }
+      },
+      "nestedComponents": [],
+      "guidelinesFile": null,
+      "variants": {
+        "Content": [
+          "None",
+          "Placeholder",
+          "Filled"
+        ]
+      }
+    },
+    "fm-multi-select-menu-item": {
+      "name": "FM Multi-select menu item",
+      "key": "56ad08f30372948c12ebb989e47e6260342eab52",
+      "nodeId": "8:21659",
+      "importMethod": "set",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:14.615Z",
+      "page": "Fat Marker",
+      "properties": {
+        "Dropdown item text#1428:2": {
+          "type": "TEXT",
+          "default": "Dropdown item"
+        }
+      },
+      "nestedComponents": [],
+      "guidelinesFile": null,
+      "variants": {
+        "State": [
+          "On",
+          "Off",
+          "User Off"
+        ]
+      }
+    },
+    "fm-checkbox": {
+      "name": "FM Checkbox",
+      "key": "965cf2c85659bbde891f6f086bbd02d50d445d58",
+      "nodeId": "8:21147",
+      "importMethod": "set",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:14.615Z",
+      "page": "Fat Marker",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null,
+      "variants": {
+        "State": [
+          "Off",
+          "On"
+        ],
+        "Style": [
+          "Default",
+          "Disabled"
+        ]
+      }
+    },
+    "fm-toast": {
+      "name": "FM Toast",
+      "key": "6140b137ce98ebfeeb7fc7e426f6d09de1cc18d0",
+      "nodeId": "8:21566",
+      "importMethod": "set",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:14.615Z",
+      "page": "Fat Marker",
+      "properties": {
+        "Icon#1485:2": {
+          "type": "INSTANCE_SWAP",
+          "default": "8:20570"
+        }
+      },
+      "nestedComponents": [],
+      "guidelinesFile": null,
+      "variants": {
+        "Style": [
+          "Standard",
+          "Outline"
+        ]
+      }
+    },
+    "fm-tooltip": {
+      "name": "FM Tooltip",
+      "key": "82fc81413312e7e69981169db50003765cf94423",
+      "nodeId": "8:22316",
+      "importMethod": "set",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:14.615Z",
+      "page": "Fat Marker",
+      "properties": {
+        "Icon#163:311": {
+          "type": "BOOLEAN",
+          "default": false
+        },
+        "↳ Icon#163:324": {
+          "type": "INSTANCE_SWAP",
+          "default": "2:5"
+        }
+      },
+      "nestedComponents": [],
+      "guidelinesFile": null,
+      "variants": {
+        "Position": [
+          "Left",
+          "Left Top",
+          "Left Bottom",
+          "Right",
+          "Right Top",
+          "Right Bottom",
+          "Top",
+          "Top Left",
+          "Top Right",
+          "Bottom",
+          "Bottom Left",
+          "Bottom Right"
+        ]
+      }
+    },
+    "fm-chip": {
+      "name": "FM Chip",
+      "key": "0861d937682e66d39f57fe52ca83d526e634ff66",
+      "nodeId": "8:22389",
+      "importMethod": "set",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:14.615Z",
+      "page": "Fat Marker",
+      "properties": {
+        "Icon#163:337": {
+          "type": "BOOLEAN",
+          "default": true
+        },
+        "↳ Icon#163:340": {
+          "type": "INSTANCE_SWAP",
+          "default": "9:1404"
+        }
+      },
+      "nestedComponents": [],
+      "guidelinesFile": null,
+      "variants": {
+        "Outline": [
+          "False",
+          "True"
+        ]
+      }
+    },
+    "fm-cursor": {
+      "name": "FM Cursor",
+      "key": "0f68684930c7e7a364121853baafe23fdb921730",
+      "nodeId": "8:21470",
+      "importMethod": "set",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:14.615Z",
+      "page": "Fat Marker",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null,
+      "variants": {
+        "Cursor Type": [
+          "Link",
+          "Pointer",
+          "Dragging",
+          "Text"
+        ]
+      }
+    },
+    "fm-progress-bar": {
+      "name": "FM Progress bar",
+      "key": "12abe66d36a63ef385a17e2553a1312560a0f106",
+      "nodeId": "8:21584",
+      "importMethod": "set",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:14.615Z",
+      "page": "Fat Marker",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null,
+      "variants": {
+        "Completion": [
+          "10%",
+          "20%",
+          "30%",
+          "40%",
+          "50%",
+          "60%",
+          "70%",
+          "80%",
+          "90%",
+          "100%"
+        ]
+      }
+    },
+    "fm-text-input": {
+      "name": "FM Text input",
+      "key": "355855c7b2e05b5b336167883b3c9ebbfbd881ad",
+      "nodeId": "8:21220",
+      "importMethod": "set",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:14.615Z",
+      "page": "Fat Marker",
+      "properties": {
+        "Show label#176:0": {
+          "type": "BOOLEAN",
+          "default": true
+        },
+        "Leading Icon#1411:36": {
+          "type": "INSTANCE_SWAP",
+          "default": "8:20720"
+        },
+        "Trailing Icon#1411:43": {
+          "type": "INSTANCE_SWAP",
+          "default": "8:20720"
+        },
+        "Input Text#1411:57": {
+          "type": "TEXT",
+          "default": "Input text"
+        },
+        "👁 Leading Icon#1411:74": {
+          "type": "BOOLEAN",
+          "default": false
+        },
+        "👁 Trailing Icon#1411:76": {
+          "type": "BOOLEAN",
+          "default": false
+        }
+      },
+      "nestedComponents": [],
+      "guidelinesFile": null,
+      "variants": {
+        "Type": [
+          "Empty",
+          "Placeholder",
+          "Default",
+          "Disabled"
+        ]
+      }
+    },
+    "fm-slider": {
+      "name": "FM Slider",
+      "key": "181d7f761179e7ce2f2849ae5c73989177d3a3c6",
+      "nodeId": "8:21194",
+      "importMethod": "set",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:14.615Z",
+      "page": "Fat Marker",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null,
+      "variants": {
+        "Progress": [
+          "0%",
+          "25%",
+          "50%",
+          "75%",
+          "100%"
+        ]
+      }
+    },
+    "fm-badge": {
+      "name": "FM Badge",
+      "key": "2410b87c83d33d3bcb2a6ac7aa2168a53a4eb3d8",
+      "nodeId": "8:22406",
+      "importMethod": "set",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:14.615Z",
+      "page": "Fat Marker",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null,
+      "variants": {
+        "Size": [
+          "Small",
+          "Medium",
+          "Large"
+        ],
+        "Type": [
+          "Icon",
+          "Number",
+          "Number Expand"
+        ]
+      }
+    },
+    "fm-menu-item": {
+      "name": "FM Menu item",
+      "key": "6d3a9c26c31762f832a3a95033c1594edf33da72",
+      "nodeId": "8:21652",
+      "importMethod": "set",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:14.615Z",
+      "page": "Fat Marker",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null,
+      "variants": {
+        "State": [
+          "Default",
+          "Hover",
+          "Active"
+        ]
+      }
+    },
+    "fm-multi-select-dropdown": {
+      "name": "FM Multi-select dropdown",
+      "key": "876bfa32334594915085ebea82f1f887b3fecb09",
+      "nodeId": "8:21443",
+      "importMethod": "set",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:14.615Z",
+      "page": "Fat Marker",
+      "properties": {
+        "Show label#176:18": {
+          "type": "BOOLEAN",
+          "default": true
+        },
+        "Dropdown Text#1411:84": {
+          "type": "TEXT",
+          "default": "Select"
+        }
+      },
+      "nestedComponents": [],
+      "guidelinesFile": null,
+      "variants": {
+        "Type": [
+          "Placeholder",
+          "Disabled",
+          "Open Multi-select",
+          "Filled",
+          "User Filled"
+        ]
+      }
+    },
+    "sticky-note": {
+      "name": "Sticky note",
+      "key": "9b4f450c92de6178731d1eca0f03f42ac3f64085",
+      "nodeId": "139:2309",
+      "importMethod": "set",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:14.615Z",
+      "page": "Fat Marker",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null,
+      "variants": {
+        "Property 1": [
+          "Default",
+          "Critical"
+        ]
+      }
+    },
+    "fm-date-input": {
+      "name": "FM Date input",
+      "key": "69d6329ea2d5ac3515b6ebb04ad6c1bd72e4890e",
+      "nodeId": "8:21321",
+      "importMethod": "set",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:14.615Z",
+      "page": "Fat Marker",
+      "properties": {
+        "Input Text#1451:1": {
+          "type": "TEXT",
+          "default": "MM / DD / YYYY"
+        }
+      },
+      "nestedComponents": [],
+      "guidelinesFile": null,
+      "variants": {
+        "State": [
+          "Default",
+          "Open",
+          "Placeholder"
+        ]
+      }
+    },
+    "fm-tag": {
+      "name": "FM Tag",
+      "key": "c7239d9355ddf557f36f4d159153619672ab81ef",
+      "nodeId": "8:22396",
+      "importMethod": "set",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:14.615Z",
+      "page": "Fat Marker",
+      "properties": {
+        "Icon Right#50:0": {
+          "type": "BOOLEAN",
+          "default": false
+        },
+        "↳ Icon R#50:8": {
+          "type": "INSTANCE_SWAP",
+          "default": "9:1404"
+        },
+        "Icon Left#163:343": {
+          "type": "BOOLEAN",
+          "default": true
+        },
+        "↳ Icon L#163:347": {
+          "type": "INSTANCE_SWAP",
+          "default": "9:1404"
+        }
+      },
+      "nestedComponents": [],
+      "guidelinesFile": null,
+      "variants": {
+        "Style": [
+          "Filled",
+          "Outline",
+          "Light"
+        ]
+      }
+    },
+    "fm-placeholder": {
+      "name": "FM Placeholder",
+      "key": "e49a9de0573cf527736e8173f722f230fa957fb8",
+      "nodeId": "86:716",
+      "importMethod": "set",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:14.615Z",
+      "page": "Fat Marker",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null,
+      "variants": {
+        "Type": [
+          "Label+1line",
+          "Label+3lines",
+          "Label+6lines",
+          "Label+avatars",
+          "metric"
+        ]
+      }
+    },
+    "fm-icon-buttons": {
+      "name": "FM Icon Buttons",
+      "key": "f868aabb0aa2c52f00610c09da8dce3bccc79dc4",
+      "nodeId": "8:21121",
+      "importMethod": "set",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:14.615Z",
+      "page": "Fat Marker",
+      "properties": {
+        "Icon#1470:32": {
+          "type": "INSTANCE_SWAP",
+          "default": "8:20614"
+        }
+      },
+      "nestedComponents": [],
+      "guidelinesFile": null,
+      "variants": {
+        "Type": [
+          "Primary",
+          "Secondary",
+          "Outline"
+        ],
+        "State": [
+          "Default",
+          "Disabled"
+        ]
+      }
+    },
+    "fm-input-label": {
+      "name": "FM Input Label",
+      "key": "a39aa1c7cb593f7d26b7659e4cbe4e419e00c766",
+      "nodeId": "23:1207",
+      "importMethod": "set",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:14.615Z",
+      "page": "Fat Marker",
+      "properties": {
+        "Caption#1555:9": {
+          "type": "BOOLEAN",
+          "default": true
+        },
+        "Required#1555:10": {
+          "type": "BOOLEAN",
+          "default": false
+        },
+        "Label Text#1555:11": {
+          "type": "TEXT",
+          "default": "Label"
+        },
+        "Caption Text#1555:12": {
+          "type": "TEXT",
+          "default": "Caption"
+        }
+      },
+      "nestedComponents": [],
+      "guidelinesFile": null,
+      "variants": {
+        "Disabled": [
+          "No",
+          "Yes"
+        ],
+        "Type": [
+          "Text",
+          "Placeholder"
+        ]
+      }
+    },
+    "fm-nav-bar": {
+      "name": "FM Nav bar",
+      "key": "1e8673ccc2818b68f9faabb99757bfd44af2b592",
+      "nodeId": "1020:2324",
+      "importMethod": "set",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:14.615Z",
+      "page": "Fat Marker",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null,
+      "variants": {
+        "Property 1": [
+          "Default",
+          "Slim"
+        ]
+      }
+    },
+    "fm-stepper": {
+      "name": "FM Stepper",
+      "key": "d0a21b5288571cc7690c6c9289d18cd298035c53",
+      "nodeId": "1052:9653",
+      "importMethod": "set",
+      "description": "Step indicator for multi-step wizard flows. Place in a horizontal row — one instance per step. Active = current step, Complete = done, Upcoming = not yet reached.",
+      "lastSynced": "2026-05-09T15:47:14.615Z",
+      "page": "Fat Marker",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null,
+      "variants": {
+        "State": [
+          "Active",
+          "Complete",
+          "Upcoming"
+        ]
+      }
+    },
+    "fm-app-header": {
+      "name": "FM App_header",
+      "key": "8fc9bcee610c7f8d22ebcc268467993f6dc99c87",
+      "nodeId": "67:1858",
+      "importMethod": "set",
+      "description": "Top-level application header bar. Contains the Actian logo, product label, and user avatar. Use at the top of every screen mockup.",
+      "lastSynced": "2026-05-09T15:47:14.615Z",
+      "page": "Fat Marker",
+      "properties": {
+        "Show Context inputs#186:0": {
+          "type": "BOOLEAN",
+          "default": true
+        }
+      },
+      "nestedComponents": [],
+      "guidelinesFile": null,
+      "variants": {
+        "Type": [
+          "Admin",
+          "Explorer",
+          "Studio",
+          "Actian"
+        ]
+      }
+    },
+    "fm-alert": {
+      "name": "FM Alert",
+      "key": "fe30f37740688350762bd2b1be426d9d1588b7d9",
+      "nodeId": "1052:9637",
+      "importMethod": "set",
+      "description": "Inline feedback message for success, error, or warning states. Use for persistent status messages — for brief confirmations, use FM Toast instead.",
+      "lastSynced": "2026-05-09T15:47:14.615Z",
+      "page": "Fat Marker",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null,
+      "variants": {
+        "Type": [
+          "Success",
+          "Error",
+          "Warning"
+        ]
+      }
+    },
+    "fm-button": {
+      "name": "FM Button",
+      "key": "368b62312ca941c80ea8eeed84a57d33bb470b09",
+      "nodeId": "8:21044",
+      "importMethod": "set",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:14.615Z",
+      "page": "Fat Marker",
+      "properties": {
+        "Leading Icon#1410:0": {
+          "type": "INSTANCE_SWAP",
+          "default": "9:1404"
+        },
+        "👁 Leading Icon#1410:3": {
+          "type": "BOOLEAN",
+          "default": true
+        },
+        "👁 Trailing Icon#1410:6": {
+          "type": "BOOLEAN",
+          "default": true
+        },
+        "Trailing Icon#1410:9": {
+          "type": "INSTANCE_SWAP",
+          "default": "9:1404"
+        },
+        "Label#1411:32": {
+          "type": "TEXT",
+          "default": "Button label"
+        }
+      },
+      "nestedComponents": [],
+      "guidelinesFile": null,
+      "variants": {
+        "Size": [
+          "md",
+          "sm"
+        ],
+        "Shape": [
+          "Regular",
+          "Pill"
+        ],
+        "Type": [
+          "Primary",
+          "Secondary",
+          "Outline",
+          "Destructive"
+        ],
+        "State": [
+          "Default",
+          "Disabled"
+        ]
+      }
+    },
+    "fm-dropdown": {
+      "name": "FM Dropdown",
+      "key": "781f86dca2a37706771f3e2e580242d2693a722f",
+      "nodeId": "8:21420",
+      "importMethod": "set",
+      "description": "Single-select dropdown. Placeholder = empty, Filled = value selected, Open = showing options, Disabled = non-interactive.",
+      "lastSynced": "2026-05-09T15:47:14.615Z",
+      "page": "Fat Marker",
+      "properties": {
+        "Show label#176:13": {
+          "type": "BOOLEAN",
+          "default": true
+        }
+      },
+      "nestedComponents": [],
+      "guidelinesFile": null,
+      "variants": {
+        "Type": [
+          "Placeholder",
+          "Open",
+          "Disabled",
+          "Filled"
+        ]
+      }
+    },
+    "fm-table-cell": {
+      "name": "FM Table Cell",
+      "key": "9267fecfadc4577563deb1425fa598d1f5af9144",
+      "nodeId": "8:21551",
+      "importMethod": "set",
+      "description": "Table cell for data tables. Header = column title, Text = data value, Pill = status badge, Placeholder = future column.",
+      "lastSynced": "2026-05-09T15:47:14.615Z",
+      "page": "Fat Marker",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null,
+      "variants": {
+        "Type": [
+          "Header",
+          "Text",
+          "Pill",
+          "Placeholder"
+        ]
+      }
+    },
+    "fm-empty-state": {
+      "name": "FM Empty State",
+      "key": "cf44b9c0b5623a394d90f320f98250dc77378268",
+      "nodeId": "228:2994",
+      "importMethod": "set",
+      "description": "Empty or zero-data state placeholder. Default = centered with icon and text. Compact = smaller, for inline use. Include onboarding hint text to guide the user.",
+      "lastSynced": "2026-05-09T15:47:14.615Z",
+      "page": "Fat Marker",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null,
+      "variants": {
+        "Type": [
+          "Default",
+          "Compact"
+        ]
+      }
+    },
+    "fm-tab": {
+      "name": "FM Tab",
+      "key": "cfbd732ff4f4e6620b333c60f1ac7fe5116a93aa",
+      "nodeId": "8:21619",
+      "importMethod": "set",
+      "description": "Tab for switching between views within the same context. On = active tab, Off = inactive, Placeholder = future/reserved tab slot.",
+      "lastSynced": "2026-05-09T15:47:14.615Z",
+      "page": "Fat Marker",
+      "properties": {
+        "Show Icon#20:0": {
+          "type": "BOOLEAN",
+          "default": true
+        }
+      },
+      "nestedComponents": [],
+      "guidelinesFile": null,
+      "variants": {
+        "State": [
+          "On",
+          "Off",
+          "Placeholder"
+        ]
+      }
+    },
+    "fm-toggle": {
+      "name": "FM Toggle",
+      "key": "fe9e82118d1df75a8aea732eb7f9169ccaa21878",
+      "nodeId": "8:21173",
+      "importMethod": "set",
+      "description": "On/off toggle switch. Use for immediate binary actions. Pair with a text label using fm-custom-toggle-row layout. Disabled style reduces opacity.",
+      "lastSynced": "2026-05-09T15:47:14.615Z",
+      "page": "Fat Marker",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null,
+      "variants": {
+        "State": [
+          "Off",
+          "On"
+        ],
+        "Style": [
+          "Default",
+          "Disabled"
+        ]
+      }
+    },
+    "fm-nav-item": {
+      "name": "FM Nav item",
+      "key": "d18a0a772ed4acd760c497cb93de796ff052a7b4",
+      "nodeId": "8:21525",
+      "importMethod": "set",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:14.615Z",
+      "page": "Fat Marker",
+      "properties": {
+        "Show icon#166:0": {
+          "type": "BOOLEAN",
+          "default": true
+        },
+        "Show Label#1020:0": {
+          "type": "BOOLEAN",
+          "default": true
+        },
+        "Label#1463:4": {
+          "type": "TEXT",
+          "default": "Nav Item"
+        },
+        "Icon#1503:0": {
+          "type": "INSTANCE_SWAP",
+          "default": "9:1404"
+        },
+        "Chevron#1507:0": {
+          "type": "BOOLEAN",
+          "default": true
+        }
+      },
+      "nestedComponents": [],
+      "guidelinesFile": null,
+      "variants": {
+        "State": [
+          "On",
+          "Off",
+          "Placeholder"
+        ]
+      }
+    },
+    "fm-page-header": {
+      "name": "FM Page Header",
+      "key": "ae1f8684a4a89aa74463d439e4e8c1e7a48137fe",
+      "nodeId": "979:3117",
+      "importMethod": "set",
+      "description": "Page title area with optional subtitle and action buttons.",
+      "lastSynced": "2026-05-09T15:47:14.615Z",
+      "page": "Fat Marker",
+      "properties": {
+        "Title#979:22": {
+          "type": "TEXT",
+          "default": "Page Title"
+        },
+        "Subtitle#979:23": {
+          "type": "TEXT",
+          "default": "Description text"
+        }
+      },
+      "nestedComponents": [],
+      "guidelinesFile": null,
+      "variants": {
+        "Type": [
+          "Title only",
+          "Title + Subtitle",
+          "Title + Actions",
+          "Placeholder"
+        ]
+      }
+    },
+    "fm-radio-button": {
+      "name": "FM Radio button",
+      "key": "1569353eb82fd5f6cb8da979f1048cd1b323e8c4",
+      "nodeId": "8:21160",
+      "importMethod": "set",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:14.615Z",
+      "page": "Fat Marker",
+      "properties": {
+        "Show Label#1072:0": {
+          "type": "BOOLEAN",
+          "default": true
+        }
+      },
+      "nestedComponents": [],
+      "guidelinesFile": null,
+      "variants": {
+        "Format": [
+          "Default",
+          "Card"
+        ],
+        "State": [
+          "On",
+          "Off"
+        ],
+        "Style": [
+          "Default",
+          "Disabled"
+        ]
+      }
+    },
+    "currency-pound": {
+      "name": "currency-pound",
+      "key": "545b484b089f348b32829cf4387238bd67171f54",
+      "nodeId": "8:20618",
+      "importMethod": "single",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:14.615Z",
+      "page": "Fat Marker",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null
+    },
+    "sun": {
+      "name": "sun",
+      "key": "aefc3a20a2bdd3b86d7fafccf0cfe99d4503e6db",
+      "nodeId": "8:20780",
+      "importMethod": "single",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:14.615Z",
+      "page": "Fat Marker",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null
+    },
+    "status-online": {
+      "name": "status-online",
+      "key": "b556ab0751d672997c555b61ce79b1acaa22f9dc",
+      "nodeId": "8:20964",
+      "importMethod": "single",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:14.615Z",
+      "page": "Fat Marker",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null
+    },
+    "clipboard": {
+      "name": "clipboard",
+      "key": "10438bc8dc8217a31fadb316c37ce82807a41a9a",
+      "nodeId": "8:20764",
+      "importMethod": "single",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:14.615Z",
+      "page": "Fat Marker",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null
+    },
+    "phone-outgoing": {
+      "name": "phone-outgoing",
+      "key": "1b4fa133491870938db351d4b741669132302c06",
+      "nodeId": "8:20722",
+      "importMethod": "single",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:14.615Z",
+      "page": "Fat Marker",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null
+    },
+    "shield-check": {
+      "name": "shield-check",
+      "key": "2d31558affe4918eaa266f2b5b81ce894746498c",
+      "nodeId": "8:20622",
+      "importMethod": "single",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:14.615Z",
+      "page": "Fat Marker",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null
+    },
+    "device-mobile": {
+      "name": "device-mobile",
+      "key": "327211c12cc84f54aba167a67d99dbe395c99016",
+      "nodeId": "8:20932",
+      "importMethod": "single",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:14.615Z",
+      "page": "Fat Marker",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null
+    },
+    "paper-airplane": {
+      "name": "paper-airplane",
+      "key": "6a51457985d37d148705a8424a86754ba841cea9",
+      "nodeId": "8:20920",
+      "importMethod": "single",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:14.615Z",
+      "page": "Fat Marker",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null
+    },
+    "puzzle": {
+      "name": "puzzle",
+      "key": "d54a9f27a1d060e21f79e4745be50cba61f22502",
+      "nodeId": "8:20882",
+      "importMethod": "single",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:14.615Z",
+      "page": "Fat Marker",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null
+    },
+    "inbox": {
+      "name": "inbox",
+      "key": "feb7469781c0719f1cc972cb0474ac901104677d",
+      "nodeId": "8:20558",
+      "importMethod": "single",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:14.615Z",
+      "page": "Fat Marker",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null
+    },
+    "player-repeat": {
+      "name": "player-repeat",
+      "key": "8142c8c668161c2e039cc3cd11bc018380c1d319",
+      "nodeId": "8:21012",
+      "importMethod": "single",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:14.615Z",
+      "page": "Fat Marker",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null
+    },
+    "archive": {
+      "name": "archive",
+      "key": "b59f2860220a704dfddbb654f92780355cd264b0",
+      "nodeId": "8:20604",
+      "importMethod": "single",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:14.615Z",
+      "page": "Fat Marker",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null
+    },
+    "chart-bar": {
+      "name": "chart-bar",
+      "key": "f688ec904baf1b330abbbf4fc6696a1ddaf87933",
+      "nodeId": "8:20852",
+      "importMethod": "single",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:14.615Z",
+      "page": "Fat Marker",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null
+    },
+    "share": {
+      "name": "share",
+      "key": "61b8b92570b98b9c08e2daf68574bb37137f6d68",
+      "nodeId": "8:20608",
+      "importMethod": "single",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:14.615Z",
+      "page": "Fat Marker",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null
+    },
+    "document-download": {
+      "name": "document-download",
+      "key": "678ee61b1fec3f17929efec56700284ae0b454bf",
+      "nodeId": "8:20678",
+      "importMethod": "single",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:14.615Z",
+      "page": "Fat Marker",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null
+    },
+    "document-add": {
+      "name": "document-add",
+      "key": "abc90131757704cbde1796c201dbfece2ec02e28",
+      "nodeId": "8:20702",
+      "importMethod": "single",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:14.615Z",
+      "page": "Fat Marker",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null
+    },
+    "user-group": {
+      "name": "user-group",
+      "key": "e427c987f13a9a044c9ac34906c6ac8ac3a84028",
+      "nodeId": "8:20602",
+      "importMethod": "single",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:14.615Z",
+      "page": "Fat Marker",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null
+    },
+    "fm-tabs": {
+      "name": "FM Tabs",
+      "key": "860eadef9ba29cf20a3da3ca9d014718e3f6cabb",
+      "nodeId": "20:1705",
+      "importMethod": "single",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:14.615Z",
+      "page": "Fat Marker",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null
+    },
+    "chevron-down": {
+      "name": "chevron-down",
+      "key": "e1e89733c66a56f6591dec45e6e96c693795b369",
+      "nodeId": "8:20666",
+      "importMethod": "single",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:14.615Z",
+      "page": "Fat Marker",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null
+    },
+    "map": {
+      "name": "map",
+      "key": "d6fcd844e966d5e0a61ff1226d1d208c0a9c14ef",
+      "nodeId": "8:20908",
+      "importMethod": "single",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:14.615Z",
+      "page": "Fat Marker",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null
+    },
+    "video-camera": {
+      "name": "video-camera",
+      "key": "d55ef7580ac1e263f134147994d3215d9448efdc",
+      "nodeId": "8:20902",
+      "importMethod": "single",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:14.615Z",
+      "page": "Fat Marker",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null
+    },
+    "backspace": {
+      "name": "backspace",
+      "key": "d5b1f0e811fc727478f802898ac4efc373b9e1e2",
+      "nodeId": "8:20922",
+      "importMethod": "single",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:14.615Z",
+      "page": "Fat Marker",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null
+    },
+    "beaker": {
+      "name": "beaker",
+      "key": "d762e5af367669976aec16a4d9a835e3d9406cdc",
+      "nodeId": "8:20898",
+      "importMethod": "single",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:14.615Z",
+      "page": "Fat Marker",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null
+    },
+    "bookmark-alt": {
+      "name": "bookmark-alt",
+      "key": "20db68ce5ed17fdc44a044d6dc4fdd38bf1f0208",
+      "nodeId": "8:20840",
+      "importMethod": "single",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:14.615Z",
+      "page": "Fat Marker",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null
+    },
+    "currency-bangladeshi": {
+      "name": "currency-bangladeshi",
+      "key": "2969f622dd95e41429cbbb3303bf8f4ecf86f8f8",
+      "nodeId": "8:20894",
+      "importMethod": "single",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:14.615Z",
+      "page": "Fat Marker",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null
+    },
+    "newspaper": {
+      "name": "newspaper",
+      "key": "a0da4c84b660fcc8cda62e5a67b04d81f28a1729",
+      "nodeId": "8:20842",
+      "importMethod": "single",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:14.615Z",
+      "page": "Fat Marker",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null
+    },
+    "thumb-down": {
+      "name": "thumb-down",
+      "key": "3206b09cb8394c1ffe7f6fc5238c067fed44d272",
+      "nodeId": "8:20876",
+      "importMethod": "single",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:14.615Z",
+      "page": "Fat Marker",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null
+    },
+    "star": {
+      "name": "star",
+      "key": "3f304d83c6057fa75cdceaa1f9f77dda4d42cd2d",
+      "nodeId": "8:20856",
+      "importMethod": "single",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:14.615Z",
+      "page": "Fat Marker",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null
+    },
+    "sm-view-grid-add": {
+      "name": "sm-view-grid-add",
+      "key": "40bed7c635c99631854c00b036fb440248e4182d",
+      "nodeId": "8:20844",
+      "importMethod": "single",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:14.615Z",
+      "page": "Fat Marker",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null
+    },
+    "support": {
+      "name": "support",
+      "key": "abfe2e8ac13fe77de38b39b0373d208b13688f5d",
+      "nodeId": "8:20850",
+      "importMethod": "single",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:14.615Z",
+      "page": "Fat Marker",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null
+    },
+    "terminal": {
+      "name": "terminal",
+      "key": "42b85c9a37012de3ed73df7675da9bb600e388b6",
+      "nodeId": "8:20854",
+      "importMethod": "single",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:14.615Z",
+      "page": "Fat Marker",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null
+    },
+    "fm-spinner": {
+      "name": "FM Spinner",
+      "key": "52927648847b15a51d314cf06ca1c0f19f398b4d",
+      "nodeId": "8:21577",
+      "importMethod": "single",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:14.615Z",
+      "page": "Fat Marker",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null
+    },
+    "library": {
+      "name": "library",
+      "key": "5abbf4c28c65404c099b291ed92333034faf1d7a",
+      "nodeId": "8:20862",
+      "importMethod": "single",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:14.615Z",
+      "page": "Fat Marker",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null
+    },
+    "save": {
+      "name": "save",
+      "key": "615e6c63a56e2155cdf5c3913806f3a85ab33841",
+      "nodeId": "8:20918",
+      "importMethod": "single",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:14.615Z",
+      "page": "Fat Marker",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null
+    },
+    "pause": {
+      "name": "pause",
+      "key": "68590f7b3ac0dd19f5415372cc63d2226f3bd70c",
+      "nodeId": "8:20848",
+      "importMethod": "single",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:14.615Z",
+      "page": "Fat Marker",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null
+    },
+    "eye-off": {
+      "name": "eye-off",
+      "key": "6af2fecb9a4cd6604e25924fe0112a659bfd1ab8",
+      "nodeId": "8:20860",
+      "importMethod": "single",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:14.615Z",
+      "page": "Fat Marker",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null
+    },
+    "cloud-download": {
+      "name": "cloud-download",
+      "key": "79d9cee762abc4fe31a78f30e57982f23577f9cc",
+      "nodeId": "8:20946",
+      "importMethod": "single",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:14.615Z",
+      "page": "Fat Marker",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null
+    },
+    "film": {
+      "name": "film",
+      "key": "827c7f6a80e5a55aa088bf3bb972772c41b4f1e9",
+      "nodeId": "8:20926",
+      "importMethod": "single",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:14.615Z",
+      "page": "Fat Marker",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null
+    },
+    "desktop-computer": {
+      "name": "desktop-computer",
+      "key": "ae6f154255c3cc91311d40ce88c7a14409ba4088",
+      "nodeId": "8:20864",
+      "importMethod": "single",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:14.615Z",
+      "page": "Fat Marker",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null
+    },
+    "chart-square-bar": {
+      "name": "chart-square-bar",
+      "key": "9655814e0e97ee7b19bb5d0643502110817c15a9",
+      "nodeId": "8:20858",
+      "importMethod": "single",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:14.615Z",
+      "page": "Fat Marker",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null
+    },
+    "play": {
+      "name": "play",
+      "key": "0c1c23c9fc93aaddb79e61176c679b2e178c0326",
+      "nodeId": "8:20846",
+      "importMethod": "single",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:14.615Z",
+      "page": "Fat Marker",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null
+    },
+    "chat-alt-2": {
+      "name": "chat-alt-2",
+      "key": "c3e3f8f29d1ac164e488581eecacdf4a35dc8c52",
+      "nodeId": "8:20866",
+      "importMethod": "single",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:14.615Z",
+      "page": "Fat Marker",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null
+    },
+    "fire": {
+      "name": "fire",
+      "key": "caefc3e84add6fcdaa9f8459b60690768545de63",
+      "nodeId": "8:20870",
+      "importMethod": "single",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:14.615Z",
+      "page": "Fat Marker",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null
+    },
+    "stop": {
+      "name": "stop",
+      "key": "cba9a1f592d6e9d6aa8325ed8849af595106b493",
+      "nodeId": "8:20868",
+      "importMethod": "single",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:14.615Z",
+      "page": "Fat Marker",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null
+    },
+    "flag": {
+      "name": "flag",
+      "key": "910a0bda4891f3f127af7570415606a10a6e3a07",
+      "nodeId": "8:20788",
+      "importMethod": "single",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:14.615Z",
+      "page": "Fat Marker",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null
+    },
+    "logout": {
+      "name": "logout",
+      "key": "912ac21ad2bbd0b1a851c0388ff2314c081912bf",
+      "nodeId": "8:20930",
+      "importMethod": "single",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:14.615Z",
+      "page": "Fat Marker",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null
+    },
+    "user": {
+      "name": "user",
+      "key": "92c15b8b5d3339b3c4b9dbdb6348ffd192b11ce8",
+      "nodeId": "8:20556",
+      "importMethod": "single",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:14.615Z",
+      "page": "Fat Marker",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null
+    },
+    "reply": {
+      "name": "reply",
+      "key": "946d9c93fd7923efcc6eaaa18961694987c39387",
+      "nodeId": "8:20816",
+      "importMethod": "single",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:14.615Z",
+      "page": "Fat Marker",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null
+    },
+    "refresh": {
+      "name": "refresh",
+      "key": "948204d63cae5237332ccaf8d6bbe43db6ef27e4",
+      "nodeId": "8:20748",
+      "importMethod": "single",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:14.615Z",
+      "page": "Fat Marker",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null
+    },
+    "paper-clip": {
+      "name": "paper-clip",
+      "key": "9518d718e98b2c914aa9b13fe852ea9dab332f4a",
+      "nodeId": "8:20688",
+      "importMethod": "single",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:14.615Z",
+      "page": "Fat Marker",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null
+    },
+    "chevron-double-left": {
+      "name": "chevron-double-left",
+      "key": "f356a11e40160574bd66e0f08428837570d8cae1",
+      "nodeId": "8:20938",
+      "importMethod": "single",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:14.615Z",
+      "page": "Fat Marker",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null
+    },
+    "chat-alt": {
+      "name": "chat-alt",
+      "key": "fe4f2ac8259f21b6e08d82a83074624959966be3",
+      "nodeId": "8:20838",
+      "importMethod": "single",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:14.615Z",
+      "page": "Fat Marker",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null
+    },
+    "cloud-upload": {
+      "name": "cloud-upload",
+      "key": "ff0e585eac58907733beb4beb1dfa70864a5e0c5",
+      "nodeId": "8:20914",
+      "importMethod": "single",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:14.615Z",
+      "page": "Fat Marker",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null
+    },
+    "users": {
+      "name": "users",
+      "key": "96b7f9cd12d5d666136d872bea222ffbe61ad791",
+      "nodeId": "8:20580",
+      "importMethod": "single",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:14.615Z",
+      "page": "Fat Marker",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null
+    },
+    "menu-alt-3": {
+      "name": "menu-alt-3",
+      "key": "970678367beff9b2a4987adbceb1dc0601648762",
+      "nodeId": "8:20606",
+      "importMethod": "single",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:14.615Z",
+      "page": "Fat Marker",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null
+    },
+    "arrow-sm-down": {
+      "name": "arrow-sm-down",
+      "key": "97113345bf096868d877c4f0741f32a3fbbade81",
+      "nodeId": "8:20986",
+      "importMethod": "single",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:14.615Z",
+      "page": "Fat Marker",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null
+    },
+    "arrow-sm-up": {
+      "name": "arrow-sm-up",
+      "key": "9b87d472b6fe30330eced0066abb5c3280387e9e",
+      "nodeId": "8:20982",
+      "importMethod": "single",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:14.615Z",
+      "page": "Fat Marker",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null
+    },
+    "cash": {
+      "name": "cash",
+      "key": "9bba8207efc842617224e30746d0d50d7a84053e",
+      "nodeId": "8:20742",
+      "importMethod": "single",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:14.615Z",
+      "page": "Fat Marker",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null
+    },
+    "zoom-out": {
+      "name": "zoom-out",
+      "key": "9c1694817d45655852d7f7ece87656ac802cad12",
+      "nodeId": "8:20710",
+      "importMethod": "single",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:14.615Z",
+      "page": "Fat Marker",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null
+    },
+    "arrow-narrow-down": {
+      "name": "arrow-narrow-down",
+      "key": "9d242dd1f262b0915e3d0b03283bd941f39cea33",
+      "nodeId": "8:20810",
+      "importMethod": "single",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:14.615Z",
+      "page": "Fat Marker",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null
+    },
+    "clock": {
+      "name": "clock",
+      "key": "a7e669733a58cffcbe85e2f1f6af3c88a937991a",
+      "nodeId": "8:20626",
+      "importMethod": "single",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:14.615Z",
+      "page": "Fat Marker",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null
+    },
+    "phone": {
+      "name": "phone",
+      "key": "a9d8039e980e4fef6e24ca115ada800f4ebaa655",
+      "nodeId": "8:20698",
+      "importMethod": "single",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:14.615Z",
+      "page": "Fat Marker",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null
+    },
+    "calendar": {
+      "name": "calendar",
+      "key": "adb7742ac4c7b658ecae580e1f49939ee11ef938",
+      "nodeId": "8:20750",
+      "importMethod": "single",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:14.615Z",
+      "page": "Fat Marker",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null
+    },
+    "currency-dollar": {
+      "name": "currency-dollar",
+      "key": "af6faa375913ee7638e9a6c4b6f9b02d3ffcd925",
+      "nodeId": "8:20550",
+      "importMethod": "single",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:14.615Z",
+      "page": "Fat Marker",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null
+    },
+    "template": {
+      "name": "template",
+      "key": "b1b96b539ed2e05ae6d694038da0dfa8d9f3d9a1",
+      "nodeId": "8:20814",
+      "importMethod": "single",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:14.615Z",
+      "page": "Fat Marker",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null
+    },
+    "external-link": {
+      "name": "external-link",
+      "key": "b28d3f892ad7140fde614f53c8cb26a5fb5eb0ee",
+      "nodeId": "8:20778",
+      "importMethod": "single",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:14.615Z",
+      "page": "Fat Marker",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null
+    },
+    "color-swatch": {
+      "name": "color-swatch",
+      "key": "b7a5c246d4557d4f2bf4f092144a5b80237539ad",
+      "nodeId": "8:20534",
+      "importMethod": "single",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:14.615Z",
+      "page": "Fat Marker",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null
+    },
+    "view-grid": {
+      "name": "view-grid",
+      "key": "b862308a97b84b9d3359dd44324a098d28628fcc",
+      "nodeId": "8:20798",
+      "importMethod": "single",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:14.615Z",
+      "page": "Fat Marker",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null
+    },
+    "briefcase": {
+      "name": "briefcase",
+      "key": "ba24134a55744773e55c841ad48eacb6dd978664",
+      "nodeId": "8:20600",
+      "importMethod": "single",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:14.615Z",
+      "page": "Fat Marker",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null
+    },
+    "user-circle": {
+      "name": "user-circle",
+      "key": "ba371402933b358da37964155d5a5ba016711ac9",
+      "nodeId": "8:20662",
+      "importMethod": "single",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:14.615Z",
+      "page": "Fat Marker",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null
+    },
+    "chat": {
+      "name": "chat",
+      "key": "bbd47a7d4a8704fd4485493b9902d68970b9fd94",
+      "nodeId": "8:20552",
+      "importMethod": "single",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:14.615Z",
+      "page": "Fat Marker",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null
+    },
+    "qrcode": {
+      "name": "qrcode",
+      "key": "bcc0a03a0d089e3619e66f44df8503ff3c5c052b",
+      "nodeId": "8:20692",
+      "importMethod": "single",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:14.615Z",
+      "page": "Fat Marker",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null
+    },
+    "cog": {
+      "name": "cog",
+      "key": "bdb4e15137948fc72d2f858bd71b9d1cad091ff1",
+      "nodeId": "8:20670",
+      "importMethod": "single",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:14.615Z",
+      "page": "Fat Marker",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null
+    },
+    "key": {
+      "name": "key",
+      "key": "bdbdff8b379319a06f6a19b250053e079ef9fc8e",
+      "nodeId": "8:20826",
+      "importMethod": "single",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:14.615Z",
+      "page": "Fat Marker",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null
+    },
+    "upload": {
+      "name": "upload",
+      "key": "beb7400c282a76227c3605ed1e27418203ea128e",
+      "nodeId": "8:20594",
+      "importMethod": "single",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:14.615Z",
+      "page": "Fat Marker",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null
+    },
+    "cursor-click": {
+      "name": "cursor-click",
+      "key": "bf827859454ea59dbd42b902bfe4698659984d87",
+      "nodeId": "8:20824",
+      "importMethod": "single",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:14.615Z",
+      "page": "Fat Marker",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null
+    },
+    "document-remove": {
+      "name": "document-remove",
+      "key": "bf92bd5919897038d708bba5df27085eb091154b",
+      "nodeId": "8:20726",
+      "importMethod": "single",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:14.615Z",
+      "page": "Fat Marker",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null
+    },
+    "strikethrough": {
+      "name": "strikethrough",
+      "key": "c057531cbb378582472a00ec853ce195a67653fa",
+      "nodeId": "8:20996",
+      "importMethod": "single",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:14.615Z",
+      "page": "Fat Marker",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null
+    },
+    "eye": {
+      "name": "eye",
+      "key": "c1f9f7a550ed686f3abf9d75d13feeafad0302d7",
+      "nodeId": "8:20720",
+      "importMethod": "single",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:14.615Z",
+      "page": "Fat Marker",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null
+    },
+    "office-building": {
+      "name": "office-building",
+      "key": "c3d255b415093cbef924af2f068c0bc3c7c396da",
+      "nodeId": "8:20624",
+      "importMethod": "single",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:14.615Z",
+      "page": "Fat Marker",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null
+    },
+    "speakerphone": {
+      "name": "speakerphone",
+      "key": "00c5456a3ebf1b03ba2541a3793fd7a9bf580655",
+      "nodeId": "8:20834",
+      "importMethod": "single",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:14.615Z",
+      "page": "Fat Marker",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null
+    },
+    "switch-horizontal": {
+      "name": "switch-horizontal",
+      "key": "03c9359d98be7cf85dc08d23a78466c366507a9e",
+      "nodeId": "8:20676",
+      "importMethod": "single",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:14.615Z",
+      "page": "Fat Marker",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null
+    },
+    "plus-sm": {
+      "name": "plus-sm",
+      "key": "043aa623ab736925095a8ec379a1ffaa3144b2c6",
+      "nodeId": "8:20958",
+      "importMethod": "single",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:14.615Z",
+      "page": "Fat Marker",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null
+    },
+    "filter": {
+      "name": "filter",
+      "key": "0449b597665bda8f401595df36232b6e7665a28a",
+      "nodeId": "8:20682",
+      "importMethod": "single",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:14.615Z",
+      "page": "Fat Marker",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null
+    },
+    "mail": {
+      "name": "mail",
+      "key": "04a09a5c924eee871df579a56443bcaf8c92b893",
+      "nodeId": "8:20530",
+      "importMethod": "single",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:14.615Z",
+      "page": "Fat Marker",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null
+    },
+    "currency-yen": {
+      "name": "currency-yen",
+      "key": "056815dc8cb1a459ddc94022dc97f0680ac7d508",
+      "nodeId": "8:20574",
+      "importMethod": "single",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:14.615Z",
+      "page": "Fat Marker",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null
+    },
+    "thumb-up": {
+      "name": "thumb-up",
+      "key": "08ab4c6aec9ccf87199a772b88a5bffa0fb662d0",
+      "nodeId": "8:20874",
+      "importMethod": "single",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:14.615Z",
+      "page": "Fat Marker",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null
+    },
+    "academic-cap": {
+      "name": "academic-cap",
+      "key": "08df4256b82862fe1ed5060d5c62a2229235b7de",
+      "nodeId": "8:20772",
+      "importMethod": "single",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:14.615Z",
+      "page": "Fat Marker",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null
+    },
+    "trending-up": {
+      "name": "trending-up",
+      "key": "09225cf29d2b7ad55057097fe3e9ca13cbdeb8ea",
+      "nodeId": "8:20634",
+      "importMethod": "single",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:14.615Z",
+      "page": "Fat Marker",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null
+    },
+    "dots-circle-horizontal": {
+      "name": "dots-circle-horizontal",
+      "key": "0b67aa3565b8c024e80c5b42e156bfaa43ab9f0b",
+      "nodeId": "8:20644",
+      "importMethod": "single",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:14.615Z",
+      "page": "Fat Marker",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null
+    },
+    "minus": {
+      "name": "minus",
+      "key": "0bd5d7938cf6bd7201ab962c6bb3fb6591ad9455",
+      "nodeId": "8:20980",
+      "importMethod": "single",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:14.615Z",
+      "page": "Fat Marker",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null
+    },
+    "google-header": {
+      "name": "Google_Header",
+      "key": "0d7ad22ff52dfd1ebf3ef099e3dd573e99ac7020",
+      "nodeId": "215:3048",
+      "importMethod": "single",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:14.615Z",
+      "page": "Fat Marker",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null
+    },
+    "home": {
+      "name": "home",
+      "key": "0ea0c8b22d91bbcb0661252163fa3a92b0260ac3",
+      "nodeId": "8:20578",
+      "importMethod": "single",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:14.615Z",
+      "page": "Fat Marker",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null
+    },
+    "information-circle": {
+      "name": "information-circle",
+      "key": "105a9635352f4fc1c6adc4420e0085ee270646a2",
+      "nodeId": "8:20754",
+      "importMethod": "single",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:14.615Z",
+      "page": "Fat Marker",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null
+    },
+    "finger-print": {
+      "name": "finger-print",
+      "key": "106d3e9022c79c422af90d60d5d44e5c5d507b24",
+      "nodeId": "8:20942",
+      "importMethod": "single",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:14.615Z",
+      "page": "Fat Marker",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null
+    },
+    "switch-vertical": {
+      "name": "switch-vertical",
+      "key": "10de843dd54d5a5d0879c24650bd1374fae01586",
+      "nodeId": "8:20652",
+      "importMethod": "single",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:14.615Z",
+      "page": "Fat Marker",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null
+    },
+    "lock-closed": {
+      "name": "lock-closed",
+      "key": "12cd7b0b05b53e8a847e795a660cde673159eebd",
+      "nodeId": "8:20610",
+      "importMethod": "single",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:14.615Z",
+      "page": "Fat Marker",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null
+    },
+    "document-search": {
+      "name": "document-search",
+      "key": "1345daf219d7250ccf6211a98d74fe259f6442e3",
+      "nodeId": "8:20768",
+      "importMethod": "single",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:14.615Z",
+      "page": "Fat Marker",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null
+    },
+    "lightning-bolt": {
+      "name": "lightning-bolt",
+      "key": "14bae24b81e91dbc154eb178fe7847ac18f1b3cf",
+      "nodeId": "8:20796",
+      "importMethod": "single",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:14.615Z",
+      "page": "Fat Marker",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null
+    },
+    "icon-user-remove": {
+      "name": "icon-user-remove",
+      "key": "17b417685386f77cfff735af376f190c86e5a558",
+      "nodeId": "8:20804",
+      "importMethod": "single",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:14.615Z",
+      "page": "Fat Marker",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null
+    },
+    "location-marker": {
+      "name": "location-marker",
+      "key": "18d5de7bcb0a1558f315fbfe87d4ce6118f4d4aa",
+      "nodeId": "8:20532",
+      "importMethod": "single",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:14.615Z",
+      "page": "Fat Marker",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null
+    },
+    "x-circle": {
+      "name": "x-circle",
+      "key": "1aadab81934ff2be04d5dda216da8fb62dfeb794",
+      "nodeId": "8:20546",
+      "importMethod": "single",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:14.615Z",
+      "page": "Fat Marker",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null
+    },
+    "code": {
+      "name": "code",
+      "key": "1b6b8613ee1a71484eacf1e759dd261dbe64c0ac",
+      "nodeId": "8:20794",
+      "importMethod": "single",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:14.615Z",
+      "page": "Fat Marker",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null
+    },
+    "pencil": {
+      "name": "pencil",
+      "key": "1d9b83d0801f40837e65a30bb854d34afd4fc772",
+      "nodeId": "8:20696",
+      "importMethod": "single",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:14.615Z",
+      "page": "Fat Marker",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null
+    },
+    "chevron-double-right": {
+      "name": "chevron-double-right",
+      "key": "1f3f98fe57af44ec3bbaf68217c3cf715fcdd6bc",
+      "nodeId": "8:20934",
+      "importMethod": "single",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:14.615Z",
+      "page": "Fat Marker",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null
+    },
+    "heart": {
+      "name": "heart",
+      "key": "1f9b82c54410262929d294fa4d0ce4ef7536d52c",
+      "nodeId": "8:20632",
+      "importMethod": "single",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:14.615Z",
+      "page": "Fat Marker",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null
+    },
+    "rewind": {
+      "name": "rewind",
+      "key": "21a20d82395fdc76bb15b3bccc9f19bcd63fa634",
+      "nodeId": "8:20972",
+      "importMethod": "single",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:14.615Z",
+      "page": "Fat Marker",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null
+    },
+    "badge-check": {
+      "name": "badge-check",
+      "key": "236cf8fdcf652270091cf22a50314ab868b61f88",
+      "nodeId": "8:20822",
+      "importMethod": "single",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:14.615Z",
+      "page": "Fat Marker",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null
+    },
+    "clipboard-copy": {
+      "name": "clipboard-copy",
+      "key": "24a5beb473b3b10ba0c2b3073b14922ff1b10f66",
+      "nodeId": "8:20784",
+      "importMethod": "single",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:14.615Z",
+      "page": "Fat Marker",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null
+    },
+    "collection": {
+      "name": "collection",
+      "key": "24c41081173566c375d6a0fee623e7f32573529a",
+      "nodeId": "8:20790",
+      "importMethod": "single",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:14.615Z",
+      "page": "Fat Marker",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null
+    },
+    "question-mark-circle": {
+      "name": "question-mark-circle",
+      "key": "2593f314f2a1c4abd777388b48aaefc5d1e56380",
+      "nodeId": "8:20538",
+      "importMethod": "single",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:14.615Z",
+      "page": "Fat Marker",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null
+    },
+    "x": {
+      "name": "x",
+      "key": "260eb1007dc06d0000fdec676d7052ff01676aac",
+      "nodeId": "8:20700",
+      "importMethod": "single",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:14.615Z",
+      "page": "Fat Marker",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null
+    },
+    "book-open": {
+      "name": "book-open",
+      "key": "276871b2bbde45a48c74c148de0cb25333136f97",
+      "nodeId": "8:20792",
+      "importMethod": "single",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:14.615Z",
+      "page": "Fat Marker",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null
+    },
+    "download": {
+      "name": "download",
+      "key": "2819d114035f7eb35e689f7b6e85b2f0889b312e",
+      "nodeId": "8:20616",
+      "importMethod": "single",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:14.615Z",
+      "page": "Fat Marker",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null
+    },
+    "folder-open": {
+      "name": "folder-open",
+      "key": "2b73ed76a1ac2745707ef20a5735f031565a97b9",
+      "nodeId": "8:20948",
+      "importMethod": "single",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:14.615Z",
+      "page": "Fat Marker",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null
+    },
+    "variable": {
+      "name": "variable",
+      "key": "2e07718d6f456a80adf85ede2edf4c819760687a",
+      "nodeId": "8:20774",
+      "importMethod": "single",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:14.615Z",
+      "page": "Fat Marker",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null
+    },
+    "chevron-right": {
+      "name": "chevron-right",
+      "key": "2e15005164c387a95398ceef380c9114ef2cb3da",
+      "nodeId": "8:20690",
+      "importMethod": "single",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:14.615Z",
+      "page": "Fat Marker",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null
+    },
+    "music-note": {
+      "name": "music-note",
+      "key": "2f9528878b47af24203ed9ecd05b6263d193a852",
+      "nodeId": "8:20924",
+      "importMethod": "single",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:14.615Z",
+      "page": "Fat Marker",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null
+    },
+    "tag": {
+      "name": "tag",
+      "key": "30214723889333e0c3577001802a75cab6230ee4",
+      "nodeId": "8:20674",
+      "importMethod": "single",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:14.615Z",
+      "page": "Fat Marker",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null
+    },
+    "arrows-expand": {
+      "name": "arrows-expand",
+      "key": "304ad4757a346e17d39e2d4ccad4085e15e0752b",
+      "nodeId": "8:20880",
+      "importMethod": "single",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:14.615Z",
+      "page": "Fat Marker",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null
+    },
+    "database": {
+      "name": "database",
+      "key": "3336f030a7ef858da5b96be9582608a58b9da993",
+      "nodeId": "8:20928",
+      "importMethod": "single",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:14.615Z",
+      "page": "Fat Marker",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null
+    },
+    "arrow-left": {
+      "name": "arrow-left",
+      "key": "3868ffb411d9a9f0fd00230eeb1482b428522ea5",
+      "nodeId": "8:20612",
+      "importMethod": "single",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:14.615Z",
+      "page": "Fat Marker",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null
+    },
+    "user-add": {
+      "name": "user-add",
+      "key": "38b7904183440b8932f5afcd89ccbfdfdf493667",
+      "nodeId": "8:20758",
+      "importMethod": "single",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:14.615Z",
+      "page": "Fat Marker",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null
+    },
+    "exclamation-circle": {
+      "name": "exclamation-circle",
+      "key": "38e3770a47eb6184fb833bdabc2c4ad93bc11926",
+      "nodeId": "8:20592",
+      "importMethod": "single",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:14.615Z",
+      "page": "Fat Marker",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null
+    },
+    "inbox-in": {
+      "name": "inbox-in",
+      "key": "3ab2f2e563aa85773b6473845aac389213f694d0",
+      "nodeId": "8:20582",
+      "importMethod": "single",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:14.615Z",
+      "page": "Fat Marker",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null
+    },
+    "camera": {
+      "name": "camera",
+      "key": "3b1fc1c5a163f45dedb3420804936f9327797b5d",
+      "nodeId": "8:20540",
+      "importMethod": "single",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:14.615Z",
+      "page": "Fat Marker",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null
+    },
+    "arrow-right": {
+      "name": "arrow-right",
+      "key": "3ce2cdaa578b18ede460afa16390bf632ee94974",
+      "nodeId": "8:20568",
+      "importMethod": "single",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:14.615Z",
+      "page": "Fat Marker",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null
+    },
+    "pencil-alt": {
+      "name": "pencil-alt",
+      "key": "3cfe54d264adbf31a3073dff96c0f11972f3122a",
+      "nodeId": "8:20672",
+      "importMethod": "single",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:14.615Z",
+      "page": "Fat Marker",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null
+    },
+    "view-list": {
+      "name": "view-list",
+      "key": "3f112180c5592ce118f1c07a5ba12f60b8260056",
+      "nodeId": "8:20640",
+      "importMethod": "single",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:14.615Z",
+      "page": "Fat Marker",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null
+    },
+    "dots-vertical": {
+      "name": "dots-vertical",
+      "key": "40f7f83bf5da3d1199eb154ecf625eacf9ffe769",
+      "nodeId": "8:20572",
+      "importMethod": "single",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:14.615Z",
+      "page": "Fat Marker",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null
+    },
+    "document-report": {
+      "name": "document-report",
+      "key": "4423cc4226377eaec47ceab908732e2e4247aba1",
+      "nodeId": "8:20830",
+      "importMethod": "single",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:14.615Z",
+      "page": "Fat Marker",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null
+    },
+    "chip": {
+      "name": "chip",
+      "key": "46e1d850eb03fab2ca309096473ec6a1827e554d",
+      "nodeId": "8:20770",
+      "importMethod": "single",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:14.615Z",
+      "page": "Fat Marker",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null
+    },
+    "cube-transparent": {
+      "name": "cube-transparent",
+      "key": "47dabb7ccfa800a612be6075a295f587cd0337bc",
+      "nodeId": "8:20776",
+      "importMethod": "single",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:14.615Z",
+      "page": "Fat Marker",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null
+    },
+    "plus": {
+      "name": "plus",
+      "key": "4c17b84bc808e0b29079ec9386631ec9df17b51a",
+      "nodeId": "8:20724",
+      "importMethod": "single",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:14.615Z",
+      "page": "Fat Marker",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null
+    },
+    "arrow-down": {
+      "name": "arrow-down",
+      "key": "4caaf6d49061d720b9b70805aabd1a74d0716d4d",
+      "nodeId": "8:20590",
+      "importMethod": "single",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:14.615Z",
+      "page": "Fat Marker",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null
+    },
+    "shopping-cart": {
+      "name": "shopping-cart",
+      "key": "4d98d3a39ddb7bc611966dbfbed9083643467724",
+      "nodeId": "8:20820",
+      "importMethod": "single",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:14.615Z",
+      "page": "Fat Marker",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null
+    },
+    "check": {
+      "name": "check",
+      "key": "4df0c4d6f2256edd2ef5bd830d904bc0ac41c948",
+      "nodeId": "8:20694",
+      "importMethod": "single",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:14.615Z",
+      "page": "Fat Marker",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null
+    },
+    "credit-card": {
+      "name": "credit-card",
+      "key": "516f591c2ea64e2fe8063b21bc937ad8062f5250",
+      "nodeId": "8:20588",
+      "importMethod": "single",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:14.615Z",
+      "page": "Fat Marker",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null
+    },
+    "hashtag": {
+      "name": "hashtag",
+      "key": "52cb557b772169c2406640d253025f6d00539b8f",
+      "nodeId": "8:20668",
+      "importMethod": "single",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:14.615Z",
+      "page": "Fat Marker",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null
+    },
+    "menu": {
+      "name": "menu",
+      "key": "538cacc62e4f1edb74a5443fdc10ef57bf1d6fd4",
+      "nodeId": "8:20536",
+      "importMethod": "single",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:14.615Z",
+      "page": "Fat Marker",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null
+    },
+    "menu-alt-4": {
+      "name": "menu-alt-4",
+      "key": "54cd3077ffb0c96ebb2e3ce2250ebdbbccbbbb69",
+      "nodeId": "8:20628",
+      "importMethod": "single",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:14.615Z",
+      "page": "Fat Marker",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null
+    },
+    "menu-alt-1": {
+      "name": "menu-alt-1",
+      "key": "57a1650fa276027013e9ec9c770a9a8f14914d88",
+      "nodeId": "8:20560",
+      "importMethod": "single",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:14.615Z",
+      "page": "Fat Marker",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null
+    },
+    "bookmark": {
+      "name": "bookmark",
+      "key": "59a3e119cad541e627d1b7099cb60998c254fde5",
+      "nodeId": "8:20744",
+      "importMethod": "single",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:14.615Z",
+      "page": "Fat Marker",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null
+    },
+    "annotation": {
+      "name": "annotation",
+      "key": "5ada979cc5ca39ce69e5360b0bdf643873620978",
+      "nodeId": "8:20786",
+      "importMethod": "single",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:14.615Z",
+      "page": "Fat Marker",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null
+    },
+    "receipt-refund": {
+      "name": "receipt-refund",
+      "key": "5bbf1fd89e44f6d1e48d05a570d907134cf7b40d",
+      "nodeId": "8:20576",
+      "importMethod": "single",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:14.615Z",
+      "page": "Fat Marker",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null
+    },
+    "fm-user": {
+      "name": "FM User",
+      "key": "5c1b3d8d00056075c833799200d3cc27b6d915f0",
+      "nodeId": "70:1783",
+      "importMethod": "single",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:14.615Z",
+      "page": "Fat Marker",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null
+    },
+    "bold": {
+      "name": "bold",
+      "key": "5dcdbd5689926487b45448b7de31cefe98719d81",
+      "nodeId": "8:20992",
+      "importMethod": "single",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:14.615Z",
+      "page": "Fat Marker",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null
+    },
+    "volume-up": {
+      "name": "volume-up",
+      "key": "6006211edd13c5bb409837e4d8de3e291e247662",
+      "nodeId": "8:20680",
+      "importMethod": "single",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:14.615Z",
+      "page": "Fat Marker",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null
+    },
+    "arrow-sm-right": {
+      "name": "arrow-sm-right",
+      "key": "60b65e9a8385abecff08cdfd13e57b4ba87cc212",
+      "nodeId": "8:20984",
+      "importMethod": "single",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:14.615Z",
+      "page": "Fat Marker",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null
+    },
+    "globe-alt": {
+      "name": "globe-alt",
+      "key": "61e92649d84acbfba80b2fc7587cf44cf5758b87",
+      "nodeId": "8:20564",
+      "importMethod": "single",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:14.615Z",
+      "page": "Fat Marker",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null
+    },
+    "player-volume": {
+      "name": "player-volume",
+      "key": "61ff3c92915956f97f2c954abaf7d087895a9934",
+      "nodeId": "8:21016",
+      "importMethod": "single",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:14.615Z",
+      "page": "Fat Marker",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null
+    },
+    "clipboard-check": {
+      "name": "clipboard-check",
+      "key": "62a826a2c14ed329327922d32095badc420d7c5c",
+      "nodeId": "8:20716",
+      "importMethod": "single",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:14.615Z",
+      "page": "Fat Marker",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null
+    },
+    "trending-down": {
+      "name": "trending-down",
+      "key": "631f118a8d3b647c0e1fc361fc7376156feb732d",
+      "nodeId": "8:20658",
+      "importMethod": "single",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:14.615Z",
+      "page": "Fat Marker",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null
+    },
+    "arrow-narrow-left": {
+      "name": "arrow-narrow-left",
+      "key": "648baa9becc2449e4cc0242fc46434346682d407",
+      "nodeId": "8:20812",
+      "importMethod": "single",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:14.615Z",
+      "page": "Fat Marker",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null
+    },
+    "truck": {
+      "name": "truck",
+      "key": "672a9db6a1fcc70796e4815da11d81f0eefee65a",
+      "nodeId": "8:20904",
+      "importMethod": "single",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:14.615Z",
+      "page": "Fat Marker",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null
+    },
+    "currency-euro": {
+      "name": "currency-euro",
+      "key": "6cce75bed5ae5854e74b4d2e4f7c842a0c4c29b9",
+      "nodeId": "8:20596",
+      "importMethod": "single",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:14.615Z",
+      "page": "Fat Marker",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null
+    },
+    "translate": {
+      "name": "translate",
+      "key": "6cdd2a9e8f1ab31513512a785c471a795e59e57c",
+      "nodeId": "8:20718",
+      "importMethod": "single",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:14.615Z",
+      "page": "Fat Marker",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null
+    },
+    "chevron-left": {
+      "name": "chevron-left",
+      "key": "6d33856c56d2a74fc8f0d304183ed3c874b9bae4",
+      "nodeId": "8:20738",
+      "importMethod": "single",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:14.615Z",
+      "page": "Fat Marker",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null
+    },
+    "folder": {
+      "name": "folder",
+      "key": "6dc4c220719f73ba6f9e3e558899c5135afb67eb",
+      "nodeId": "8:20800",
+      "importMethod": "single",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:14.615Z",
+      "page": "Fat Marker",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null
+    },
+    "sort-ascending": {
+      "name": "sort-ascending",
+      "key": "6e6e358c72cddede4be188726a3bed67e677643f",
+      "nodeId": "8:20732",
+      "importMethod": "single",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:14.615Z",
+      "page": "Fat Marker",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null
+    },
+    "search": {
+      "name": "search",
+      "key": "701934d562bb22fd53b60a54ad8d7e9465d93daa",
+      "nodeId": "8:20734",
+      "importMethod": "single",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:14.615Z",
+      "page": "Fat Marker",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null
+    },
+    "globe": {
+      "name": "globe",
+      "key": "72d228be50f33d06cf90b9a00f34bf3bb298e7b8",
+      "nodeId": "8:20656",
+      "importMethod": "single",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:14.615Z",
+      "page": "Fat Marker",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null
+    },
+    "shopping-bag": {
+      "name": "shopping-bag",
+      "key": "733d7a986c4f34d527c72ca0cb2b1d33a31a8f1a",
+      "nodeId": "8:20872",
+      "importMethod": "single",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:14.615Z",
+      "page": "Fat Marker",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null
+    },
+    "chevron-up": {
+      "name": "chevron-up",
+      "key": "73975e9ee4c3a21b836ec6e03512cc0bc791e609",
+      "nodeId": "8:20714",
+      "importMethod": "single",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:14.615Z",
+      "page": "Fat Marker",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null
+    },
+    "save-as": {
+      "name": "save-as",
+      "key": "73e3e3a406fe2778e69d71c4d24db5638a66cfa8",
+      "nodeId": "8:20952",
+      "importMethod": "single",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:14.615Z",
+      "page": "Fat Marker",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null
+    },
+    "comment-box": {
+      "name": "Comment box",
+      "key": "74c07863dc054e1c7c7e80e7419de2989f5ac504",
+      "nodeId": "2:18929",
+      "importMethod": "single",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:14.615Z",
+      "page": "Fat Marker",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null
+    },
+    "trash": {
+      "name": "trash",
+      "key": "74e59094d4c999fad9159ed3514d0332be4775e6",
+      "nodeId": "8:20730",
+      "importMethod": "single",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:14.615Z",
+      "page": "Fat Marker",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null
+    },
+    "arrow-circle-left": {
+      "name": "arrow-circle-left",
+      "key": "7803245348c3d55cb08ba2e064f5c2ef9297d97f",
+      "nodeId": "8:20684",
+      "importMethod": "single",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:14.615Z",
+      "page": "Fat Marker",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null
+    },
+    "link": {
+      "name": "link",
+      "key": "7872167802b0cd319d07484e7ac222d6ef905937",
+      "nodeId": "8:20752",
+      "importMethod": "single",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:14.615Z",
+      "page": "Fat Marker",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null
+    },
+    "rss": {
+      "name": "rss",
+      "key": "79ed17661f8bd9f2c7ae6ede404dc6ca4f2a48d5",
+      "nodeId": "8:20912",
+      "importMethod": "single",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:14.615Z",
+      "page": "Fat Marker",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null
+    },
+    "phone-incoming": {
+      "name": "phone-incoming",
+      "key": "7aa8cc4eb8663595e8350465e1d9d3eef87cead5",
+      "nodeId": "8:20746",
+      "importMethod": "single",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:14.615Z",
+      "page": "Fat Marker",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null
+    },
+    "plus-circle": {
+      "name": "plus-circle",
+      "key": "7ba60dcd73edb9d6af19bb866c6fa00b791ae543",
+      "nodeId": "8:20614",
+      "importMethod": "single",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:14.615Z",
+      "page": "Fat Marker",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null
+    },
+    "folder-add": {
+      "name": "folder-add",
+      "key": "7cd9f77c8fb421c28e5722b54eee4a1861f8afde",
+      "nodeId": "8:20886",
+      "importMethod": "single",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:14.615Z",
+      "page": "Fat Marker",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null
+    },
+    "document": {
+      "name": "document",
+      "key": "7d02de8d798242b895e53dbdd74484b3e950c7b3",
+      "nodeId": "8:20654",
+      "importMethod": "single",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:14.615Z",
+      "page": "Fat Marker",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null
+    },
+    "currency-rupee": {
+      "name": "currency-rupee",
+      "key": "7d13085da6a568cc87cd696bea7d1ef2bbf5ef31",
+      "nodeId": "8:20642",
+      "importMethod": "single",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:14.615Z",
+      "page": "Fat Marker",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null
+    },
+    "folder-remove": {
+      "name": "folder-remove",
+      "key": "7e61248f29fcff84c1721f2a74b2f3068b567e27",
+      "nodeId": "8:20888",
+      "importMethod": "single",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:14.615Z",
+      "page": "Fat Marker",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null
+    },
+    "minus-circle": {
+      "name": "minus-circle",
+      "key": "7f2021efb6a8779e8e50875b0d9d410f8d860101",
+      "nodeId": "8:20638",
+      "importMethod": "single",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:14.615Z",
+      "page": "Fat Marker",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null
+    },
+    "folder-download": {
+      "name": "folder-download",
+      "key": "7f53a7bb837c223d32bfc05badad37a6e9e49223",
+      "nodeId": "8:20884",
+      "importMethod": "single",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:14.615Z",
+      "page": "Fat Marker",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null
+    },
+    "menu-alt-2": {
+      "name": "menu-alt-2",
+      "key": "80d8ab0ae5eb4b99708994aba332ba345b442ed3",
+      "nodeId": "8:20584",
+      "importMethod": "single",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:14.615Z",
+      "page": "Fat Marker",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null
+    },
+    "duplicate": {
+      "name": "duplicate",
+      "key": "81e310930e27171aa7fdcb3377a0a89ad1b0585d",
+      "nodeId": "8:20586",
+      "importMethod": "single",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:14.615Z",
+      "page": "Fat Marker",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null
+    },
+    "moon": {
+      "name": "moon",
+      "key": "8299b94bfc00da69c1f3bac9f75734f10ebeccc2",
+      "nodeId": "8:20782",
+      "importMethod": "single",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:14.615Z",
+      "page": "Fat Marker",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null
+    },
+    "ban": {
+      "name": "ban",
+      "key": "83d9725faef668ffd72618135296bc1515c093c0",
+      "nodeId": "8:20836",
+      "importMethod": "single",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:14.615Z",
+      "page": "Fat Marker",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null
+    },
+    "emoji-sad": {
+      "name": "emoji-sad",
+      "key": "84d9103695d5cfbbf0d0dcb3e33433667569e21b",
+      "nodeId": "8:20736",
+      "importMethod": "single",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:14.615Z",
+      "page": "Fat Marker",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null
+    },
+    "scissors": {
+      "name": "scissors",
+      "key": "8624e5b7b865b36ee6dbf585cd82c41c9140bed0",
+      "nodeId": "8:20916",
+      "importMethod": "single",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:14.615Z",
+      "page": "Fat Marker",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null
+    },
+    "check-circle": {
+      "name": "check-circle",
+      "key": "88905479981e196c1c0074246c5a386863a9e836",
+      "nodeId": "8:20570",
+      "importMethod": "single",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:14.615Z",
+      "page": "Fat Marker",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null
+    },
+    "zoom-in": {
+      "name": "zoom-in",
+      "key": "892c8274c8e034ceeaae7796893a65b359eee91c",
+      "nodeId": "8:20686",
+      "importMethod": "single",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:14.615Z",
+      "page": "Fat Marker",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null
+    },
+    "chevron-double-down": {
+      "name": "chevron-double-down",
+      "key": "c442012861fd3a81b78a221c888443f23ae8dbfb",
+      "nodeId": "8:20936",
+      "importMethod": "single",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:14.615Z",
+      "page": "Fat Marker",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null
+    },
+    "ticket": {
+      "name": "ticket",
+      "key": "c57db96f5421ca91883911eae635663c3fba3fa2",
+      "nodeId": "8:20598",
+      "importMethod": "single",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:14.615Z",
+      "page": "Fat Marker",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null
+    },
+    "arrow-circle-up": {
+      "name": "arrow-circle-up",
+      "key": "c9b3dfa3450f2e9d3fd756082e37d71e19f58e44",
+      "nodeId": "8:20708",
+      "importMethod": "single",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:14.615Z",
+      "page": "Fat Marker",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null
+    },
+    "arrow-narrow-right": {
+      "name": "arrow-narrow-right",
+      "key": "cb38e940aa88c1b113a1e95e599b321916dded6e",
+      "nodeId": "8:20808",
+      "importMethod": "single",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:14.615Z",
+      "page": "Fat Marker",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null
+    },
+    "photograph": {
+      "name": "photograph",
+      "key": "cba627b8ce861ceb176023006448cbc8a72b0e47",
+      "nodeId": "8:20650",
+      "importMethod": "single",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:14.615Z",
+      "page": "Fat Marker",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null
+    },
+    "server": {
+      "name": "server",
+      "key": "ce859148112c848c5510dd46daba8a8c41db2aee",
+      "nodeId": "8:20950",
+      "importMethod": "single",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:14.615Z",
+      "page": "Fat Marker",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null
+    },
+    "bell": {
+      "name": "bell",
+      "key": "d0f801aea8343ef59cc61c707579206e4c9f9bd8",
+      "nodeId": "8:20554",
+      "importMethod": "single",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:14.615Z",
+      "page": "Fat Marker",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null
+    },
+    "phone-missed-call": {
+      "name": "phone-missed-call",
+      "key": "d1a37b2c04106e9e7964b6d35444d3191c0b0e94",
+      "nodeId": "8:20956",
+      "importMethod": "single",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:14.615Z",
+      "page": "Fat Marker",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null
+    },
+    "minus-sm": {
+      "name": "minus-sm",
+      "key": "d2c2682f5311568aafb8437f33d2f471beeabf2f",
+      "nodeId": "8:20960",
+      "importMethod": "single",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:14.615Z",
+      "page": "Fat Marker",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null
+    },
+    "receipt-tax": {
+      "name": "receipt-tax",
+      "key": "d34b760ac7807956ada7ba824b41a0d530aa128c",
+      "nodeId": "8:20968",
+      "importMethod": "single",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:14.615Z",
+      "page": "Fat Marker",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null
+    },
+    "arrow-circle-down": {
+      "name": "arrow-circle-down",
+      "key": "d37f160587cf3b014e4640c8ae506496775edd93",
+      "nodeId": "8:20660",
+      "importMethod": "single",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:14.615Z",
+      "page": "Fat Marker",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null
+    },
+    "table": {
+      "name": "table",
+      "key": "d4ca563cb546fc1c8727358c67289b945eb86eed",
+      "nodeId": "8:20892",
+      "importMethod": "single",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:14.615Z",
+      "page": "Fat Marker",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null
+    },
+    "chart-pie": {
+      "name": "chart-pie",
+      "key": "d53df90928900dca8a0dece510ebad1335b52d63",
+      "nodeId": "8:20630",
+      "importMethod": "single",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:14.615Z",
+      "page": "Fat Marker",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null
+    },
+    "selector": {
+      "name": "selector",
+      "key": "d7ef1b77aba03f327b6e45fc04ec8bc91c704956",
+      "nodeId": "8:20762",
+      "importMethod": "single",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:14.615Z",
+      "page": "Fat Marker",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null
+    },
+    "volume-off": {
+      "name": "volume-off",
+      "key": "da813a11bc107aef2ecea25ca903d035e0373a80",
+      "nodeId": "8:20704",
+      "importMethod": "single",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:14.615Z",
+      "page": "Fat Marker",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null
+    },
+    "scale": {
+      "name": "scale",
+      "key": "daa13476a5c48e10fe6a9641e60e9c8584809913",
+      "nodeId": "8:20648",
+      "importMethod": "single",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:14.615Z",
+      "page": "Fat Marker",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null
+    },
+    "at-symbol": {
+      "name": "at-symbol",
+      "key": "dbe1c6463a6dfe12a0c4a578831a1feac992d78c",
+      "nodeId": "8:20706",
+      "importMethod": "single",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:14.615Z",
+      "page": "Fat Marker",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null
+    },
+    "italic": {
+      "name": "italic",
+      "key": "dd2ba10beb4361ced5bcabdf44535ffffa83e65a",
+      "nodeId": "8:20994",
+      "importMethod": "single",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:14.615Z",
+      "page": "Fat Marker",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null
+    },
+    "arrow-up": {
+      "name": "arrow-up",
+      "key": "de570a3d693466f8314750901d629799f27d2eb6",
+      "nodeId": "8:20544",
+      "importMethod": "single",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:14.615Z",
+      "page": "Fat Marker",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null
+    },
+    "clipboard-list": {
+      "name": "clipboard-list",
+      "key": "dee2c29b93ecee18733adc073581e329e0f3752f",
+      "nodeId": "8:20740",
+      "importMethod": "single",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:14.615Z",
+      "page": "Fat Marker",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null
+    },
+    "shield-exclamation": {
+      "name": "shield-exclamation",
+      "key": "df78b1916f71b9f1e353a6ccd0cc970e66e091a4",
+      "nodeId": "8:20646",
+      "importMethod": "single",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:14.615Z",
+      "page": "Fat Marker",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null
+    },
+    "mail-open": {
+      "name": "mail-open",
+      "key": "e1658da87c5bccafd17ab450d0cc4f4266a392dc",
+      "nodeId": "8:20542",
+      "importMethod": "single",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:14.615Z",
+      "page": "Fat Marker",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null
+    },
+    "lock-open": {
+      "name": "lock-open",
+      "key": "e5e38c45ef276066b35ad6defc9ac213b284fc62",
+      "nodeId": "8:20620",
+      "importMethod": "single",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:14.615Z",
+      "page": "Fat Marker",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null
+    },
+    "emoji-happy": {
+      "name": "emoji-happy",
+      "key": "e862ffde2f9a1b5081491f80def3d07f59208ecc",
+      "nodeId": "8:20712",
+      "importMethod": "single",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:14.615Z",
+      "page": "Fat Marker",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null
+    },
+    "chevron-double-up": {
+      "name": "chevron-double-up",
+      "key": "ea61b6f42751d28b1161934fd990df4e304a2649",
+      "nodeId": "8:20940",
+      "importMethod": "single",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:14.615Z",
+      "page": "Fat Marker",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null
+    },
+    "arrow-narrow-up": {
+      "name": "arrow-narrow-up",
+      "key": "ea89b55cde5e5e86d93ad671d8f2a783a4128f19",
+      "nodeId": "8:20806",
+      "importMethod": "single",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:14.615Z",
+      "page": "Fat Marker",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null
+    },
+    "player-play": {
+      "name": "player-play",
+      "key": "ec5a8ffc0f5159035f0318a204ce49bf73333009",
+      "nodeId": "8:21008",
+      "importMethod": "single",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:14.615Z",
+      "page": "Fat Marker",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null
+    },
+    "sparkles": {
+      "name": "sparkles",
+      "key": "ec6ca91c2659ec20fbda11d069ddadd10d2003b0",
+      "nodeId": "8:20802",
+      "importMethod": "single",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:14.615Z",
+      "page": "Fat Marker",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null
+    },
+    "light-bulb": {
+      "name": "light-bulb",
+      "key": "f0771694d95220071c2f06ba7b39264c724de7fe",
+      "nodeId": "8:20818",
+      "importMethod": "single",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:14.615Z",
+      "page": "Fat Marker",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null
+    },
+    "dots-horizontal": {
+      "name": "dots-horizontal",
+      "key": "f09c64fc6a8f703e1bb4c3c93003eadfde17daac",
+      "nodeId": "8:20548",
+      "importMethod": "single",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:14.615Z",
+      "page": "Fat Marker",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null
+    },
+    "hand": {
+      "name": "hand",
+      "key": "f10f395aaa0726c2fe3a39826fd9c2ed662cca0f",
+      "nodeId": "8:20878",
+      "importMethod": "single",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:14.615Z",
+      "page": "Fat Marker",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null
+    },
+    "sort-descending": {
+      "name": "sort-descending",
+      "key": "f240ddd501884a5c12bef1e5c48298ed1fb0e032",
+      "nodeId": "8:20756",
+      "importMethod": "single",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:14.615Z",
+      "page": "Fat Marker",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null
+    },
+    "cake": {
+      "name": "cake",
+      "key": "f322d5180cec59263866d76ff9abd8de2d493e51",
+      "nodeId": "8:20766",
+      "importMethod": "single",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:14.615Z",
+      "page": "Fat Marker",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null
+    },
+    "adjustments": {
+      "name": "adjustments",
+      "key": "f64149df3de1846230c7e3c5785491aebea10c81",
+      "nodeId": "8:20728",
+      "importMethod": "single",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:14.615Z",
+      "page": "Fat Marker",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null
+    },
+    "document-duplicate": {
+      "name": "document-duplicate",
+      "key": "f798a1600b8e79d4959036ecdedf19959729d4e3",
+      "nodeId": "8:20566",
+      "importMethod": "single",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:14.615Z",
+      "page": "Fat Marker",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null
+    },
+    "arrow-sm-left": {
+      "name": "arrow-sm-left",
+      "key": "f8918eb9e83446f8efefb57762b2330c662f1f94",
+      "nodeId": "8:20988",
+      "importMethod": "single",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:14.615Z",
+      "page": "Fat Marker",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null
+    },
+    "microphone": {
+      "name": "microphone",
+      "key": "f9fb3c69691f128e6b1e87129497cbd65d338ee5",
+      "nodeId": "8:20828",
+      "importMethod": "single",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:14.615Z",
+      "page": "Fat Marker",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null
+    },
+    "view-boards": {
+      "name": "view-boards",
+      "key": "faabfbc5dc5440ebb7da7a222d1695b78f02e0e4",
+      "nodeId": "8:20664",
+      "importMethod": "single",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:14.615Z",
+      "page": "Fat Marker",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null
+    },
+    "exclamation": {
+      "name": "exclamation",
+      "key": "faf123f065d3172a6f4e95de13f7a6960b410721",
+      "nodeId": "8:20562",
+      "importMethod": "single",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:14.615Z",
+      "page": "Fat Marker",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null
+    },
+    "wifi": {
+      "name": "wifi",
+      "key": "fd713b19d01e8e66545429f87d9577218899e3da",
+      "nodeId": "8:20954",
+      "importMethod": "single",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:14.615Z",
+      "page": "Fat Marker",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null
+    },
+    "player-heart": {
+      "name": "player-heart",
+      "key": "1a335fe5c852b7a8d15c99eb4bafe08e1e2f65b0",
+      "nodeId": "8:21014",
+      "importMethod": "single",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:14.615Z",
+      "page": "Fat Marker",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null
+    },
+    "block-quote": {
+      "name": "block quote",
+      "key": "1f710fe94372aae956a52f4314214d2f314158fb",
+      "nodeId": "8:21002",
+      "importMethod": "single",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:14.615Z",
+      "page": "Fat Marker",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null
+    },
+    "player-shuffle": {
+      "name": "player-shuffle",
+      "key": "244daa18671a2c38478381e194a490c365338e5f",
+      "nodeId": "8:21010",
+      "importMethod": "single",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:14.615Z",
+      "page": "Fat Marker",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null
+    },
+    "printer": {
+      "name": "printer",
+      "key": "37cc375f456e3b94ed7ee767e0908f9fe9529698",
+      "nodeId": "8:20760",
+      "importMethod": "single",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:14.615Z",
+      "page": "Fat Marker",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null
+    },
+    "presentation-chart-bar": {
+      "name": "presentation-chart-bar",
+      "key": "5ea9647b57b84effd75910773f6bf28d3030c6a2",
+      "nodeId": "8:20974",
+      "importMethod": "single",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:14.615Z",
+      "page": "Fat Marker",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null
+    },
+    "fm-menu": {
+      "name": "FM Menu",
+      "key": "696ef83ffe2d0af84432b8f12cc15b43e0b25a15",
+      "nodeId": "8:21644",
+      "importMethod": "single",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:14.615Z",
+      "page": "Fat Marker",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null
+    },
+    "player-prev": {
+      "name": "player-prev",
+      "key": "79d9ebc22d95d7cf8b5947c2905825912eabbb73",
+      "nodeId": "8:21004",
+      "importMethod": "single",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:14.615Z",
+      "page": "Fat Marker",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null
+    },
+    "numbered-list": {
+      "name": "numbered list",
+      "key": "8b614a2a2e63475b0744314e4930996de0bada34",
+      "nodeId": "8:20998",
+      "importMethod": "single",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:14.615Z",
+      "page": "Fat Marker",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null
+    },
+    "cube": {
+      "name": "cube",
+      "key": "8b66df015d34be87f79ca9cc1988558d7e55dcec",
+      "nodeId": "8:20944",
+      "importMethod": "single",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:14.615Z",
+      "page": "Fat Marker",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null
+    },
+    "calculator": {
+      "name": "calculator",
+      "key": "92e8b696a586b2b605d27d4d50c66e4984aca7e4",
+      "nodeId": "8:20890",
+      "importMethod": "single",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:14.615Z",
+      "page": "Fat Marker",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null
+    },
+    "device-tablet": {
+      "name": "device-tablet",
+      "key": "9aaa1d413678d31c8f309d98c327825c066d0671",
+      "nodeId": "8:20906",
+      "importMethod": "single",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:14.615Z",
+      "page": "Fat Marker",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null
+    },
+    "status-offline": {
+      "name": "status-offline",
+      "key": "9b23b5f17a717cccef7974d603dfc8c341818c17",
+      "nodeId": "8:20966",
+      "importMethod": "single",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:14.615Z",
+      "page": "Fat Marker",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null
+    },
+    "cloud": {
+      "name": "cloud",
+      "key": "9c9c4119baa0f2676fbe2f5a71d0bffb95739c9f",
+      "nodeId": "8:20976",
+      "importMethod": "single",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:14.615Z",
+      "page": "Fat Marker",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null
+    },
+    "player-next": {
+      "name": "player-next",
+      "key": "d43344d47e26f94efb609ec5343583d4d333c972",
+      "nodeId": "8:21006",
+      "importMethod": "single",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:14.615Z",
+      "page": "Fat Marker",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null
+    },
+    "document-text": {
+      "name": "document-text",
+      "key": "d91039013a464c196a4d11042ea495b4bb196065",
+      "nodeId": "8:20896",
+      "importMethod": "single",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:14.615Z",
+      "page": "Fat Marker",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null
+    },
+    "presentation-chart-line": {
+      "name": "presentation-chart-line",
+      "key": "e066c9d5768c7559b57556a4f13c34601dbe154a",
+      "nodeId": "8:20962",
+      "importMethod": "single",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:14.615Z",
+      "page": "Fat Marker",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null
+    },
+    "search-circle": {
+      "name": "search-circle",
+      "key": "e5ade0076ffb8d0180ac9f621926e1fce901aa04",
+      "nodeId": "8:20978",
+      "importMethod": "single",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:14.615Z",
+      "page": "Fat Marker",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null
+    },
+    "bulleted-list": {
+      "name": "bulleted list",
+      "key": "e5d8d72ccf18ca6435a4db948e8ef295f50ffe64",
+      "nodeId": "8:21000",
+      "importMethod": "single",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:14.615Z",
+      "page": "Fat Marker",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null
+    },
+    "identification": {
+      "name": "identification",
+      "key": "e7f314591cf5b3ad8252df5c1f6d908c7268e38b",
+      "nodeId": "8:20910",
+      "importMethod": "single",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:14.615Z",
+      "page": "Fat Marker",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null
+    },
+    "underline": {
+      "name": "underline",
+      "key": "f1b96fb678c3af9d4c3748afd0a2fba4e3a3a31e",
+      "nodeId": "8:20990",
+      "importMethod": "single",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:14.615Z",
+      "page": "Fat Marker",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null
+    },
+    "gift": {
+      "name": "gift",
+      "key": "0e4aaa30b855bd6fe0a229acdd593ad83172f91b",
+      "nodeId": "8:20900",
+      "importMethod": "single",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:14.615Z",
+      "page": "Fat Marker",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null
+    },
+    "fast-forward": {
+      "name": "fast-forward",
+      "key": "153406ac1399935e61490640e80bfe2a0cfd2b23",
+      "nodeId": "8:20970",
+      "importMethod": "single",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:14.615Z",
+      "page": "Fat Marker",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null
+    },
+    "arrow-circle-right": {
+      "name": "arrow-circle-right",
+      "key": "6fb05e49455680e7d21702197af9de0f712918e7",
+      "nodeId": "8:20636",
+      "importMethod": "single",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:14.615Z",
+      "page": "Fat Marker",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null
+    },
+    "icon-placeholder": {
+      "name": "icon-placeholder",
+      "key": "ae4cb8ae57725689509e57001cfaf83a28ee1c85",
+      "nodeId": "9:1404",
+      "importMethod": "single",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:14.615Z",
+      "page": "Fat Marker",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null
+    },
+    "fm-dialog": {
+      "name": "FM Dialog",
+      "key": "0cc53eca9c90cccb8cbc57864ea110378414fd2b",
+      "nodeId": "9:1382",
+      "importMethod": "single",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:14.615Z",
+      "page": "Fat Marker",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null
+    },
+    "fm-rich-text-field": {
+      "name": "FM Rich text field",
+      "key": "284aa580c4c313ba309ff9eda15b3da8c957cd18",
+      "nodeId": "8:21282",
+      "importMethod": "single",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:14.615Z",
+      "page": "Fat Marker",
+      "properties": {
+        "Input Text#1428:1": {
+          "type": "TEXT",
+          "default": "Rich text editor."
+        }
+      },
+      "nestedComponents": [],
+      "guidelinesFile": null
+    },
+    "fm-table-example": {
+      "name": "FM Table example",
+      "key": "31c00b04d7dfda38c8577f8541afe48b15fba00a",
+      "nodeId": "9:1127",
+      "importMethod": "single",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:14.615Z",
+      "page": "Fat Marker",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null
+    },
+    "fm-banner": {
+      "name": "FM Banner",
+      "key": "d7f323e492b456a2c56f81f3dc892eb24de11a6e",
+      "nodeId": "36:3235",
+      "importMethod": "single",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:14.615Z",
+      "page": "Fat Marker",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null
+    }
+  }
+}

--- a/plugins/actian-design-system/vendor/components/registries/meta-kit/styles.json
+++ b/plugins/actian-design-system/vendor/components/registries/meta-kit/styles.json
@@ -1,0 +1,400 @@
+{
+  "textStyles": [
+    {
+      "name": "label-micro",
+      "key": "1abb2bafb770f181a96123707f8fd4b1199c5341",
+      "fontFamily": "Roboto",
+      "fontStyle": "Medium",
+      "fontSize": 10,
+      "lineHeight": {
+        "unit": "PIXELS",
+        "value": 14
+      },
+      "letterSpacing": {
+        "unit": "PIXELS",
+        "value": 0.4000000059604645
+      },
+      "textDecoration": "NONE",
+      "textCase": "ORIGINAL"
+    },
+    {
+      "name": "label-subtle",
+      "key": "48d53e9b9fca2555a64713c9c6eca3f0be96058e",
+      "fontFamily": "Roboto",
+      "fontStyle": "Medium",
+      "fontSize": 12,
+      "lineHeight": {
+        "unit": "PIXELS",
+        "value": 16
+      },
+      "letterSpacing": {
+        "unit": "PIXELS",
+        "value": 0.30000001192092896
+      },
+      "textDecoration": "NONE",
+      "textCase": "ORIGINAL"
+    },
+    {
+      "name": "label-standard",
+      "key": "693f5c1da87bf4ac6c00821229e0c47cea40ccd7",
+      "fontFamily": "Roboto",
+      "fontStyle": "Medium",
+      "fontSize": 14,
+      "lineHeight": {
+        "unit": "PIXELS",
+        "value": 20
+      },
+      "letterSpacing": {
+        "unit": "PIXELS",
+        "value": 0.20000000298023224
+      },
+      "textDecoration": "NONE",
+      "textCase": "ORIGINAL"
+    },
+    {
+      "name": "heading-prominent",
+      "key": "6fe718b74016ab3a13b59f00020ad605edc82f55",
+      "fontFamily": "Roboto",
+      "fontStyle": "SemiBold",
+      "fontSize": 18,
+      "lineHeight": {
+        "unit": "PIXELS",
+        "value": 26
+      },
+      "letterSpacing": {
+        "unit": "PIXELS",
+        "value": 0
+      },
+      "textDecoration": "NONE",
+      "textCase": "ORIGINAL"
+    },
+    {
+      "name": "heading-micro",
+      "key": "9847fe1277845ce86f97157b5ba8342ecaf3f180",
+      "fontFamily": "Roboto",
+      "fontStyle": "SemiBold",
+      "fontSize": 12,
+      "lineHeight": {
+        "unit": "PIXELS",
+        "value": 16
+      },
+      "letterSpacing": {
+        "unit": "PIXELS",
+        "value": 0.30000001192092896
+      },
+      "textDecoration": "NONE",
+      "textCase": "ORIGINAL"
+    },
+    {
+      "name": "body-micro",
+      "key": "9862f620e4c4e2114aeb1bd35838174be5098103",
+      "fontFamily": "Roboto",
+      "fontStyle": "Regular",
+      "fontSize": 10,
+      "lineHeight": {
+        "unit": "PIXELS",
+        "value": 14
+      },
+      "letterSpacing": {
+        "unit": "PIXELS",
+        "value": 0.4000000059604645
+      },
+      "textDecoration": "NONE",
+      "textCase": "ORIGINAL"
+    },
+    {
+      "name": "body-prominent",
+      "key": "9997e4e40cb87b1902f1c832dfef7589175e0226",
+      "fontFamily": "Roboto",
+      "fontStyle": "Regular",
+      "fontSize": 16,
+      "lineHeight": {
+        "unit": "PIXELS",
+        "value": 24
+      },
+      "letterSpacing": {
+        "unit": "PIXELS",
+        "value": 0.10000000149011612
+      },
+      "textDecoration": "NONE",
+      "textCase": "ORIGINAL"
+    },
+    {
+      "name": "heading-display",
+      "key": "a14c21c5bc8ae3817de4f44cf89ac193e067bac7",
+      "fontFamily": "Roboto",
+      "fontStyle": "SemiBold",
+      "fontSize": 24,
+      "lineHeight": {
+        "unit": "PIXELS",
+        "value": 32
+      },
+      "letterSpacing": {
+        "unit": "PIXELS",
+        "value": 0
+      },
+      "textDecoration": "NONE",
+      "textCase": "ORIGINAL"
+    },
+    {
+      "name": "heading-subtle",
+      "key": "c8c9880fd0f780b4e9a558f336c83131abe3447f",
+      "fontFamily": "Roboto",
+      "fontStyle": "SemiBold",
+      "fontSize": 14,
+      "lineHeight": {
+        "unit": "PIXELS",
+        "value": 20
+      },
+      "letterSpacing": {
+        "unit": "PIXELS",
+        "value": 0.20000000298023224
+      },
+      "textDecoration": "NONE",
+      "textCase": "ORIGINAL"
+    },
+    {
+      "name": "body-stardard",
+      "key": "e2d890ede4702bfa4815b6805f53ac812caef4ad",
+      "fontFamily": "Roboto",
+      "fontStyle": "Regular",
+      "fontSize": 14,
+      "lineHeight": {
+        "unit": "PIXELS",
+        "value": 20
+      },
+      "letterSpacing": {
+        "unit": "PIXELS",
+        "value": 0.20000000298023224
+      },
+      "textDecoration": "NONE",
+      "textCase": "ORIGINAL"
+    },
+    {
+      "name": "body-subtle",
+      "key": "e91a526042a6328e2e9b33b8aaa493a7d456d96e",
+      "fontFamily": "Roboto",
+      "fontStyle": "Regular",
+      "fontSize": 12,
+      "lineHeight": {
+        "unit": "PIXELS",
+        "value": 16
+      },
+      "letterSpacing": {
+        "unit": "PIXELS",
+        "value": 0.30000001192092896
+      },
+      "textDecoration": "NONE",
+      "textCase": "ORIGINAL"
+    },
+    {
+      "name": "heading-standard",
+      "key": "ea7401fa6fba7514c1aca93e911581cd3f16a1d8",
+      "fontFamily": "Roboto",
+      "fontStyle": "SemiBold",
+      "fontSize": 16,
+      "lineHeight": {
+        "unit": "PIXELS",
+        "value": 24
+      },
+      "letterSpacing": {
+        "unit": "PIXELS",
+        "value": 0.10000000149011612
+      },
+      "textDecoration": "NONE",
+      "textCase": "ORIGINAL"
+    }
+  ],
+  "effectStyles": [
+    {
+      "name": "shadow-sm",
+      "key": "3bdec05719c6a80952f2a909b2ee818bf23dc8b6",
+      "effects": [
+        {
+          "type": "DROP_SHADOW",
+          "color": {
+            "r": 0,
+            "g": 0,
+            "b": 0.0784313753247261,
+            "a": 0.07999999821186066
+          },
+          "offset": {
+            "x": 0,
+            "y": 1
+          },
+          "radius": 7,
+          "spread": 3,
+          "visible": true
+        },
+        {
+          "type": "DROP_SHADOW",
+          "color": {
+            "r": 0,
+            "g": 0,
+            "b": 0.12156862765550613,
+            "a": 0.11999999731779099
+          },
+          "offset": {
+            "x": 0,
+            "y": 1
+          },
+          "radius": 3,
+          "spread": 1,
+          "visible": true
+        }
+      ]
+    },
+    {
+      "name": "shadow-lg",
+      "key": "50793d1ceb271d09ec2ae79cb188b8d7c8ea85ba",
+      "effects": [
+        {
+          "type": "DROP_SHADOW",
+          "color": {
+            "r": 0,
+            "g": 0,
+            "b": 0.14901961386203766,
+            "a": 0.15000000596046448
+          },
+          "offset": {
+            "x": 0,
+            "y": 6
+          },
+          "radius": 10,
+          "spread": 4,
+          "visible": true
+        },
+        {
+          "type": "DROP_SHADOW",
+          "color": {
+            "r": 0,
+            "g": 0,
+            "b": 0.3019607961177826,
+            "a": 0.30000001192092896
+          },
+          "offset": {
+            "x": 0,
+            "y": 2
+          },
+          "radius": 3,
+          "spread": 0,
+          "visible": true
+        }
+      ]
+    },
+    {
+      "name": "shadow-md",
+      "key": "a2b3143e1394d5cf10c76cd5cfa67ee3a769415e",
+      "effects": [
+        {
+          "type": "DROP_SHADOW",
+          "color": {
+            "r": 0,
+            "g": 0,
+            "b": 0.3019607961177826,
+            "a": 0.30000001192092896
+          },
+          "offset": {
+            "x": 0,
+            "y": 1
+          },
+          "radius": 3,
+          "spread": 0,
+          "visible": true
+        },
+        {
+          "type": "DROP_SHADOW",
+          "color": {
+            "r": 0,
+            "g": 0,
+            "b": 0.14901961386203766,
+            "a": 0.15000000596046448
+          },
+          "offset": {
+            "x": 0,
+            "y": 4
+          },
+          "radius": 8,
+          "spread": 3,
+          "visible": true
+        }
+      ]
+    },
+    {
+      "name": "shadow-xs",
+      "key": "e5e6f1d0c3aabfd9ff4aab0978c489771e7efcce",
+      "effects": [
+        {
+          "type": "DROP_SHADOW",
+          "color": {
+            "r": 0,
+            "g": 0,
+            "b": 0.05882352963089943,
+            "a": 0.05999999865889549
+          },
+          "offset": {
+            "x": 0,
+            "y": 1
+          },
+          "radius": 3,
+          "spread": 1,
+          "visible": true
+        },
+        {
+          "type": "DROP_SHADOW",
+          "color": {
+            "r": 0,
+            "g": 0,
+            "b": 0.07058823853731155,
+            "a": 0.07000000029802322
+          },
+          "offset": {
+            "x": 0,
+            "y": 1
+          },
+          "radius": 5,
+          "spread": 0,
+          "visible": true
+        }
+      ]
+    },
+    {
+      "name": "shadow-xl",
+      "key": "ed326603bcb9d1ce54a00ae66352cdbdf9645a93",
+      "effects": [
+        {
+          "type": "DROP_SHADOW",
+          "color": {
+            "r": 0,
+            "g": 0,
+            "b": 0.14901961386203766,
+            "a": 0.15000000596046448
+          },
+          "offset": {
+            "x": 0,
+            "y": 8
+          },
+          "radius": 12,
+          "spread": 6,
+          "visible": true
+        },
+        {
+          "type": "DROP_SHADOW",
+          "color": {
+            "r": 0,
+            "g": 0,
+            "b": 0.3019607961177826,
+            "a": 0.30000001192092896
+          },
+          "offset": {
+            "x": 0,
+            "y": 4
+          },
+          "radius": 4,
+          "spread": 0,
+          "visible": true
+        }
+      ]
+    }
+  ]
+}

--- a/plugins/actian-design-system/vendor/components/registries/metakit.json
+++ b/plugins/actian-design-system/vendor/components/registries/metakit.json
@@ -1,0 +1,708 @@
+{
+  "library": "meta-kit",
+  "fileKey": "osoeCLcrWqfoq8TvLQoyh0",
+  "lastSynced": "2026-05-09T15:47:21.183Z",
+  "componentCount": 28,
+  "components": {
+    "meta-content-stat-card": {
+      "name": "Meta / Content / Stat Card",
+      "key": "8662c721d74d6f0079f273f76eec374b12ec2fae",
+      "nodeId": "46:29",
+      "importMethod": "set",
+      "description": "Data callout card with value, trend indicator, and label. Used in presentations for KPI highlights.",
+      "lastSynced": "2026-05-09T15:47:21.183Z",
+      "page": "Brief",
+      "properties": {
+        "Value#46:6": {
+          "type": "TEXT",
+          "default": "94%"
+        },
+        "Label#46:7": {
+          "type": "TEXT",
+          "default": "WCAG AA compliance"
+        }
+      },
+      "nestedComponents": [],
+      "guidelinesFile": null,
+      "variants": {
+        "Trend": [
+          "Up",
+          "Down",
+          "Neutral"
+        ]
+      }
+    },
+    "meta-chrome-theme-card": {
+      "name": "Meta / Chrome / Theme Card",
+      "key": "9081a7761dfbe11d576182f3cb1711b9e76c2d36",
+      "nodeId": "47:43",
+      "importMethod": "set",
+      "description": "Theme-branded card with colored accent bar. Used in component-brief for theme comparison views (Actian/Studio/Explorer). Detach to append content.",
+      "lastSynced": "2026-05-09T15:47:21.183Z",
+      "page": "Brief",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null,
+      "variants": {
+        "Theme": [
+          "Actian",
+          "Studio",
+          "Explorer"
+        ]
+      }
+    },
+    "meta-chrome-feedback": {
+      "name": "Meta / Chrome / Feedback",
+      "key": "d5cba21bc3dbf36578665bac89834fbe1ca29ed0",
+      "nodeId": "66:20",
+      "importMethod": "set",
+      "description": "Annotation component for designer feedback and library gap markers. Designer variant: place next to issues for /refine comments. System variant: auto-placed when plugin improvises around a library gap",
+      "lastSynced": "2026-05-09T15:47:21.183Z",
+      "page": "Shared",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null,
+      "variants": {
+        "Type": [
+          "Designer",
+          "System"
+        ]
+      }
+    },
+    "meta-content-do-don-t-pair": {
+      "name": "Meta / Content / Do-Don't Pair",
+      "key": "28edfacf13e50706586172bd48f8a3ad84d7c263",
+      "nodeId": "9:24",
+      "importMethod": "set",
+      "description": "Side-by-side Do and Don't examples with green/red color bars. Used in component-brief Cards 6-7 and presentation best-practice slides.",
+      "lastSynced": "2026-05-09T15:47:21.183Z",
+      "page": "Brief",
+      "properties": {
+        "Do Label#9:8": {
+          "type": "TEXT",
+          "default": "Do — Use sentence case for all UI labels"
+        },
+        "Don't Label#9:9": {
+          "type": "TEXT",
+          "default": "Don't — Use ALL CAPS for labels"
+        },
+        "Do Example#9:10": {
+          "type": "TEXT",
+          "default": "Save changes"
+        },
+        "Don't Example#9:11": {
+          "type": "TEXT",
+          "default": "SAVE CHANGES"
+        }
+      },
+      "nestedComponents": [],
+      "guidelinesFile": null,
+      "variants": {
+        "Mode": [
+          "DS",
+          "FM"
+        ]
+      }
+    },
+    "meta-chrome-brief-card": {
+      "name": "Meta / Chrome / Brief Card",
+      "key": "3dbb732730af0754210cde7af35e5236a2502843",
+      "nodeId": "7:2",
+      "importMethod": "set",
+      "description": "Card shell for component spec pages. 4 variants: DS Standard (1200px grey header), DS Page Header (1200px white with logo), FM Standard (820px grey header), FM Page Header (820px dark).",
+      "lastSynced": "2026-05-09T15:47:21.183Z",
+      "page": "Brief",
+      "properties": {
+        "Component Name#7:2": {
+          "type": "TEXT",
+          "default": "Component name"
+        },
+        "Description#7:3": {
+          "type": "TEXT",
+          "default": "Component description"
+        },
+        "Source#7:4": {
+          "type": "TEXT",
+          "default": "FAT MARKER WIREFRAME KIT"
+        }
+      },
+      "nestedComponents": [],
+      "guidelinesFile": null,
+      "variants": {
+        "Mode": [
+          "DS",
+          "FM"
+        ],
+        "Type": [
+          "Standard",
+          "Page Header"
+        ]
+      }
+    },
+    "meta-chrome-flow-screen": {
+      "name": "Meta / Chrome / Flow Screen",
+      "key": "2ca7c756ad54e81219104d3a270ba8eb9eeffcf6",
+      "nodeId": "21:1198",
+      "importMethod": "set",
+      "description": "Screen frame for wireframe flows. Composes FM App_header + FM Side navigation bar + Content Area. Standard (1440x960) and Compact (1440x700).",
+      "lastSynced": "2026-05-09T15:47:21.183Z",
+      "page": "Flow",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null,
+      "variants": {
+        "Size": [
+          "Standard",
+          "Compact"
+        ]
+      }
+    },
+    "meta-chrome-accessibility-card": {
+      "name": "Meta / Chrome / Accessibility Card",
+      "key": "b4779a13f4097d682413a669eaaf9ead1b49f115",
+      "nodeId": "47:24",
+      "importMethod": "set",
+      "description": "Container for WCAG requirements with severity badges. Used in component-brief Cards 7-8. Detach instance before appending content to the Content slot.",
+      "lastSynced": "2026-05-09T15:47:21.183Z",
+      "page": "Brief",
+      "properties": {
+        "Title#47:2": {
+          "type": "TEXT",
+          "default": "Accessibility Requirements"
+        }
+      },
+      "nestedComponents": [],
+      "guidelinesFile": null,
+      "variants": {
+        "Mode": [
+          "DS",
+          "FM"
+        ]
+      }
+    },
+    "meta-content-dimension-annotation": {
+      "name": "Meta / Content / Dimension Annotation",
+      "key": "49bf6a1b210a403ba145a3fdee9b1994eb54069a",
+      "nodeId": "45:37",
+      "importMethod": "set",
+      "description": "Measurement annotation with endcaps and value label. Used in component-brief Card 3 (Anatomy - Specs) for dimension callouts between elements.",
+      "lastSynced": "2026-05-09T15:47:21.183Z",
+      "page": "Brief",
+      "properties": {
+        "Value#45:7": {
+          "type": "TEXT",
+          "default": "16px"
+        }
+      },
+      "nestedComponents": [],
+      "guidelinesFile": null,
+      "variants": {
+        "Orientation": [
+          "Horizontal",
+          "Vertical"
+        ]
+      }
+    },
+    "meta-content-pointer-badge": {
+      "name": "Meta / Content / Pointer Badge",
+      "key": "7e066fc21d9a2bbbcd1149113787cf59140162d4",
+      "nodeId": "45:26",
+      "importMethod": "set",
+      "description": "Dimension callout label with directional line. Used in component-brief Card 3 (Anatomy) for pink dimension annotations.",
+      "lastSynced": "2026-05-09T15:47:21.183Z",
+      "page": "Brief",
+      "properties": {
+        "Label#45:4": {
+          "type": "TEXT",
+          "default": "24px"
+        }
+      },
+      "nestedComponents": [],
+      "guidelinesFile": null,
+      "variants": {
+        "Direction": [
+          "Left",
+          "Right",
+          "Up",
+          "Down"
+        ]
+      }
+    },
+    "meta-content-contrast-badge": {
+      "name": "Meta / Content / Contrast Badge",
+      "key": "941756541adc6ce21e32e848c2039c64fece0fcf",
+      "nodeId": "44:20",
+      "importMethod": "set",
+      "description": "WCAG contrast result badge (Pass/Exempt/Fail). Used in component-brief Card 8 accessibility contrast table.",
+      "lastSynced": "2026-05-09T15:47:21.183Z",
+      "page": "Brief",
+      "properties": {
+        "Label#44:3": {
+          "type": "TEXT",
+          "default": "Pass"
+        }
+      },
+      "nestedComponents": [],
+      "guidelinesFile": null,
+      "variants": {
+        "Status": [
+          "Pass",
+          "Exempt",
+          "Fail"
+        ]
+      }
+    },
+    "meta-content-color-swatch": {
+      "name": "Meta / Content / Color Swatch",
+      "key": "da3369932f710386b76ca91a40ebd48d94e3f2e0",
+      "nodeId": "42:17",
+      "importMethod": "set",
+      "description": "Circular color indicator. Used in component-brief Card 4 (token tables) and Card 8 (contrast tables). Bind fill to a DS2026 variable at runtime.",
+      "lastSynced": "2026-05-09T15:47:21.183Z",
+      "page": "Brief",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null,
+      "variants": {
+        "Size": [
+          "Small",
+          "Medium",
+          "Large"
+        ]
+      }
+    },
+    "meta-template-table-data-row": {
+      "name": "Meta / Template / Table Data Row",
+      "key": "3a1fae22dd85936f81565122888efd8a50e37180",
+      "nodeId": "74:12",
+      "importMethod": "single",
+      "description": "Hidden template for table data rows. Skills clone and fill text slots via the template engine. Do not use directly.",
+      "lastSynced": "2026-05-09T15:47:21.183Z",
+      "page": "Brief",
+      "properties": {
+        "label#84:0": {
+          "type": "TEXT",
+          "default": "Label"
+        },
+        "value#84:1": {
+          "type": "TEXT",
+          "default": "Value"
+        }
+      },
+      "nestedComponents": [],
+      "guidelinesFile": null
+    },
+    "meta-template-state-column": {
+      "name": "Meta / Template / State Column",
+      "key": "4f782d1a8541b4474858767209f99dce1428784b",
+      "nodeId": "75:12",
+      "importMethod": "single",
+      "description": "Hidden template for state grid columns. Skills clone, fill title, replace content placeholder. Do not use directly.",
+      "lastSynced": "2026-05-09T15:47:21.183Z",
+      "page": "Brief",
+      "properties": {
+        "title#85:0": {
+          "type": "TEXT",
+          "default": "State"
+        }
+      },
+      "nestedComponents": [],
+      "guidelinesFile": null
+    },
+    "meta-content-research-frame": {
+      "name": "Meta / Content / Research Frame",
+      "key": "e671618f2b4c6ea406a995fdc3012ac54eadfe56",
+      "nodeId": "48:31",
+      "importMethod": "single",
+      "description": "Container for research findings in presentations. Shows title, source attribution, and content area.",
+      "lastSynced": "2026-05-09T15:47:21.183Z",
+      "page": "Presentation",
+      "properties": {
+        "Title#48:10": {
+          "type": "TEXT",
+          "default": "Research Finding"
+        },
+        "Source#48:11": {
+          "type": "TEXT",
+          "default": "Source: Research Study 2026"
+        }
+      },
+      "nestedComponents": [],
+      "guidelinesFile": null
+    },
+    "meta-utility-card-divider": {
+      "name": "Meta / Utility / Card Divider",
+      "key": "f4d778e1cf9bb61a33712c791486f54bb1c095b7",
+      "nodeId": "4:2",
+      "importMethod": "single",
+      "description": "Horizontal divider line between card sections. Set layoutSizingHorizontal = 'FILL' on instances to fill parent width.",
+      "lastSynced": "2026-05-09T15:47:21.183Z",
+      "page": "Shared",
+      "properties": {},
+      "nestedComponents": [],
+      "guidelinesFile": null
+    },
+    "meta-template-a11y-spec-row": {
+      "name": "Meta / Template / A11y Spec Row",
+      "key": "92ed7bc88cf229782c4b42238aacba1d15f8fd06",
+      "nodeId": "96:12",
+      "importMethod": "single",
+      "description": "",
+      "lastSynced": "2026-05-09T15:47:21.183Z",
+      "page": "Brief",
+      "properties": {
+        "element#105:0": {
+          "type": "TEXT",
+          "default": "element"
+        },
+        "role#105:1": {
+          "type": "TEXT",
+          "default": "role"
+        },
+        "label#105:2": {
+          "type": "TEXT",
+          "default": "label"
+        },
+        "focus-order#105:3": {
+          "type": "TEXT",
+          "default": "focus-order"
+        },
+        "keyboard#105:4": {
+          "type": "TEXT",
+          "default": "keyboard"
+        },
+        "announcement#105:5": {
+          "type": "TEXT",
+          "default": "announcement"
+        }
+      },
+      "nestedComponents": [],
+      "guidelinesFile": null
+    },
+    "meta-chrome-brief-card-header": {
+      "name": "Meta / Chrome / Brief Card Header",
+      "key": "057e742610975479a8c9c245e713d9911a49e484",
+      "nodeId": "140:12",
+      "importMethod": "single",
+      "description": "Card header for component briefs. Used as first child inside Brief Card shells. Set Title, Subtitle, and Show Subtitle via properties — do not detach.",
+      "lastSynced": "2026-05-09T15:47:21.183Z",
+      "page": "Brief",
+      "properties": {
+        "Title#140:0": {
+          "type": "TEXT",
+          "default": "Card title "
+        },
+        "Subtitle#140:1": {
+          "type": "TEXT",
+          "default": "Subtitle text"
+        },
+        "Show Subtitle#140:2": {
+          "type": "BOOLEAN",
+          "default": true
+        }
+      },
+      "nestedComponents": [],
+      "guidelinesFile": null
+    },
+    "meta-template-section-header": {
+      "name": "Meta / Template / Section Header",
+      "key": "f4fd576001f4f1f4606a4efb051d1e4492e378c4",
+      "nodeId": "76:12",
+      "importMethod": "single",
+      "description": "Hidden template for section headers with title and subtitle. Skills clone and fill text slots. Do not use directly.",
+      "lastSynced": "2026-05-09T15:47:21.183Z",
+      "page": "Brief",
+      "properties": {
+        "title#86:0": {
+          "type": "TEXT",
+          "default": "Section Title"
+        },
+        "subtitle#86:1": {
+          "type": "TEXT",
+          "default": "Optional description text"
+        },
+        "Show Subtitle#138:0": {
+          "type": "BOOLEAN",
+          "default": true
+        }
+      },
+      "nestedComponents": [],
+      "guidelinesFile": null
+    },
+    "meta-chrome-generation-log": {
+      "name": "Meta / Chrome / Generation Log",
+      "key": "a9653f30925367e96dea90093d750bfe70849571",
+      "nodeId": "3:2",
+      "importMethod": "single",
+      "description": "Generation metadata card. First element in every AI-generated output. Shows skill name, prompt, timestamp, duration, model, and plugin version.",
+      "lastSynced": "2026-05-09T15:47:21.183Z",
+      "page": "Shared",
+      "properties": {
+        "Skill#3:0": {
+          "type": "TEXT",
+          "default": "Skill: component-brief"
+        },
+        "Prompt#3:1": {
+          "type": "TEXT",
+          "default": "Prompt: Create a component brief for Button"
+        },
+        "Date#3:2": {
+          "type": "TEXT",
+          "default": "2026-03-26T10:00:00Z"
+        },
+        "Duration#3:3": {
+          "type": "TEXT",
+          "default": "Duration: 2m 34s"
+        },
+        "Model#3:4": {
+          "type": "TEXT",
+          "default": "claude-opus-4-6"
+        },
+        "Plugin Version#3:5": {
+          "type": "TEXT",
+          "default": "v1.11.0"
+        }
+      },
+      "nestedComponents": [],
+      "guidelinesFile": null
+    },
+    "meta-slide-body-full": {
+      "name": "Meta / Slide / Body Full",
+      "key": "281e7a9bc55abe69bb2364e639f7511b4a005694",
+      "nodeId": "112:15",
+      "importMethod": "single",
+      "description": "Presentation slide template. Used by generate-presentation skill.",
+      "lastSynced": "2026-05-09T15:47:21.183Z",
+      "page": "Presentation",
+      "properties": {
+        "Title#112:5": {
+          "type": "TEXT",
+          "default": "Title"
+        }
+      },
+      "nestedComponents": [],
+      "guidelinesFile": null
+    },
+    "meta-slide-cover": {
+      "name": "Meta / Slide / Cover",
+      "key": "a12f6f0b26fffc59fdac49df2bc3c36182c912da",
+      "nodeId": "112:14",
+      "importMethod": "single",
+      "description": "Presentation slide template. Used by generate-presentation skill.",
+      "lastSynced": "2026-05-09T15:47:21.183Z",
+      "page": "Presentation",
+      "properties": {
+        "Topic#112:0": {
+          "type": "TEXT",
+          "default": "Topic"
+        },
+        "Title#112:1": {
+          "type": "TEXT",
+          "default": "Title"
+        },
+        "Subtitle#112:2": {
+          "type": "TEXT",
+          "default": "Subtitle"
+        },
+        "Date#112:3": {
+          "type": "TEXT",
+          "default": "Created date or month, year"
+        },
+        "Creators#112:4": {
+          "type": "TEXT",
+          "default": "Creators"
+        }
+      },
+      "nestedComponents": [],
+      "guidelinesFile": null
+    },
+    "meta-slide-body-text-visual": {
+      "name": "Meta / Slide / Body Text Visual",
+      "key": "28ea7a37752149d78679847ec7893368a4c4f1a0",
+      "nodeId": "112:16",
+      "importMethod": "single",
+      "description": "Presentation slide template. Used by generate-presentation skill.",
+      "lastSynced": "2026-05-09T15:47:21.183Z",
+      "page": "Presentation",
+      "properties": {
+        "Title#112:6": {
+          "type": "TEXT",
+          "default": "Title"
+        },
+        "Body#112:7": {
+          "type": "TEXT",
+          "default": "Body"
+        }
+      },
+      "nestedComponents": [],
+      "guidelinesFile": null
+    },
+    "meta-slide-back-cover": {
+      "name": "Meta / Slide / Back Cover",
+      "key": "6df533ae800a6596fd84e93a2e5fc725dbd6a369",
+      "nodeId": "112:18",
+      "importMethod": "single",
+      "description": "Presentation slide template. Used by generate-presentation skill.",
+      "lastSynced": "2026-05-09T15:47:21.183Z",
+      "page": "Presentation",
+      "properties": {
+        "Title#112:10": {
+          "type": "TEXT",
+          "default": "Thank you"
+        }
+      },
+      "nestedComponents": [],
+      "guidelinesFile": null
+    },
+    "meta-slide-section": {
+      "name": "Meta / Slide / Section",
+      "key": "348efaa22a6da818c435017399a357b47257bcdc",
+      "nodeId": "112:17",
+      "importMethod": "single",
+      "description": "Presentation slide template. Used by generate-presentation skill.",
+      "lastSynced": "2026-05-09T15:47:21.183Z",
+      "page": "Presentation",
+      "properties": {
+        "Topic#112:8": {
+          "type": "TEXT",
+          "default": "Topic"
+        },
+        "Title#112:9": {
+          "type": "TEXT",
+          "default": "Title"
+        }
+      },
+      "nestedComponents": [],
+      "guidelinesFile": null
+    },
+    "meta-content-code-block": {
+      "name": "Meta / Content / Code Block",
+      "key": "1bf10eee1751a46da5f90a9671be6c9abf0073b7",
+      "nodeId": "8:2",
+      "importMethod": "single",
+      "description": "Dark code block for CSS, HTML, ARIA code examples. Used in component-brief Card 9 and presentation code slides. Toggle Show Header for filename/language label.",
+      "lastSynced": "2026-05-09T15:47:21.183Z",
+      "page": "Brief",
+      "properties": {
+        "Show Header#8:0": {
+          "type": "BOOLEAN",
+          "default": true
+        },
+        "Header Text#8:1": {
+          "type": "TEXT",
+          "default": "button.css"
+        },
+        "Code#8:2": {
+          "type": "TEXT",
+          "default": ".button {\n  background: var(--zen-color-theme-primary);\n}"
+        }
+      },
+      "nestedComponents": [],
+      "guidelinesFile": null
+    },
+    "meta-template-table-header-row": {
+      "name": "Meta / Template / Table Header Row",
+      "key": "0754accfc4bc79ce9a68ff8fe7a108f1b41b9b2e",
+      "nodeId": "73:12",
+      "importMethod": "single",
+      "description": "Hidden template for table header rows. Skills clone and fill text slots via the template engine. Do not use directly.",
+      "lastSynced": "2026-05-09T15:47:21.183Z",
+      "page": "Brief",
+      "properties": {
+        "label#83:0": {
+          "type": "TEXT",
+          "default": "Header"
+        }
+      },
+      "nestedComponents": [],
+      "guidelinesFile": null
+    },
+    "meta-chrome-flow-cover-card": {
+      "name": "Meta / Chrome / Flow Cover Card",
+      "key": "eaebde6bd07d2f19f3f9c00a9587240cb085a90d",
+      "nodeId": "46:344",
+      "importMethod": "single",
+      "description": "Dark cover card at the start of each sub-flow. Shows Feature, Flow, and User fields on a dark background.",
+      "lastSynced": "2026-05-09T15:47:21.183Z",
+      "page": "Flow",
+      "properties": {
+        "Feature#46:8": {
+          "type": "TEXT",
+          "default": "Feature Name"
+        },
+        "Flow#46:9": {
+          "type": "TEXT",
+          "default": "Flow Description"
+        },
+        "User#46:10": {
+          "type": "TEXT",
+          "default": "User Persona"
+        }
+      },
+      "nestedComponents": [],
+      "guidelinesFile": null
+    },
+    "meta-template-swatch-row": {
+      "name": "Meta / Template / Swatch Row",
+      "key": "96647364b6cb5c55b7ced72106708daaa33afb7f",
+      "nodeId": "77:12",
+      "importMethod": "single",
+      "description": "Hidden template for color swatch rows. Skills clone, fill text slots, bind swatch fill to variable. Do not use directly.",
+      "lastSynced": "2026-05-09T15:47:21.183Z",
+      "page": "Brief",
+      "properties": {
+        "name#87:0": {
+          "type": "TEXT",
+          "default": "Token name"
+        },
+        "value#87:1": {
+          "type": "TEXT",
+          "default": "--zen-color-name"
+        },
+        "hex#87:2": {
+          "type": "TEXT",
+          "default": "#000000"
+        }
+      },
+      "nestedComponents": [],
+      "guidelinesFile": null
+    }
+  },
+  "templates": {
+    "section-header": {
+      "key": "f4fd576001f4f1f4606a4efb051d1e4492e378c4",
+      "nodeId": "76:12",
+      "textSlots": [
+        "title",
+        "subtitle"
+      ],
+      "visibility": "template-only",
+      "category": "layout"
+    },
+    "swatch-row": {
+      "key": "96647364b6cb5c55b7ced72106708daaa33afb7f",
+      "nodeId": "77:12",
+      "textSlots": [
+        "name",
+        "value",
+        "hex"
+      ],
+      "visibility": "template-only",
+      "category": "tokens"
+    },
+    "a11y-spec-row": {
+      "key": "92ed7bc88cf229782c4b42238aacba1d15f8fd06",
+      "nodeId": "96:12",
+      "textSlots": [
+        "element",
+        "role",
+        "label",
+        "focus-order",
+        "keyboard",
+        "announcement"
+      ],
+      "visibility": "template-only",
+      "category": "a11y"
+    }
+  }
+}


### PR DESCRIPTION
## Federation Phase 1.4b — close the vendoring loop

Plugin code now reads DS knowledge from `vendor/` instead of `docs/`, `tokens/`. Knowledge content is canonically in [`volivarii/actian-ds-knowledge`](https://github.com/volivarii/actian-ds-knowledge); `vendor/` is a pinned snapshot per `vendored.json` (Phase 1.4a).

### Scope

**Code paths (5 files)** — registry loader + cosmetic:
- `scripts/lib/shared-constants.js` — registry loader switched from `docs/generated/` to `vendor/components/registries/`
- `scripts/renderers/render-component-reference.js` — KIT_HEADERS source labels (cosmetic in generated MD output)
- `scripts/renderers/html-renderers/brief-renderer.js` — stub-fallback footer message
- `scripts/validation/component-property-rules.js` — CLI help text
- `scripts/validation/validate-flow-data.js` — stub-guideline info message

**Doc cross-refs (17 files)** — SKILL.md + references/ batch sed across all consumer-facing docs.

### Path mapping table

| Was | Now |
|---|---|
| `docs/foundations.md` | `vendor/foundations/foundations.md` |
| `docs/foundations-authoring.md` | `vendor/foundations/AUTHORING.md` |
| `docs/foundations/<topic>.json` | `vendor/foundations/<topic>.json` |
| `docs/generated/foundations/<topic>.json` | `vendor/foundations/<topic>.json` |
| `docs/generated/{dskit,fmkit,metakit}.json` | `vendor/components/registries/{dskit,fmkit,metakit}.json` |
| `docs/component-guidelines/<slug>.json` | `vendor/components/guidelines/<slug>.json` |
| `docs/accessibility-guidelines.md` | `vendor/accessibility/accessibility.md` |
| `docs/content-guidelines.md` | `vendor/content/content.md` |
| `docs/generated/app-context.json` | `vendor/app-context/app-context.json` |
| `docs/generated/fm-to-ds-map.json` | `vendor/fm-to-ds-map/fm-to-ds-map.json` |
| `tokens/actian-ds.tokens.json` | `vendor/tokens/tokens.json` |
| `tokens/actian-ds.tokens.css` | `vendor/tokens/tokens.css` |

### Deliberately NOT touched

- **`skills/sync-design-system/`** — about to be deprecated in Phase 1.5; references describe its current behavior accurately.
- **Auto-generated MDs** (`docs/generated/{dskit,fm}-components.md`, `meta-kit/components.md`, `token-reference.md`, etc.) — NOT in vendor/ because the knowledge repo's sync pipeline doesn't generate them yet. References stay at `docs/generated/` for now; Phase 1.5 cleanup adds MD generation to knowledge-repo CI and re-vendors.
- **Sync infrastructure** (`scripts/sync/`, `scripts/foundations/`, `scripts/changelog/`, their workflows) — about to be deprecated in Phase 1.5; parallel-change discipline keeps them running until smoke confirms decommission is safe.

### llms.txt + llms-overview.md updated

- `llms.txt` URLs now point at the **canonical knowledge repo** (`raw.githubusercontent.com/volivarii/actian-ds-knowledge/main/...`) instead of plugin's `docs/` paths. External AI agents fetch from the federated source.
- `llms-overview.md` restructured to show vendor/ paths (in-plugin) and knowledge-repo paths (canonical) side by side. Federation status table updated.

### Test plan

- [x] `node --test plugins/actian-design-system/tests/` — 948/948 pass
- [x] Registry loader at `shared-constants.js` reads cleanly from `vendor/components/registries/` (verified by component-keys-resolution tests)
- [x] golden fixture for `render-component-reference` updated for new KIT_HEADERS.source
- [ ] **Live verification (post-merge):** trigger one brief generation via `/component-brief` to confirm runtime reads from vendor/ work end-to-end against a real Figma push.

### Why MINOR (v1.78.0)

Plugin's internal paths changed from `docs/` to `vendor/`. Externally-observable contract (skills, MCP integration, push patterns) is unchanged. Plugin still works. `docs/` content stays in-tree until Phase 1.5 cleanup.

### Federation Phase 1 status after merge

- ✅ Phase 1.1 — knowledge repo standup, components/registries, 85 guidelines
- ✅ Phase 1.2 — foundations
- ✅ Phase 1.3 — content, tokens, app-context, accessibility, fm-to-ds-map
- ✅ Phase 1.4a — vendoring infrastructure (PR #51, v1.77.0)
- ✅ Phase 1.4b — path remap (this PR, v1.78.0)
- ⏳ Phase 1.5 — `/sync-design-system` decommission (after Smoke pass #2 in 1-2 weeks; MIGRATIONS.md Rule 1 parallel-change discipline)

### Spec / plan

- `plugins/actian-design-system/docs/superpowers/specs/2026-05-09-federation-phase-1-design.md` (untracked)
- Knowledge repo: https://github.com/volivarii/actian-ds-knowledge

🤖 Generated with [Claude Code](https://claude.com/claude-code)