### PR TITLE
chore(content): port PR #33 + sweep Phase 1.5 stale paths (v1.79.1)

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,11 +24,12 @@ Iterate inside the loop with **refine** (paste a screen-frame URL + edit instruc
 - Compare two competing designs side by side (also works between branches and variants)
 - Research UX patterns and competitor approaches on demand
 - Build presentations using Actian slide templates
-- Sync tokens, components, foundations, and guidelines directly from Figma — auto-stubs missing component guidelines and auto-bumps the plugin version on data change
 
 The guidelines hold throughout — tokens, spacing, content rules, accessibility — but the output stays creative within them.
 
-**v1.67.0** · 9 skills (tiered generation: recognized / adapted / improvised) · 9 agents · 23 recipes · 155 design tokens across 8 collections · 3 themes · WCAG 2.1 AA · surgical refine engine · vision-grounded references · interactive gates · MD-as-SoT foundations · component briefs with Section 1 supercard (anatomy + variation + tokens + specs / usages / content / motion / accessibility) — Section 6 (real platform examples) deferred
+DS knowledge (tokens, components, foundations, content + accessibility guidelines) is vendored from [`volivarii/actian-ds-knowledge`](https://github.com/volivarii/actian-ds-knowledge) — the canonical source-of-truth repo synced directly from Figma. The plugin pulls a pinned snapshot nightly via `vendor-snapshot.yml`.
+
+**v1.79.1** · 8 skills (tiered generation: recognized / adapted / improvised) · 9 agents · 23 recipes · 155 design tokens across 8 collections · 3 themes · WCAG 2.1 AA · surgical refine engine · vision-grounded references · interactive gates · federated knowledge substrate · component briefs with Section 1 supercard (anatomy + variation + tokens + specs / usages / content / motion / accessibility) — Section 6 (real platform examples) deferred
 
 ---
 

--- a/plugins/actian-design-system/.claude-plugin/plugin.json
+++ b/plugins/actian-design-system/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "actian-design-system",
   "description": "Actian Design System toolkit — generate wireframe flows with prototype wiring, create component briefs, audit designs, compare flows, and build presentations. 8 skills (with tiered generation: recognized / adapted / improvised), 8 agents, 155 tokens (3 themes, 8 collections), WCAG 2.1 AA. DS knowledge vendored from volivarii/actian-ds-knowledge.",
-  "version": "1.79.0",
+  "version": "1.79.1",
   "author": {
     "name": "Actian UX Team"
   },

--- a/plugins/actian-design-system/ARCHITECTURE.md
+++ b/plugins/actian-design-system/ARCHITECTURE.md
@@ -16,7 +16,7 @@ sections below are authoritative as of v1.62.1.
 | `.claude-plugin/` | Plugin manifest (`plugin.json`) — name, version, marketplace metadata. |
 | `agents/` | Subagents dispatched by skills. One `.md` per agent. |
 | `commands/` | (none currently — slash commands are co-located with skills) |
-| `docs/` | Source-of-truth design docs. `foundations.md`, `content-guidelines.md`, `accessibility-guidelines.md`, plus `component-guidelines/` (per-component MDs) and `generated/` (auto-derived JSON registries). |
+| `vendor/` | Vendored snapshot of `volivarii/actian-ds-knowledge` — design docs (`foundations/`, `content/`, `accessibility/`), per-component guidelines (`components/guidelines/`), component registries (`components/registries/`), tokens (`tokens/`), app context (`app-context/`), FM↔DS map (`fm-to-ds-map/`), presentation guide (`presentation/`). Refreshed nightly via `vendor-snapshot.yml`. Treat as read-only — edits belong upstream. |
 | `examples/` | Reference outputs for skills (sample flows, briefs, presentations). |
 | `evals/` | Eval suites for skills. |
 | `hooks/` | `hooks.json` — PreToolUse/PostToolUse hooks wired to scripts under `scripts/` (will move to `scripts/hooks/` in PR-2). |
@@ -28,7 +28,7 @@ sections below are authoritative as of v1.62.1.
 | `skills/` | One subdir per user-facing skill, each with a `SKILL.md`. |
 | `templates/` | Per-skill HTML/JSON templates. |
 | `tests/` | Bun test suite. PR-3 will mirror `scripts/` structure. |
-| `tokens/` | DTCG design tokens (`actian-ds.tokens.json`). |
+| `vendored.json` | Pinned knowledge-repo SHA + sync metadata for the current vendor snapshot. |
 
 ---
 

--- a/plugins/actian-design-system/agents/brief-researcher.md
+++ b/plugins/actian-design-system/agents/brief-researcher.md
@@ -40,10 +40,10 @@ You will receive:
 - **Component name** and **slug** (e.g., "Button" / "button")
 - **Scoped cards** — array of card keys to research (subset of `card_usage`, `card_content`, `card_accessibility`)
 - **Existing context** — inlined contents of:
-  - `docs/component-guidelines/<slug>.json`
-  - `docs/foundations.md` (relevant excerpts)
-  - `docs/content-guidelines.md`
-  - `docs/accessibility-guidelines.md`
+  - `vendor/components/guidelines/<slug>.json`
+  - `vendor/foundations/foundations.md` (relevant excerpts)
+  - `vendor/content/content.md`
+  - `vendor/accessibility/accessibility.md`
 - **Output path** for the findings JSON
 
 ## Research targets
@@ -90,7 +90,7 @@ Use `WebSearch` for discovery, `WebFetch` for the canonical doc page per DS.
     "divergences_from_existing": [
       {
         "field": "primary_action_position",
-        "existing": "right-aligned per docs/content-guidelines.md",
+        "existing": "right-aligned per vendor/content/content.md",
         "research": "left-aligned in 4/5 surveyed DSs",
         "note": "Designer review needed"
       }

--- a/plugins/actian-design-system/agents/card-generator.md
+++ b/plugins/actian-design-system/agents/card-generator.md
@@ -84,6 +84,7 @@ If your batch includes a Phase A key, that's a bug in the dispatcher — report 
 - Every card object MUST have `_source: "generated"` — validator will reject cards without it.
 - All token names use `--zen-` prefix (DS Kit) or `--fm-` prefix (FM). No hardcoded hex.
 - No truncation — complete all arrays, all variant rows, all properties.
+- **Example copy:** Any example/specimen text inside generated cards (button labels, error messages, placeholder text, table cells, tooltips) must comply with `vendor/content/content.md` — sentence case, verb + object button labels, no banned words (please, sorry, ensure, execute, abort, sign in, disabled), realistic placeholders that model input rather than repeating the field label.
 - Write the file silently — do not output the JSON to chat.
 - Reconciliation rule on research: existing context wins. Research informs; never overrides.
 - If you cannot generate a card, write the card key with an empty object + `_source: "generated"` + `_fallback: true` + `_fallbackReason: "<short>"` and report DONE_WITH_CONCERNS.

--- a/plugins/actian-design-system/agents/flow-consistency.md
+++ b/plugins/actian-design-system/agents/flow-consistency.md
@@ -60,7 +60,7 @@ For each screen, verify:
 
 ### 4. Check terminology
 
-Scan all visible text in the HTML for terminology violations. Load `docs/generated/app-context.json` → `terminology` section. For each term, check if any `notUse` values appear in visible text (case-insensitive word-boundary match):
+Scan all visible text in the HTML for terminology violations. Load `vendor/app-context/app-context.json` → `terminology` section. For each term, check if any `notUse` values appear in visible text (case-insensitive word-boundary match):
 
 | Wrong | Correct |
 |-------|---------|

--- a/plugins/actian-design-system/agents/flow-researcher.md
+++ b/plugins/actian-design-system/agents/flow-researcher.md
@@ -64,7 +64,7 @@ Use WebSearch to find how 2-3 best-in-class SaaS apps handle this specific flow:
 
 ### 4. Component guidelines
 
-Check if `docs/component-guidelines/<relevant>.json` exists for components involved in this flow. Extract design rules and content rules that apply.
+Check if `vendor/components/guidelines/<relevant>.json` exists for components involved in this flow. Extract design rules and content rules that apply.
 
 ## Output format
 

--- a/plugins/actian-design-system/agents/screen-generator.md
+++ b/plugins/actian-design-system/agents/screen-generator.md
@@ -68,7 +68,7 @@ When the fingerprint pushes you off the obvious tier-1 recipe and the screen end
 
 ## Step -1: Property completeness pre-check
 
-**Run this once per screen before writing INSTANCE nodes.** Do NOT do per-component registry dumps with python or repeated reads of `docs/generated/fmkit.json` / `docs/generated/dskit.json` — use the CLI helper:
+**Run this once per screen before writing INSTANCE nodes.** Do NOT do per-component registry dumps with python or repeated reads of `vendor/components/registries/fmkit.json` / `vendor/components/registries/dskit.json` — use the CLI helper:
 
 ```bash
 source "${CLAUDE_PLUGIN_ROOT}/scripts/lib/resolve-node.sh"
@@ -103,7 +103,7 @@ Use the output to write each `{ type: "INSTANCE", ref: "<slug>", props: {...} }`
 
    - **Recipe match** — does any single recipe in `recipes/flow/_index.json` (entries WITHOUT `kind: "composition"`) cleanly fit the screen's purpose?
    - **Composition fit** — does the screen need 2 recipes composed? Check `recipes/flow/_index.json` entries WITH `kind: "composition"`. The composition's `composes` array names the base recipes; if both base recipes describe parts of the screen, this composition is a fit.
-   - **App-context precedent** — read `docs/generated/app-context.json`. Does the feature have precedent in Studio / Explorer / Administration? Strong precedent → tier 1; no precedent → tier 3.
+   - **App-context precedent** — read `vendor/app-context/app-context.json`. Does the feature have precedent in Studio / Explorer / Administration? Strong precedent → tier 1; no precedent → tier 3.
    - **Reference URLs (`--ref` from prompt)** — if the prompt provides reference URLs, weigh whether they confirm the matched recipe (tier 1 still valid) or signal deviation desire (tier 2 minimum).
    - **Domain novelty** — is the feature in app-context's entity set, or new? Novel domain → tier 3.
 
@@ -170,7 +170,7 @@ Apply different rules for content generation per the classified tier:
 ### Tier 1 — Recognized
 
 - Follow the `matchedRecipe` skeleton exactly. Don't add or remove top-level sections.
-- Variant selection, copy, density follow defaults from `docs/generated/app-context.json` and `docs/component-guidelines/*.json`.
+- Variant selection, copy, density follow defaults from `vendor/app-context/app-context.json` and `vendor/components/guidelines/*.json`.
 - Minor deviations within slots (column count in a table, button order in a toolbar) allowed without justification — these are creative latitude, not soft deviation.
 - **Boundary:** "minor" means the change does not add or remove a content section from the recipe's top-level slots. If you find yourself adding a slot that wasn't in the recipe (e.g., a sidebar to a `table-list` recipe), that's no longer minor — escalate to tier 2 deviation and justify, or pick a different (composition) recipe.
 
@@ -222,7 +222,8 @@ Example for screens 4-6:
 - All buttons must set `"👁 Leading Icon": false, "👁 Trailing Icon": false`
 - Use `primaryAxisAlignItems: "SPACE_BETWEEN"` for push-apart layouts — never Spacer frames
 - **Glossary:** If `meta._glossary` is present, use it as the single source for entity names in page headers/breadcrumbs/body text, action verbs in button labels/CTAs, and the active sidebar item. Never invent alternative phrasings for glossary terms.
-- **Entity properties:** If generating form fields, table columns, or detail page content for a known entity, read `docs/generated/app-context.json` → `entities[entityId].properties` for standard field names. Use these instead of generic placeholders.
+- **Entity properties:** If generating form fields, table columns, or detail page content for a known entity, read `vendor/app-context/app-context.json` → `entities[entityId].properties` for standard field names. Use these instead of generic placeholders.
+- **Copy:** All visible text must follow Actian content guidelines per `vendor/content/content.md` — sentence case everywhere; verb + object button labels ("Create data product", "Delete connection"); no banned words (please, sorry, ensure, execute, abort, sign in, disabled); empty states include a headline + body + CTA; placeholder text models input and never repeats the field label.
 - Feature focus: spotlight the feature, placeholder everything else. **Concrete enforcement:** for any `fmNavItem` / `fmTab` that is NOT the active marker for the screen's feature, use `variant: "State=Placeholder"` (or substitute an `fmPlaceholder` instance). Only the single nav-item whose label matches `meta._glossary.sidebarActive` may carry `State=On` with a real label. The validator enforces this as `unmuted-chrome` warning at push time. **For destructive flows** (delete confirmations, bulk-remove footers, account-deletion modals): set `intent: "destructive-action"` on the dialog/section FRAME — descendants inherit. The Cancel button stays at default (inherits cluster intent). For success-confirmation toasts and error banners, set `intent: "success-confirmation"` or `"error-state"` on the relevant FRAME. The `intent` field is metadata only at FM tier — `/convert-to-hifi` reads it to pick correct DS variants, and the hifi-tier validator enforces consistency.
 - **`screen.id` (auto-stamped, B-refine.1):** You MAY emit a kebab-case `id` field on each screen, but the validator (`scripts/validation/validate-flow-data.js`) stamps `<feature-slug>-<index>` automatically when omitted. User-supplied ids are preserved unchanged. The id is the stable handle for refine + scope-aware gating + bulk ops; downstream consumers always see one populated.
 - Write the file silently — do not output the JSON to chat

--- a/plugins/actian-design-system/agents/slide-generator.md
+++ b/plugins/actian-design-system/agents/slide-generator.md
@@ -33,7 +33,7 @@ You will receive:
 ## Process
 
 1. Read `references/generate-presentation/figma-spec-builder.md` for the slide schema and chart patterns
-2. Read `docs/presentation-guide.md` for voice & tone, typography, colors
+2. Read `vendor/presentation/presentation-guide.md` for voice & tone, typography, colors
 3. For each assigned slide, generate the slide object following the schema exactly
 4. Write the partial JSON to the specified output path
 

--- a/plugins/actian-design-system/evals/component-brief/grader.md
+++ b/plugins/actian-design-system/evals/component-brief/grader.md
@@ -72,7 +72,7 @@ for any of:
 - `--zen-font-body-stardard` (the v1.71.0 typo)
 - `--zen-color-them` (truncation seen in some failed runs)
 - Any `--zen-` prefix followed by a word containing a doubled letter
-  pair that doesn't appear in `tokens/actian-ds.tokens.json`
+  pair that doesn't appear in `vendor/tokens/tokens.json`
 
 - **Pass:** no matches
 - **Fail:** any match

--- a/plugins/actian-design-system/recipes/brief/card-accessibility.json
+++ b/plugins/actian-design-system/recipes/brief/card-accessibility.json
@@ -3,7 +3,7 @@
   "title": "Accessibility",
   "description": "6 requirement cards in 2x3 grid, contrast table, ARIA specification table",
   "phase": "generate",
-  "grounding": ["docs/accessibility-guidelines.md"],
+  "grounding": ["vendor/accessibility/accessibility.md"],
   "research": {
     "applicable": true,
     "focus": ["a11y-patterns", "wcag-interpretation", "keyboard-screenreader"]

--- a/plugins/actian-design-system/recipes/brief/card-anatomy.json
+++ b/plugins/actian-design-system/recipes/brief/card-anatomy.json
@@ -3,7 +3,7 @@
   "title": "Anatomy",
   "description": "Component structure with positioned leader-line badges, dimension annotations with real Meta Kit components, specs table with token cross-references, and interactive state row",
   "phase": "generate",
-  "grounding": ["docs/foundations.md"],
+  "grounding": ["vendor/foundations/foundations.md"],
   "sections": {
     "parts": "Letter-labeled callouts (A, B, C...) for every visible sub-element. figmaLayerName must match actual Figma layer names — badges are positioned by reading layer bounding boxes. Include container, text elements, icons, dividers — anything a developer needs to know about.",
     "specs": "Dimension annotations positioned on the component using Meta / Content / Dimension Annotation (Horizontal/Vertical) and Meta / Content / Pointer Badge (Left/Right/Up/Down) components. Each entry has: value (e.g. '24px', '4px'), layerName (Figma layer to anchor to), orientation (Horizontal/Vertical for Dimension Annotation) OR direction (Left/Right/Up/Down for Pointer Badge), and optional side/offset for positioning.",

--- a/plugins/actian-design-system/recipes/brief/card-component.json
+++ b/plugins/actian-design-system/recipes/brief/card-component.json
@@ -3,7 +3,7 @@
   "title": "Component",
   "description": "Real library instances showing all variants plus themed component comparison across Actian, Studio, and Explorer",
   "phase": "generate",
-  "grounding": ["docs/component-guidelines/<slug>.json"],
+  "grounding": ["vendor/components/guidelines/<slug>.json"],
   "sections": {
     "variantAxes": "List ALL variant axes from the component set. Common axes: Type, State, Size, Style. Never omit axes even if they have only 2 values.",
     "variantMatrix": "Rows = primary axis (usually Type or Style), columns = secondary axis (usually State). Must include EVERY variant combination — never truncate. If the matrix would exceed 8 columns, split into multiple rows per primary axis value.",

--- a/plugins/actian-design-system/recipes/brief/card-content.json
+++ b/plugins/actian-design-system/recipes/brief/card-content.json
@@ -4,9 +4,13 @@
   "description": "Copy rules with do/don't examples plus terminology table",
   "phase": "transcribe",
   "source": {
-    "primary": { "type": "guidelines-content-sections", "registry": "docs/component-guidelines/<slug>.json", "field": "content_guidelines.sections" },
+    "primary": {
+      "type": "guidelines-content-sections",
+      "registry": "vendor/components/guidelines/<slug>.json",
+      "field": "content_guidelines.sections"
+    },
     "fallback": "claude-generate",
-    "grounding": ["docs/content-guidelines.md"]
+    "grounding": ["vendor/content/content.md"]
   },
   "research": {
     "applicable": true,

--- a/plugins/actian-design-system/recipes/brief/card-header.json
+++ b/plugins/actian-design-system/recipes/brief/card-header.json
@@ -4,7 +4,11 @@
   "description": "Component name and description — the brief's title card",
   "phase": "transcribe",
   "source": {
-    "primary": { "type": "registry-description", "registry": "docs/generated/dskit.json", "field": "description" },
+    "primary": {
+      "type": "registry-description",
+      "registry": "vendor/components/registries/dskit.json",
+      "field": "description"
+    },
     "secondary": { "type": "figma-mcp", "field": "node.description" },
     "fallback": "claude-generate",
     "grounding": []

--- a/plugins/actian-design-system/recipes/brief/card-motion.json
+++ b/plugins/actian-design-system/recipes/brief/card-motion.json
@@ -1,18 +1,18 @@
 {
   "card": "card_motion",
   "title": "Behavior & motion",
-  "description": "Conditional card. Renders only when the component has behavior.motion.pattern set in its component-guidelines JSON. Pulls phase rows from docs/generated/foundations/interaction-motion.json#patterns.<slug>.",
+  "description": "Conditional card. Renders only when the component has behavior.motion.pattern set in its component-guidelines JSON. Pulls phase rows from vendor/foundations/interaction-motion.json#patterns.<slug>.",
   "phase": "transcribe",
   "source": {
     "primary": {
       "type": "motion-pattern-lookup",
-      "registry": "docs/component-guidelines/<slug>.json",
+      "registry": "vendor/components/guidelines/<slug>.json",
       "field": "behavior.motion.pattern",
-      "patternRegistry": "docs/generated/foundations/interaction-motion.json",
+      "patternRegistry": "vendor/foundations/interaction-motion.json",
       "patternKey": "patterns.<pattern>"
     },
     "fallback": "skip-card",
-    "grounding": ["docs/foundations.md"]
+    "grounding": ["vendor/foundations/foundations.md"]
   },
   "research": {
     "applicable": false

--- a/plugins/actian-design-system/recipes/brief/card-tokens.json
+++ b/plugins/actian-design-system/recipes/brief/card-tokens.json
@@ -3,7 +3,10 @@
   "title": "Design tokens",
   "description": "Color, sizing, and typography token bindings by component state",
   "phase": "generate",
-  "grounding": ["docs/foundations.md", "tokens/actian-ds.tokens.json"],
+  "grounding": [
+    "vendor/foundations/foundations.md",
+    "vendor/tokens/tokens.json"
+  ],
   "sections": {
     "colorTokens": "State-by-state color breakdown. Columns: one per visual element that has a color (Border, Label, Background, Icon, etc). Rows: one per interactive state. Include Default, Focused, Error, Disabled at minimum. More states if the component has them (Hovered, Active, Selected).",
     "sizingTokens": "Every fixed dimension with its token name and resolved pixel value. Cover: height, horizontal padding, vertical padding, internal gaps, border-radius, border-width, icon size.",

--- a/plugins/actian-design-system/recipes/brief/card-usage.json
+++ b/plugins/actian-design-system/recipes/brief/card-usage.json
@@ -3,7 +3,10 @@
   "title": "Usage guidelines",
   "description": "When to use, when not to use, and do/don't pairs with concrete UI examples",
   "phase": "generate",
-  "grounding": ["docs/content-guidelines.md", "docs/component-guidelines/<slug>.json"],
+  "grounding": [
+    "vendor/content/content.md",
+    "vendor/components/guidelines/<slug>.json"
+  ],
   "research": {
     "applicable": true,
     "focus": ["usage-patterns", "when-to-use", "do-dont"]

--- a/plugins/actian-design-system/references/ds-rules/quality-checklist.md
+++ b/plugins/actian-design-system/references/ds-rules/quality-checklist.md
@@ -85,7 +85,7 @@ Items specific to the `generate-flow` skill, in addition to Universal.
 | 6 | **Missing states flagged** | Empty, error, loading, and confirmation states are included (or explicitly noted as out of scope). |
 | 7 | **Reading order** | Screens flow left-to-right, top-to-bottom. One row per sub-flow, no wrapping. |
 | 8 | **Custom elements follow FM conventions** | `fm-custom-` prefix, `--fm-*` variables, FM spacing/typography, HTML comment explaining purpose. Lo-fi fidelity. |
-| 9 | **Content guidelines applied** | Button labels use action verbs (title case). Form labels are concise (no colons). Error messages explain what + how to fix. |
+| 9 | **Content guidelines applied** | Sentence case on all UI text (not title case). Buttons are verb + object ("Save changes", not "Save Changes" or bare "Save"). Form labels concise (no colons). Error messages explain what + how to fix. No banned words (please, sorry, ensure, execute, abort, sign in, disabled). Placeholder text models input — never repeats the label. See `../../vendor/content/content.md`. |
 | 10 | **Accessibility basics** | Interactive elements have focus indicators. Form inputs have labels. No text below 11px. Color is not the only status indicator. |
 
 ---

--- a/plugins/actian-design-system/schemas/brief-data.schema.json
+++ b/plugins/actian-design-system/schemas/brief-data.schema.json
@@ -432,7 +432,7 @@
     },
     "card_motion": {
       "type": "object",
-      "description": "Behavior & motion card (DS mode) — conditional. Only present when the component has a curated motion pattern (component-guidelines/<slug>.json behavior.motion.pattern is set). Pattern data is sourced from docs/generated/foundations/interaction-motion.json.",
+      "description": "Behavior & motion card (DS mode) — conditional. Only present when the component has a curated motion pattern (vendor/components/guidelines/<slug>.json behavior.motion.pattern is set). Pattern data is sourced from vendor/foundations/interaction-motion.json.",
       "properties": {
         "_source": {
           "type": "string",

--- a/plugins/actian-design-system/scripts/lib/shared-constants.js
+++ b/plugins/actian-design-system/scripts/lib/shared-constants.js
@@ -186,7 +186,7 @@ function buildKeyMapFromRegistry(registryName, prefix, section, overrides) {
 // Ref-name → registry-slug mappings (only source of duplication)
 // ---------------------------------------------------------------------------
 
-// Slug values match the canonical keys in docs/generated/metakit.json. The REST sync
+// Slug values match the canonical keys in vendor/components/registries/metakit.json. The REST sync
 // orchestrator (Sprint 1) normalizes Figma component names through a single
 // slugify pass that collapses runs of non-alphanumeric chars to "-", which
 // dropped the legacy "meta-/-X-/-Y" form on 2026-04-30. Keep this table in

--- a/plugins/actian-design-system/scripts/renderers/figma-table/schemas/render-table.json
+++ b/plugins/actian-design-system/scripts/renderers/figma-table/schemas/render-table.json
@@ -73,8 +73,15 @@
       "required": ["type", "value"],
       "properties": {
         "type": { "const": "text" },
-        "value": { "type": "string", "description": "Display text. Multi-line via \\n." },
-        "weight": { "type": "string", "enum": ["regular", "semibold"], "default": "regular" }
+        "value": {
+          "type": "string",
+          "description": "Display text. Multi-line via \\n."
+        },
+        "weight": {
+          "type": "string",
+          "enum": ["regular", "semibold"],
+          "default": "regular"
+        }
       }
     },
     "tokenPillCell": {
@@ -86,7 +93,7 @@
         "value": {
           "type": "string",
           "pattern": "^--zen-",
-          "description": "Token name. Validated against tokens/actian-ds.tokens.json at boundary."
+          "description": "Token name. Validated against vendor/tokens/tokens.json at boundary."
         }
       }
     },
@@ -96,7 +103,10 @@
       "required": ["type", "value"],
       "properties": {
         "type": { "const": "code" },
-        "value": { "type": "string", "description": "Code snippet. Rendered in Fira Code monospace." }
+        "value": {
+          "type": "string",
+          "description": "Code snippet. Rendered in Fira Code monospace."
+        }
       }
     },
     "badgeCell": {

--- a/plugins/actian-design-system/scripts/transformers/brief-sourcing.js
+++ b/plugins/actian-design-system/scripts/transformers/brief-sourcing.js
@@ -37,7 +37,7 @@ function transcribeContentGuidelines(guidelinesJson) {
 }
 
 // Motion is a registry-derived card (pattern data lives in
-// docs/generated/foundations/interaction-motion.json under #patterns.<slug>).
+// vendor/foundations/interaction-motion.json under #patterns.<slug>).
 // The component-guideline only declares which pattern + optional overrides;
 // the canonical phase data comes from foundations. Caller passes
 // ctx.motionPatterns (the patterns object from interaction-motion.json).

--- a/plugins/actian-design-system/scripts/transformers/transform-registry.js
+++ b/plugins/actian-design-system/scripts/transformers/transform-registry.js
@@ -16,7 +16,7 @@
 //     standaloneNodes:   Object<nodeId, NodePayload>  // batched /nodes for standalones
 //   }
 //
-// Output: registry JSON, same shape as docs/generated/dskit.json / fmkit.json / metakit.json.
+// Output: registry JSON, same shape as vendor/components/registries/{dskit,fmkit,metakit}.json.
 
 var DESCRIPTION_MAX = 200; // matches project_sync_skill_enhancements.md item #2
 

--- a/plugins/actian-design-system/scripts/vendor/vendor-snapshot.js
+++ b/plugins/actian-design-system/scripts/vendor/vendor-snapshot.js
@@ -11,10 +11,10 @@
 //   node scripts/vendor/vendor-snapshot.js               (pulls SHA from vendored.json)
 //   node scripts/vendor/vendor-snapshot.js --sha <sha>   (override SHA, also rewrites vendored.json)
 //
-// Phase 1.4b will rewrite consumer paths (e.g. docs/foundations.md →
-// vendor/foundations/foundations.md) so vendored content actually
-// becomes the source of truth at runtime. For Phase 1.4a, vendor/ is
-// populated but unused — plugin still reads from docs/, tokens/, etc.
+// Phase 1.5 (shipped) rewrote all consumer paths to read from vendor/
+// — the plugin no longer maintains its own docs/ or tokens/ trees.
+// vendored.json#knowledge_repo_sha pins the snapshot; vendor-snapshot.yml
+// refreshes it nightly and bumps plugin.json patch on diff.
 
 var fs = require("fs");
 var path = require("path");
@@ -69,14 +69,17 @@ function fetchTarball(sha, destPath) {
   // GitHub returns a tarball at this URL for any SHA on a public repo. No auth
   // needed. The .tar.gz contains a single top-level directory like
   // `actian-ds-knowledge-<full-sha>/` with the repo content inside.
-  var url = "https://github.com/" + KNOWLEDGE_REPO + "/archive/" + sha + ".tar.gz";
+  var url =
+    "https://github.com/" + KNOWLEDGE_REPO + "/archive/" + sha + ".tar.gz";
   process.stdout.write("[vendor] fetching " + url + "\n");
   execFileSync("curl", ["-sSL", "-o", destPath, url], { stdio: "inherit" });
 }
 
 function extractTarball(tarballPath, destDir) {
   fs.mkdirSync(destDir, { recursive: true });
-  execFileSync("tar", ["-xzf", tarballPath, "-C", destDir], { stdio: "inherit" });
+  execFileSync("tar", ["-xzf", tarballPath, "-C", destDir], {
+    stdio: "inherit",
+  });
   // After extraction, destDir contains a single subdir like
   // `actian-ds-knowledge-<sha>/`. Return its absolute path.
   var entries = fs.readdirSync(destDir).filter(function (e) {
@@ -84,7 +87,8 @@ function extractTarball(tarballPath, destDir) {
   });
   if (entries.length !== 1) {
     throw new Error(
-      "[vendor] expected exactly one top-level dir in tarball, got " + entries.length,
+      "[vendor] expected exactly one top-level dir in tarball, got " +
+        entries.length,
     );
   }
   return path.join(destDir, entries[0]);

--- a/plugins/actian-design-system/skills/convert-to-hifi/SKILL.md
+++ b/plugins/actian-design-system/skills/convert-to-hifi/SKILL.md
@@ -186,6 +186,16 @@ Apply DS spacing tokens and layout rules to every container before pushing:
 - Typography: map FM text sizes to DS text style tokens (body, label, heading tiers)
 - See `references/ds-rules/component-instance-rules.md` for property-setting rules
 
+### Copy polish
+
+Before pushing, audit all visible text against `vendor/content/content.md`:
+- Sentence case on all UI text (buttons, labels, headings, column headers, placeholders)
+- Buttons: verb + object ("Save changes", not "Save Changes" and not bare "Save")
+- No banned words: please, sorry, ensure, execute, abort, sign in, signin, disabled
+- Error messages: state what went wrong + how to fix it (never just "Invalid" or "Error")
+- Empty states: headline + one-sentence body + one CTA button
+- Placeholder text: models expected input — never repeats the field label
+
 ### Push sequence (one small `use_figma` call per step)
 
 1. **Create wrapper frame** — same parent as original, named `"[Original name] — HiFi wrapper"`, `HORIZONTAL` auto layout, gap 32, no fills. This holds the gen card and hifi frame side by side.

--- a/plugins/actian-design-system/skills/create-component/SKILL.md
+++ b/plugins/actian-design-system/skills/create-component/SKILL.md
@@ -64,7 +64,7 @@ Every component exposes: text properties (titles, labels), boolean properties (o
 
 Run `../../references/ds-rules/quality-checklist.md` (Universal + Create Component sections). Then parity check per `../../references/figma/parity-check.md`: screenshot, dispatch `parity-analyzer`, fix P0s, write `.last-push.json`. Manifest includes `sourceHash`, `componentKeys`, and `tokenHash` — see `references/figma/parity-check.md` for computation.
 
-After creation, offer: "Want me to generate a component brief?" If accepted, invoke `component-brief`. Remind user to run `/sync-design-system` to update local references.
+After creation, offer: "Want me to generate a component brief?" If accepted, invoke `component-brief`. Remind user that the next nightly `vendor-snapshot.yml` run will pull the new component into `vendor/components/` once it's published in the knowledge repo's Figma sync.
 
 ## Key rules
 
@@ -72,6 +72,7 @@ After creation, offer: "Want me to generate a component brief?" If accepted, inv
 - Use `primaryAxisAlignItems: "SPACE_BETWEEN"` for push-apart layouts, never Spacer frames
 - Button booleans: `"👁 Leading Icon": false, "👁 Trailing Icon": false` by default
 - Never leave variableScopes as `ALL_SCOPES`
+- **Default text values:** Set all default text properties to copy that complies with `vendor/content/content.md` — sentence case, verb + object for action labels, realistic placeholder text that models input. Never ship "Label", "Text", "Lorem ipsum", or labels that just repeat the field name as defaults.
 
 ## References
 

--- a/plugins/actian-design-system/skills/design-audit/SKILL.md
+++ b/plugins/actian-design-system/skills/design-audit/SKILL.md
@@ -74,7 +74,7 @@ When `--scope` is set, run only the listed dimensions; otherwise run all.
 - **Forms layout** (scope: `all`): Simple inputs 480px max-width, extended elements full-width, action footer sticky bottom with primary right
 - **Missing states** (scope: `heuristic`, `all`): Empty, error, loading, confirmation states; form validation, disabled, required indicators
 - **Accessibility** (scope: `a11y`, `all`): WCAG AA contrast, visible focus states, no text below 11px
-- **Copy review** (scope: `copy`, `all`): Sentence case, action-oriented CTA verbs, no jargon, terminology consistent with `vendor/app-context/app-context.json` glossary, error messages explain what to do next
+- **Copy review** (scope: `copy`, `all`): Audit against `../../vendor/content/content.md` — sentence case on all UI text; verb + object button labels ("Save changes" not "Save Changes" or bare "Save"); no banned words (please, sorry, ensure, execute, abort, sign in, signin, disabled); error messages state what went wrong + how to fix it; empty states include headline + body + CTA; placeholder text models expected input and never repeats the field label; terminology consistent with `vendor/app-context/app-context.json` glossary
 - **Heuristic UX** (scope: `heuristic`, `all`) — *placeholder, full impl is engine work*: Surface a section in the report titled "Heuristic findings (preview)" describing IA clarity, task efficiency, and feedback patterns. Findings here are advisory until the engine work lands.
 
 ## Output format

--- a/plugins/actian-design-system/skills/generate-flow/SKILL.md
+++ b/plugins/actian-design-system/skills/generate-flow/SKILL.md
@@ -520,6 +520,7 @@ Push-apart row: `{ "type": "FRAME", "name": "Header Row", "layout": { "mode": "H
 - **Feature focus:** Spotlight the feature, placeholder everything else; build sidebar from navItems in flow-data.json
 - **Small direct calls:** Keep each `use_figma` call under 2KB
 - **No contentHtml:** Use structured content[] nodes (FRAME, TEXT, INSTANCE, DIVIDER) only
+- **Copy:** All visible text follows `vendor/content/content.md` — sentence case for all UI text, verb + object button labels ("Create data product"), no banned words (please, sorry, ensure, execute, abort, sign in, disabled), placeholder text models input (never repeats the field label), empty states include a headline + body + CTA
 
 ## References
 

--- a/plugins/actian-design-system/templates/component-playground-wrapper.html
+++ b/plugins/actian-design-system/templates/component-playground-wrapper.html
@@ -8,8 +8,10 @@
   <!-- Alpine.js — reactive state management for the playground controls -->
   <script defer src="https://cdn.jsdelivr.net/npm/alpinejs@3.14.9/dist/cdn.min.js"></script>
 
-  <!-- Design tokens — provides --zen-* CSS custom properties for all 3 themes -->
-  <link rel="stylesheet" href="../../tokens/tokens.css">
+  <!-- Design tokens — provides --zen-* CSS custom properties for all 3 themes.
+       Loaded from the canonical actian-ds-knowledge repo so the playground
+       works at any project location. -->
+  <link rel="stylesheet" href="https://raw.githubusercontent.com/volivarii/actian-ds-knowledge/main/tokens/tokens.css">
 
   <style>
     /* ============================================================

--- a/plugins/actian-design-system/tests/fixtures/brief/button-no-figma-description.json
+++ b/plugins/actian-design-system/tests/fixtures/brief/button-no-figma-description.json
@@ -4,5 +4,5 @@
   "fileKey": "test-file-key",
   "nodeId": "1:1",
   "nodeDescription": null,
-  "guidelinesJsonPath": "docs/component-guidelines/button.json"
+  "guidelinesJsonPath": "vendor/components/guidelines/button.json"
 }

--- a/plugins/actian-design-system/tests/fixtures/brief/button-with-figma-description.json
+++ b/plugins/actian-design-system/tests/fixtures/brief/button-with-figma-description.json
@@ -4,5 +4,5 @@
   "fileKey": "test-file-key",
   "nodeId": "1:1",
   "nodeDescription": "Primary action element. Use for the main call-to-action on a page or modal. Distinct from Link (semantic navigation) and Icon Button (compact icon-only action).",
-  "guidelinesJsonPath": "docs/component-guidelines/button.json"
+  "guidelinesJsonPath": "vendor/components/guidelines/button.json"
 }

--- a/plugins/actian-design-system/tests/integration/path-validation.test.js
+++ b/plugins/actian-design-system/tests/integration/path-validation.test.js
@@ -31,25 +31,19 @@ var SCAN_DIRS = [
 
 var SCAN_FILES = [path.join(PLUGIN_ROOT, "CLAUDE.md")];
 
-// Paths that only exist after running /sync-design-system, or are
-// gitignored secrets/local-only files. These are referenced in skill docs
-// — skip them in assertions but still log them so they stay visible.
+// Paths that are gitignored secrets/local-only files. These are referenced
+// in skill docs — skip them in assertions but still log them so they stay
+// visible.
 var KNOWN_SYNC_OUTPUTS = [
-  "docs/generated/meta-kit/meta-kit-reference.md",
-  "tokens/actian-ds.tokens.css",
-  "docs/foundations/_index.json",
-  // Sprint 1 Wave 1: REST orchestrator output, populated on first nightly run.
-  "docs/generated/meta-kit/styles.json",
   // Gitignored: contains the Figma PAT. Materialized from FIGMA_KEYS_JSON
-  // secret in the sync-from-figma workflow; never committed.
+  // secret in the knowledge-repo's sync-from-figma workflow; never committed.
   ".figma-keys.json",
 ];
 
 // Known root-relative prefixes (resolve from plugin root)
 var ROOT_PREFIXES = [
   "scripts/",
-  "docs/",
-  "tokens/",
+  "vendor/",
   "templates/",
   "references/",
   "skills/",

--- a/plugins/actian-design-system/tests/renderers/figma-table.test.js
+++ b/plugins/actian-design-system/tests/renderers/figma-table.test.js
@@ -9,7 +9,7 @@ var html = require("../../scripts/renderers/figma-table/render-html.js");
 // ---------------------------------------------------------------------------
 // Hermetic token set used by most tests so failures don't depend on the live
 // registry shape. Two dedicated tests below exercise loadTokenNames() against
-// tokens/actian-ds.tokens.json directly.
+// vendor/tokens/tokens.json directly.
 // ---------------------------------------------------------------------------
 
 var TEST_TOKENS = new Set([
@@ -458,7 +458,7 @@ test("validate rejects unexpected field on footnote", function () {
 // Set for hermeticism; this test confirms the walker handles the real shape.
 // ---------------------------------------------------------------------------
 
-test("loadTokenNames parses the live tokens/actian-ds.tokens.json registry", function () {
+test("loadTokenNames parses the live vendor/tokens/tokens.json registry", function () {
   var names = figma.loadTokenNames();
   assert.ok(names instanceof Set, "expected a Set");
   assert.ok(names.size > 100, "expected >100 tokens, got " + names.size);

--- a/plugins/actian-design-system/tests/transformers/brief-sourcing.test.js
+++ b/plugins/actian-design-system/tests/transformers/brief-sourcing.test.js
@@ -110,11 +110,11 @@ test("resolveSection — generate recipe → returns Phase B marker, no transcri
   var recipe = {
     card: "card_anatomy",
     phase: "generate",
-    grounding: ["docs/foundations.md"],
+    grounding: ["vendor/foundations/foundations.md"],
   };
   var result = sourcing.resolveSection("card_anatomy", ctx, recipe);
   assert.equal(result.phase, "B");
-  assert.deepEqual(result.grounding, ["docs/foundations.md"]);
+  assert.deepEqual(result.grounding, ["vendor/foundations/foundations.md"]);
 });
 
 test("resolveSection — content card with rich guidelines → figma result", function () {
@@ -197,11 +197,11 @@ test("resolveSection — stub guideline forces Phase B even on generate recipe (
   var recipe = {
     card: "card_anatomy",
     phase: "generate",
-    grounding: ["docs/foundations.md"],
+    grounding: ["vendor/foundations/foundations.md"],
   };
   var result = sourcing.resolveSection("card_anatomy", ctx, recipe);
   assert.equal(result.phase, "B");
-  assert.deepEqual(result.grounding, ["docs/foundations.md"]);
+  assert.deepEqual(result.grounding, ["vendor/foundations/foundations.md"]);
   assert.equal(result.fallback, true);
 });
 
@@ -289,7 +289,7 @@ test("card_motion — resolveSection returns figma source when guideline declare
   };
   var result = sourcing.resolveSection("card_motion", ctx, {
     phase: "transcribe",
-    grounding: ["docs/foundations.md"],
+    grounding: ["vendor/foundations/foundations.md"],
   });
   assert.equal(result.phase, "A");
   assert.equal(result.source, "figma");
@@ -304,7 +304,7 @@ test("card_motion — skipCard when guideline has no behavior.motion", function 
   };
   var result = sourcing.resolveSection("card_motion", ctx, {
     phase: "transcribe",
-    grounding: ["docs/foundations.md"],
+    grounding: ["vendor/foundations/foundations.md"],
   });
   assert.equal(result.phase, "A");
   assert.equal(result.source, null);
@@ -320,7 +320,7 @@ test("card_motion — fallback when slug references unknown pattern", function (
   };
   var result = sourcing.resolveSection("card_motion", ctx, {
     phase: "transcribe",
-    grounding: ["docs/foundations.md"],
+    grounding: ["vendor/foundations/foundations.md"],
   });
   assert.equal(result.phase, "A");
   assert.equal(result.fallback, true);


### PR DESCRIPTION
## Summary

Forward-port PR #33 (Jeff's content-guidelines integration — conflicting, stale, targeted pre-Phase-1.5 docs/ tree) to land the copy-discipline rules on the current vendor/ surface. Bundled with a deep sweep of Phase 1.5 stale path leftovers across agents, scripts, schemas, recipes, templates, and tests.

Closes the gap left after PR #33 + PR #54 (Phase 1.5).

## What's in here

**Skill + agent copy discipline (PR #33 forward-port):**
- `agents/card-generator` — example-copy compliance rule
- `agents/screen-generator` — visible-text copy rule
- `skills/convert-to-hifi` — full **Copy polish** subsection
- `skills/create-component` — default text values rule
- `skills/design-audit` — expanded copy-review rule
- `skills/generate-flow` — copy rule
- `references/ds-rules/quality-checklist.md` — title→sentence case + rule expansion

**Phase 1.5 stale path remaps:**
- 4 agents: brief-researcher, flow-researcher, flow-consistency, screen-generator
- 4 scripts: shared-constants.js, brief-sourcing.js, transform-registry.js, vendor-snapshot.js comments
- 2 schemas: brief-data.schema.json, render-table.json descriptions
- 8 brief recipes: all grounding paths repointed at \`vendor/\`

**Load-bearing fixes:**
- `agents/slide-generator` — presentation-guide path
- `templates/component-playground-wrapper.html` — broken stylesheet link now loads from canonical knowledge-repo CDN URL
- `evals/component-brief/grader.md` — token registry path

**Test cleanup:**
- 2 brief fixtures, path-validation allowlist + ROOT_PREFIXES, figma-table comment + test name, brief-sourcing fixture strings

**Doc updates:**
- `plugin.json` 1.79.0 → 1.79.1
- `ARCHITECTURE.md`: \`docs/\` + \`tokens/\` rows replaced with \`vendor/\` + \`vendored.json\`
- `README.md`: v1.67.0 → v1.79.1, 9 skills → 8, removed stale Sync bullet, added federated-knowledge note
- `create-component`: removed stale \`/sync-design-system\` reminder

## Test plan

- [x] 42/42 tests pass locally
- [ ] CI (\`tests + JSON syntax + plugin.json bumped\` checks)
- [ ] Smoke: trigger \`vendor-snapshot.yml\` manually post-merge to confirm regen still works against the bumped paths

## Knowledge-repo upstream PR still needed (out of scope)

These live inside \`vendor/\` so editing them here would be reverted by the next nightly snapshot:
- \`vendor/foundations/AUTHORING.md\` — 4 stale \`docs/\` refs in author instructions
- \`vendor/foundations/*.json\` (8 files) — \`"source": "docs/foundations.md"\` metadata
- \`vendor/fm-to-ds-map/fm-to-ds-map.json\` — fmRegistry/dsRegistry metadata
- \`vendor/accessibility/accessibility.md\` — auto-gen header comment

Will be addressed in a separate PR on \`volivarii/actian-ds-knowledge\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)