### PR TITLE
chore: Phase A cleanups + introduce paths.js (v1.79.3)

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,7 +176,6 @@ Every capability is also available as a direct command. Use these when you know 
 | `/create-component` | Build Figma components with variants and correct token binding, with a build plan review before push |
 | `/compare-flows` | Side-by-side analysis of two Figma flows — v1 vs v2, competing approaches, branches, variants |
 | `/generate-presentation` | Slide deck with Actian templates, token-bound backgrounds, and chart support |
-| `/sync-design-system` | Extract tokens, components, foundations, and guidelines directly from Figma via MCP. Auto-stubs missing component guidelines on additive/breaking verdicts, auto-bumps `plugin.json` on data change. |
 
 ---
 
@@ -241,16 +240,19 @@ Agents are dispatched automatically by skills — they run as background subproc
 
 ## Data architecture
 
-Figma libraries are the single source of truth. `/sync-design-system` extracts directly via MCP.
+Figma libraries are the single source of truth. `volivarii/actian-ds-knowledge` CI runs the syncs (`sync-from-figma.yml` daily at 07:00 UTC for registries, tokens, and foundations); the plugin vendors a pinned snapshot nightly (`vendor-snapshot.yml` at 09:00 UTC).
 
 ```
 Figma libraries (DS Kit + FM Kit + Meta Kit) + foundations.md (UX-authored)
     |
-/sync-design-system (Figma MCP)
+volivarii/actian-ds-knowledge CI (sync-from-figma + foundations-derive)
     |
-docs/generated/  -- registries, app-context, fm-to-ds-map, foundations JSONs
-docs/component-guidelines/  -- per-component (full + auto-stub)
-tokens/  -- W3C DTCG + CSS custom properties
+plugin's vendor/ snapshot (refreshed nightly via vendor-snapshot.yml)
+    ├─ vendor/components/registries/  -- DS Kit + FM Kit + Meta Kit registries
+    ├─ vendor/components/guidelines/  -- per-component guidelines (44 curated + 41 auto-stubs)
+    ├─ vendor/foundations/            -- foundations.md + 8 derived JSONs
+    ├─ vendor/tokens/                 -- DTCG + CSS custom properties
+    ├─ vendor/{content,accessibility,presentation,app-context,fm-to-ds-map}/
     |
 Companion + skills read at runtime
 ```
@@ -291,17 +293,16 @@ actian-design-system-plugin/
 │   ├── .claude-plugin/plugin.json
 │   ├── ARCHITECTURE.md                    # canonical map (read first)
 │   ├── CLAUDE.md
-│   ├── skills/                            # 9 skills (companion + 8 specialized)
-│   ├── agents/                            # 9 agents (6 validation/research + 3 parallel generation)
-│   ├── recipes/                           # 23 recipes (11 flow, 7 brief cards, 5 presentation)
+│   ├── skills/                            # 8 skills (companion + 7 specialized)
+│   ├── agents/                            # parallel-generation + validation/research agents
+│   ├── recipes/                           # flow + brief + presentation recipes
 │   ├── scripts/
-│   │   ├── lib/                           # shared-constants, registry loaders, palette, buildGenLog
+│   │   ├── lib/                           # paths.js, shared-constants, registry loaders, palette, buildGenLog
 │   │   ├── hooks/                         # Claude Code hook guards
-│   │   ├── sync/                          # /sync-design-system phases + helpers
-│   │   ├── foundations/                   # foundations.md → JSON regeneration
+│   │   ├── vendor/                        # vendor-snapshot pipeline (pulls knowledge repo)
 │   │   ├── validation/                    # validate-flow-data, validate-schema, validateBriefData
-│   │   ├── transformers/                  # fm-tree-to-flow-data, transform-to-hifi, sync-fm-to-ds-map
-│   │   ├── renderers/                     # assemble-preview + html-renderers
+│   │   ├── transformers/                  # fm-tree-to-flow-data, transform-to-hifi
+│   │   ├── renderers/                     # assemble-preview + html-renderers + render-component-reference
 │   │   └── changelog/                     # push-to-push diffing
 │   ├── references/
 │   │   ├── figma/                         # MCP workflow, push patterns, parity, prototype, annotations
@@ -345,11 +346,11 @@ claude --plugin-dir plugins/actian-design-system
 
 | What changed | What to do |
 |-------------|------------|
-| Tokens/components in Figma | `/sync-design-system all` (auto-bumps plugin.json on data change) |
-| Single component's guidelines | `/sync-design-system Button` |
-| Foundation docs | edit `docs/foundations.md` — CI regenerates derived JSONs on PR |
+| Tokens/components in Figma | Knowledge repo's `sync-from-figma.yml` runs nightly (07:00 UTC) and opens an additive PR; the plugin's `vendor-snapshot.yml` then propagates it (09:00 UTC) and auto-bumps `plugin.json`. To force a refresh, manually trigger `vendor-snapshot.yml` in the plugin repo. |
+| Single component's guidelines | Edit upstream in `volivarii/actian-ds-knowledge` (`components/guidelines/<slug>.json`); the next vendor-snapshot pulls the change. |
+| Foundation docs | Edit upstream in `volivarii/actian-ds-knowledge` (`foundations/foundations.md`); CI regenerates derived JSONs on PR; the next vendor-snapshot pulls them. |
 | New skill | Add `skills/<name>/SKILL.md` and update `ARCHITECTURE.md` Section 2 |
-| Version bump | Handled automatically by `/sync-design-system` on additive/breaking verdicts; manual bumps in `.claude-plugin/plugin.json` |
+| Version bump | Handled automatically by `vendor-snapshot.yml` on knowledge-repo data change; manual bumps in `.claude-plugin/plugin.json` |
 
 ---
 

--- a/USAGE.md
+++ b/USAGE.md
@@ -123,7 +123,7 @@ audit this
 
 Runs `/design-audit` — tokens, contrast, copy, heuristics — with confidence-scored findings. Auto-fix what's safe, flag what needs judgment.
 
-> **Content designer's path:** `audit this --scope copy --fix all` rewrites strings against `docs/content-guidelines.md` — sentence case, action verbs, error-message patterns, empty-state CTAs — applied automatically.
+> **Content designer's path:** `audit this --scope copy --fix all` rewrites strings against `vendor/content/content.md` — sentence case, action verbs, error-message patterns, empty-state CTAs — applied automatically.
 >
 > **A11y specialist's path:** `audit this --scope a11y` focuses on contrast (4.5:1 normal, 3:1 large), focus order, and target sizes (44×44px min). Other findings stay quiet.
 
@@ -448,7 +448,6 @@ Every capability is also a direct command. Use these when you know exactly what 
 | `/create-component [description]` | Jump to component creation |
 | `/compare-flows [URL1] [URL2]` | Side-by-side diff (also works between branches/variants) |
 | `/generate-presentation [topic]` | Jump to deck creation |
-| `/sync-design-system [scope]` | Jump to sync |
 
 ---
 

--- a/llms.txt
+++ b/llms.txt
@@ -44,4 +44,4 @@ The Actian DS is in a federated configuration (2026-05-09): the **knowledge laye
 - [Knowledge repo README](https://raw.githubusercontent.com/volivarii/actian-ds-knowledge/main/README.md): federation status, repo layout, CI workflows
 - [Component guidelines (85 JSON files, 44 curated)](https://github.com/volivarii/actian-ds-knowledge/tree/main/components/guidelines): per-component guideline JSONs
 - [Foundations subtree (8 JSON files)](https://github.com/volivarii/actian-ds-knowledge/tree/main/foundations): per-foundation JSON files derived from foundations.md
-- [Presentation guide](https://raw.githubusercontent.com/volivarii/Actian-DS-Claude-plugin/main/plugins/actian-design-system/docs/presentation-guide.md): generate-presentation skill content patterns
+- [Presentation guide](https://raw.githubusercontent.com/volivarii/actian-ds-knowledge/main/presentation/presentation-guide.md): generate-presentation skill content patterns

--- a/plugins/actian-design-system/.claude-plugin/plugin.json
+++ b/plugins/actian-design-system/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "actian-design-system",
   "description": "Actian Design System toolkit — generate wireframe flows with prototype wiring, create component briefs, audit designs, compare flows, and build presentations. 8 skills (with tiered generation: recognized / adapted / improvised), 8 agents, 155 tokens (3 themes, 8 collections), WCAG 2.1 AA. DS knowledge vendored from volivarii/actian-ds-knowledge.",
-  "version": "1.79.3",
+  "version": "1.79.4",
   "author": {
     "name": "Actian UX Team"
   },

--- a/plugins/actian-design-system/TEST-PROMPTS.md
+++ b/plugins/actian-design-system/TEST-PROMPTS.md
@@ -405,7 +405,6 @@ abort                                                            # Stop
 /compare-flows https://figma.com/design/FILEKEY/File?node-id=111-222 https://figma.com/design/FILEKEY/File?node-id=333-444
 /generate-presentation Q1 design system review
 /create-component Status Badge with info, success, warning, error types
-/sync-design-system all
 /release-notes
 ```
 

--- a/plugins/actian-design-system/docs/llms-overview.md
+++ b/plugins/actian-design-system/docs/llms-overview.md
@@ -51,9 +51,9 @@ Phase 1 of the federation arc is shipping incrementally:
 - ✅ Phase 1.3 — tokens + content + accessibility + app-context + fm-to-ds-map
 - ✅ Phase 1.4a — vendoring infrastructure (v1.77.0)
 - ✅ Phase 1.4b — path remap (v1.78.0, plugin code reads from `vendor/`)
-- ⏳ Phase 1.5 — `/sync-design-system` decommission (after Smoke pass #2; multi-week parallel-change discipline)
+- ✅ Phase 1.5 — `/sync-design-system` decommission (v1.79.0, 2026-05-10)
 
-Knowledge repo CI workflows (sync-from-figma.yml, foundations-derive.yml) keep the content fresh in parallel with the plugin's existing `/sync-design-system` skill until decommission completes.
+Knowledge repo CI workflows (sync-from-figma.yml, foundations-derive.yml) keep the content fresh; the plugin's nightly vendor-snapshot.yml propagates updates to `vendor/` and auto-bumps `plugin.json`.
 
 ## Plugin substrate
 

--- a/plugins/actian-design-system/references/ds-rules/interactive-gates.md
+++ b/plugins/actian-design-system/references/ds-rules/interactive-gates.md
@@ -144,5 +144,5 @@ When adopting this convention in a new skill:
 ## Out of scope for this convention
 
 - `/component-brief` Step 1.5 already batches its gates; it does NOT need `--no-prompt` until a future iteration adds it for parity.
-- `/sync-design-system`, `/compare-flows`, `/create-component` don't currently have gateable flags — adopt the convention if/when they grow them.
+- `/compare-flows`, `/create-component` don't currently have gateable flags — adopt the convention if/when they grow them.
 - Gates inside refine flows (URL + prose) — refine intent is already explicit; no gate needed.

--- a/plugins/actian-design-system/references/figma/figma-push-patterns.md
+++ b/plugins/actian-design-system/references/figma/figma-push-patterns.md
@@ -9,7 +9,7 @@ Direct Figma Plugin API patterns for pushing content to Figma. Each pattern is a
 
 ## 1. Component Keys
 
-**Source of truth: registry JSON files** (synced from Figma via `/sync-design-system`).
+**Source of truth: registry JSON files** (vendored from `volivarii/actian-ds-knowledge`; the knowledge repo's `sync-from-figma.yml` CI keeps them fresh nightly).
 
 | Registry | File | Contents |
 |----------|------|----------|

--- a/plugins/actian-design-system/scripts/lib/paths.js
+++ b/plugins/actian-design-system/scripts/lib/paths.js
@@ -1,0 +1,101 @@
+"use strict";
+
+/**
+ * paths.js — Single source of truth for vendor subtree paths.
+ *
+ * Plugin reads DS knowledge from the vendored snapshot of
+ * volivarii/actian-ds-knowledge under plugins/actian-design-system/vendor/.
+ * Centralizing the leaf paths here means a future folder rename in the
+ * upstream knowledge repo (e.g., src/+dist/ split per the 2026-05-10
+ * restructure design) becomes a 1-file edit, not a 64-file edit across
+ * skills/agents/refs/recipes/scripts.
+ *
+ * Markdown prose (skills, agents, references, recipes) keeps literal
+ * path strings — those don't import from this module — but every
+ * runtime script that builds a vendor path SHOULD import from here.
+ *
+ * Pre-restructure paths shown below; constants will be updated to
+ * point at vendor/<domain>/{src,dist}/... once Phase B/C lands.
+ */
+
+const path = require("path");
+
+const PLUGIN_ROOT = path.resolve(__dirname, "..", "..");
+const VENDOR = path.join(PLUGIN_ROOT, "vendor");
+
+const PATHS = {
+  pluginRoot: PLUGIN_ROOT,
+  vendor: VENDOR,
+  foundations: {
+    md: path.join(VENDOR, "foundations", "foundations.md"),
+    authoring: path.join(VENDOR, "foundations", "AUTHORING.md"),
+    dist: path.join(VENDOR, "foundations"),
+    color: path.join(VENDOR, "foundations", "color.json"),
+    borders: path.join(VENDOR, "foundations", "borders.json"),
+    elevation: path.join(VENDOR, "foundations", "elevation.json"),
+    spacing: path.join(VENDOR, "foundations", "spacing.json"),
+    typography: path.join(VENDOR, "foundations", "typography.json"),
+    motion: path.join(VENDOR, "foundations", "interaction-motion.json"),
+    icons: path.join(VENDOR, "foundations", "icons.json"),
+    breakpointGridStructure: path.join(
+      VENDOR,
+      "foundations",
+      "breakpoint-grid-structure.json",
+    ),
+  },
+  tokens: {
+    json: path.join(VENDOR, "tokens", "tokens.json"),
+    css: path.join(VENDOR, "tokens", "tokens.css"),
+    reference: path.join(VENDOR, "tokens", "token-reference.md"),
+  },
+  components: {
+    guidelinesDir: path.join(VENDOR, "components", "guidelines"),
+    guidelinesIndex: path.join(
+      VENDOR,
+      "components",
+      "guidelines",
+      "_index.json",
+    ),
+    guideline: function (slug) {
+      return path.join(VENDOR, "components", "guidelines", slug + ".json");
+    },
+    registries: {
+      dskit: path.join(VENDOR, "components", "registries", "dskit.json"),
+      fmkit: path.join(VENDOR, "components", "registries", "fmkit.json"),
+      metakit: path.join(VENDOR, "components", "registries", "metakit.json"),
+      styles: path.join(
+        VENDOR,
+        "components",
+        "registries",
+        "meta-kit",
+        "styles.json",
+      ),
+      byKit: function (kit) {
+        // kit: "ds" | "fm" | "meta"
+        if (kit === "ds")
+          return path.join(VENDOR, "components", "registries", "dskit.json");
+        if (kit === "fm")
+          return path.join(VENDOR, "components", "registries", "fmkit.json");
+        if (kit === "meta")
+          return path.join(VENDOR, "components", "registries", "metakit.json");
+        throw new Error(
+          'paths.components.registries.byKit: unknown kit "' + kit + '"',
+        );
+      },
+    },
+    mirrors: {
+      ds: path.join(VENDOR, "components", "dskit-components.md"),
+      fm: path.join(VENDOR, "components", "fm-components.md"),
+      metaKit: path.join(VENDOR, "components", "meta-kit", "components.md"),
+      textStyles: path.join(VENDOR, "components", "text-styles.md"),
+      effectStyles: path.join(VENDOR, "components", "effect-styles.md"),
+    },
+  },
+  content: path.join(VENDOR, "content", "content.md"),
+  accessibility: path.join(VENDOR, "accessibility", "accessibility.md"),
+  presentation: path.join(VENDOR, "presentation", "presentation-guide.md"),
+  appContext: path.join(VENDOR, "app-context", "app-context.json"),
+  fmToDsMap: path.join(VENDOR, "fm-to-ds-map", "fm-to-ds-map.json"),
+};
+
+module.exports = PATHS;

--- a/plugins/actian-design-system/scripts/validation/validate-flow-data.js
+++ b/plugins/actian-design-system/scripts/validation/validate-flow-data.js
@@ -4,7 +4,7 @@
 var fs = require("fs");
 var path = require("path");
 
-var PLUGIN_ROOT = path.resolve(__dirname, "../..");
+var PATHS = require(path.join(__dirname, "..", "lib", "paths.js"));
 var rules = require(path.join(__dirname, "component-property-rules.js"));
 var resolver = require(path.join(__dirname, "..", "lib", "intent-resolver.js"));
 
@@ -13,17 +13,7 @@ var resolver = require(path.join(__dirname, "..", "lib", "intent-resolver.js"));
 // ---------------------------------------------------------------------------
 
 function loadKitRegistry(kit) {
-  var fileName =
-    kit === "fm" ? "fmkit.json" : kit === "ds" ? "dskit.json" : "metakit.json";
-  var registryPath = path.join(
-    __dirname,
-    "..",
-    "..",
-    "vendor",
-    "components",
-    "registries",
-    fileName,
-  );
+  var registryPath = PATHS.components.registries.byKit(kit);
   try {
     return JSON.parse(fs.readFileSync(registryPath, "utf8"));
   } catch (e) {
@@ -48,13 +38,7 @@ function loadGuidelineForSlug(refOrSlug, opts) {
   if (Object.prototype.hasOwnProperty.call(_guidelineCache, slug)) {
     return _guidelineCache[slug];
   }
-  var p = path.join(
-    PLUGIN_ROOT,
-    "vendor",
-    "components",
-    "guidelines",
-    slug + ".json",
-  );
+  var p = PATHS.components.guideline(slug);
   var data = null;
   try {
     data = JSON.parse(fs.readFileSync(p, "utf8"));
@@ -307,7 +291,7 @@ function findBannedTextRaw(data) {
 // ---------------------------------------------------------------------------
 
 function loadTokenNames() {
-  var cssPath = path.join(PLUGIN_ROOT, "vendor", "tokens", "tokens.css");
+  var cssPath = PATHS.tokens.css;
   try {
     var css = fs.readFileSync(cssPath, "utf8");
     var names = {};
@@ -389,12 +373,7 @@ function findUnresolvedTokensRaw(data) {
 // ---------------------------------------------------------------------------
 
 function loadTerminology() {
-  var appContextPath = path.join(
-    PLUGIN_ROOT,
-    "vendor",
-    "app-context",
-    "app-context.json",
-  );
+  var appContextPath = PATHS.appContext;
   try {
     var appContext = JSON.parse(fs.readFileSync(appContextPath, "utf8"));
     return appContext.terminology || {};

--- a/plugins/actian-design-system/skills/companion/SKILL.md
+++ b/plugins/actian-design-system/skills/companion/SKILL.md
@@ -74,9 +74,10 @@ The companion is the API. Match the user's prose against this table; pick the mo
 | 19 | "make this realistic" / "use real data" / "fill with proper content" | yes | `/generate-flow <url> "use realistic data drawn from app-context"` (refine) |
 | 20 | "responsive" / "for tablet" / "mobile version" | yes | `/generate-flow <url> --breakpoints tablet,mobile --no-prompt` |
 | 21 | "document this component" / "brief for this" | yes (component) | `/component-brief <url>` |
-| 22 | "sync the design system" / "pull tokens from Figma" / "refresh registries" | optional | `/sync-design-system` |
 
 Invoke the chosen skill via the Skill tool with the user's message as argument. If no row fits, proceed to Step 4 (direct help).
+
+> Note: design-system content syncs are now automated via `volivarii/actian-ds-knowledge` CI + the plugin's nightly `vendor-snapshot.yml`. There is no user-facing sync skill — if a user asks to "sync the design system," explain that the knowledge repo's nightly cron handles it and point them at the plugin's `vendor-snapshot.yml` for manual triggers.
 
 ### 3.0 The `--no-prompt` rule (interactive gates)
 

--- a/plugins/actian-design-system/tests/fixtures/foundations-parser/golden/expected/borders.json
+++ b/plugins/actian-design-system/tests/fixtures/foundations-parser/golden/expected/borders.json
@@ -1,7 +1,7 @@
 {
   "_meta": {
     "auto_generated": true,
-    "source": "docs/foundations.md",
+    "source": "foundations/foundations.md",
     "do_not_edit": "Edit the source MD; CI regenerates this file."
   },
   "rows": [

--- a/plugins/actian-design-system/tests/fixtures/foundations-parser/golden/expected/breakpoint-grid-structure.json
+++ b/plugins/actian-design-system/tests/fixtures/foundations-parser/golden/expected/breakpoint-grid-structure.json
@@ -1,7 +1,7 @@
 {
   "_meta": {
     "auto_generated": true,
-    "source": "docs/foundations.md",
+    "source": "foundations/foundations.md",
     "do_not_edit": "Edit the source MD; CI regenerates this file."
   },
   "rows": [

--- a/plugins/actian-design-system/tests/fixtures/foundations-parser/golden/expected/color.json
+++ b/plugins/actian-design-system/tests/fixtures/foundations-parser/golden/expected/color.json
@@ -1,7 +1,7 @@
 {
   "_meta": {
     "auto_generated": true,
-    "source": "docs/foundations.md",
+    "source": "foundations/foundations.md",
     "do_not_edit": "Edit the source MD; CI regenerates this file."
   },
   "primitives": {

--- a/plugins/actian-design-system/tests/fixtures/foundations-parser/golden/expected/elevation.json
+++ b/plugins/actian-design-system/tests/fixtures/foundations-parser/golden/expected/elevation.json
@@ -1,7 +1,7 @@
 {
   "_meta": {
     "auto_generated": true,
-    "source": "docs/foundations.md",
+    "source": "foundations/foundations.md",
     "do_not_edit": "Edit the source MD; CI regenerates this file."
   },
   "rows": [

--- a/plugins/actian-design-system/tests/fixtures/foundations-parser/golden/expected/icons.json
+++ b/plugins/actian-design-system/tests/fixtures/foundations-parser/golden/expected/icons.json
@@ -1,7 +1,7 @@
 {
   "_meta": {
     "auto_generated": true,
-    "source": "docs/foundations.md",
+    "source": "foundations/foundations.md",
     "do_not_edit": "Edit the source MD; CI regenerates this file."
   },
   "rows": [

--- a/plugins/actian-design-system/tests/fixtures/foundations-parser/golden/expected/interaction-motion.json
+++ b/plugins/actian-design-system/tests/fixtures/foundations-parser/golden/expected/interaction-motion.json
@@ -1,7 +1,7 @@
 {
   "_meta": {
     "auto_generated": true,
-    "source": "docs/foundations.md",
+    "source": "foundations/foundations.md",
     "do_not_edit": "Edit the source MD; CI regenerates this file."
   },
   "description": "Motion tokens cover three dimensions: duration (how long), easing (how it accelerates), and delay (when it starts). All three must be specified together for any animated component.",

--- a/plugins/actian-design-system/tests/fixtures/foundations-parser/golden/expected/spacing.json
+++ b/plugins/actian-design-system/tests/fixtures/foundations-parser/golden/expected/spacing.json
@@ -1,7 +1,7 @@
 {
   "_meta": {
     "auto_generated": true,
-    "source": "docs/foundations.md",
+    "source": "foundations/foundations.md",
     "do_not_edit": "Edit the source MD; CI regenerates this file."
   },
   "rows": [

--- a/plugins/actian-design-system/tests/fixtures/foundations-parser/golden/expected/typography.json
+++ b/plugins/actian-design-system/tests/fixtures/foundations-parser/golden/expected/typography.json
@@ -1,7 +1,7 @@
 {
   "_meta": {
     "auto_generated": true,
-    "source": "docs/foundations.md",
+    "source": "foundations/foundations.md",
     "do_not_edit": "Edit the source MD; CI regenerates this file."
   },
   "rows": [


### PR DESCRIPTION
## Summary

Pre-restructure cleanup sweep ahead of the knowledge-repo `src/`+`dist/` restructure (spec: `docs/superpowers/specs/2026-05-10-knowledge-repo-restructure-design.md`, gitignored). Two threads, both Phase A scope.

## 1. Central path constants — `scripts/lib/paths.js` (NEW)

New module exposes every vendor subtree path that the plugin reads. Reduces a future folder rename in `actian-ds-knowledge` from a ~64-file edit to a ~5-file edit. Markdown prose (skills, agents, refs, recipes) keeps literal strings — no clean way to template — but every runtime script that builds a vendor path now imports from here.

First consumer: `scripts/validation/validate-flow-data.js` — 4 inline `path.join(PLUGIN_ROOT, "vendor", ...)` sites refactored; unused `PLUGIN_ROOT` constant removed.

## 2. Stale-path + decommissioned-skill sweep

The v1.79.x federation cleanup landed `/sync-design-system` decommission, but the deep-scan pass during Phase A surfaced several references that escaped:

| File | Issue | Resolution |
|---|---|---|
| `skills/companion/SKILL.md:77` | **RUNTIME BUG** — intent table row 22 routed "sync the design system" to nonexistent skill | Replaced row with note pointing users at the nightly vendor-snapshot cron |
| `TEST-PROMPTS.md:408` | Test prompt against decommissioned skill | Dropped |
| `references/figma/figma-push-patterns.md:12` | Active reference doc described registries as "synced via `/sync-design-system`" | Rewritten: "vendored from `actian-ds-knowledge`; the knowledge repo's `sync-from-figma.yml` CI keeps them fresh nightly" |
| `references/ds-rules/interactive-gates.md:147` | Decommissioned skill in "no gateable flags" list | Dropped |
| `docs/llms-overview.md:54-56` | Phase 1.5 marked ⏳ in-progress when it shipped in v1.79.0 | Flipped to ✅ |
| `tests/fixtures/foundations-parser/golden/expected/*.json` (8 files) | `"source": "docs/foundations.md"` (plugin-era) | Updated to `"foundations/foundations.md"` (matches current knowledge-repo parser output) |
| Root `README.md` | Stale prose contradicting new diagram; decommissioned skill row in command table; outdated directory tree | Rewrote architecture prose; removed `/sync-design-system` row; updated skill count (8) and `scripts/` tree to v1.79.0 layout |
| Root `USAGE.md:451` | `/sync-design-system [scope]` row in supporting commands table | Dropped |
| Root `USAGE.md:126` | `docs/content-guidelines.md` reference | Updated to `vendor/content/content.md` |
| Root `llms.txt:47` | Presentation-guide raw URL pointed at non-existent path | Updated to knowledge-repo URL |

## Why now

Same as PR #9 on the knowledge repo: doing this first surfaces and fixes pre-existing bugs before any structural moves land in Phase B. The `companion/SKILL.md` row was actively misrouting users to a nonexistent skill — that one is a real defect, not just stale prose.

## Test plan

- [x] `npm test` (full suite via `node --test tests/integration/*.test.js tests/renderers/*.test.js tests/transformers/*.test.js tests/lib/*.test.js tests/evals/*.test.js tests/validation/*.test.js`) — 759/759 passing.
- [ ] Manual: invoke `/companion` with prompt "sync the design system" — verify companion responds with the new note instead of routing to nonexistent skill.
- [ ] Manual: smoke `/component-brief Button` — confirm path resolution from new `paths.js` constants is correct (validate-flow-data is part of the brief pipeline).
- [ ] Companion PR #9 on `actian-ds-knowledge` (sister cleanups) — independent but ships together.

## Version bump

`plugin.json` 1.79.2 → 1.79.3 (PATCH; bug-fix sweep + new internal module, no API changes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)