### PR TITLE
chore: tag-range vendor resolution (Move A2, v1.79.5)

### DIFF
--- a/.github/workflows/vendor-snapshot.yml
+++ b/.github/workflows/vendor-snapshot.yml
@@ -25,7 +25,11 @@ on:
   workflow_dispatch:
     inputs:
       sha:
-        description: 'Knowledge repo SHA to vendor (defaults to current vendored.json#knowledge_repo_sha or main HEAD)'
+        description: 'Knowledge repo SHA to vendor (override; default resolves version range from vendored.json)'
+        required: false
+        type: string
+      range:
+        description: 'Override the semver range from vendored.json (e.g. "~0.2.0")'
         required: false
         type: string
 
@@ -45,19 +49,43 @@ jobs:
         with:
           node-version: '22'
 
-      - name: Resolve target SHA
+      - name: Resolve target tag and SHA
         id: target
+        working-directory: plugins/actian-design-system
         run: |
           INPUT_SHA="${{ github.event.inputs.sha }}"
-          if [ -z "$INPUT_SHA" ]; then
-            LATEST=$(curl -sSL "https://api.github.com/repos/volivarii/actian-ds-knowledge/commits/main" | jq -r '.sha')
-            echo "Resolved knowledge-repo main → $LATEST"
-            echo "sha=$LATEST" >> "$GITHUB_OUTPUT"
-            echo "short_sha=$(echo "$LATEST" | cut -c1-7)" >> "$GITHUB_OUTPUT"
-          else
+          INPUT_RANGE="${{ github.event.inputs.range }}"
+
+          if [ -n "$INPUT_SHA" ]; then
+            # Manual SHA override — bypasses range resolution
             echo "Using explicit SHA → $INPUT_SHA"
             echo "sha=$INPUT_SHA" >> "$GITHUB_OUTPUT"
+            echo "version=" >> "$GITHUB_OUTPUT"
             echo "short_sha=$(echo "$INPUT_SHA" | cut -c1-7)" >> "$GITHUB_OUTPUT"
+            echo "label=$(echo "$INPUT_SHA" | cut -c1-7)" >> "$GITHUB_OUTPUT"
+          else
+            # Range resolution — read range from vendored.json (or input override)
+            if [ -n "$INPUT_RANGE" ]; then
+              OUT=$(node scripts/vendor/vendor-snapshot.js --range "$INPUT_RANGE" --resolve-only)
+            else
+              OUT=$(node scripts/vendor/vendor-snapshot.js --resolve-only)
+            fi
+            echo "$OUT"
+            SHA=$(echo "$OUT" | sed -n 's/^sha=//p')
+            VERSION=$(echo "$OUT" | sed -n 's/^version=//p')
+            if [ -z "$SHA" ]; then
+              echo "::error::Failed to resolve target SHA from output"
+              exit 1
+            fi
+            echo "sha=$SHA" >> "$GITHUB_OUTPUT"
+            echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+            echo "short_sha=$(echo "$SHA" | cut -c1-7)" >> "$GITHUB_OUTPUT"
+            # Label preference: tag version > short SHA
+            if [ -n "$VERSION" ]; then
+              echo "label=$VERSION" >> "$GITHUB_OUTPUT"
+            else
+              echo "label=$(echo "$SHA" | cut -c1-7)" >> "$GITHUB_OUTPUT"
+            fi
           fi
 
       - name: Pull vendor snapshot
@@ -105,10 +133,10 @@ jobs:
         id: cpr
         uses: peter-evans/create-pull-request@v7
         with:
-          commit-message: "vendor(knowledge): refresh to ${{ steps.target.outputs.short_sha }} + bump"
-          title: "vendor(knowledge): refresh to ${{ steps.target.outputs.short_sha }}"
+          commit-message: "vendor(knowledge): refresh to ${{ steps.target.outputs.label }} + bump"
+          title: "vendor(knowledge): refresh to ${{ steps.target.outputs.label }}"
           body: |
-            Vendored snapshot of `volivarii/actian-ds-knowledge` updated to SHA `${{ steps.target.outputs.sha }}`.
+            Vendored snapshot of `volivarii/actian-ds-knowledge` updated to `${{ steps.target.outputs.label }}` (SHA `${{ steps.target.outputs.sha }}`).
 
             See https://github.com/volivarii/actian-ds-knowledge/tree/${{ steps.target.outputs.sha }} for source state.
 
@@ -132,7 +160,7 @@ jobs:
         if: always()
         run: |
           if [ "${{ steps.diff.outputs.changed }}" = "true" ]; then
-            echo "### Vendor refreshed: ${{ steps.target.outputs.short_sha }} (auto-bump applied)" >> "$GITHUB_STEP_SUMMARY"
+            echo "### Vendor refreshed: ${{ steps.target.outputs.label }} (auto-bump applied)" >> "$GITHUB_STEP_SUMMARY"
           else
-            echo "### Vendor: no changes (already at ${{ steps.target.outputs.short_sha }})" >> "$GITHUB_STEP_SUMMARY"
+            echo "### Vendor: no changes (already at ${{ steps.target.outputs.label }})" >> "$GITHUB_STEP_SUMMARY"
           fi

--- a/plugins/actian-design-system/.claude-plugin/plugin.json
+++ b/plugins/actian-design-system/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "actian-design-system",
   "description": "Actian Design System toolkit — generate wireframe flows with prototype wiring, create component briefs, audit designs, compare flows, and build presentations. 8 skills (with tiered generation: recognized / adapted / improvised), 8 agents, 155 tokens (3 themes, 8 collections), WCAG 2.1 AA. DS knowledge vendored from volivarii/actian-ds-knowledge.",
-  "version": "1.79.4",
+  "version": "1.79.5",
   "author": {
     "name": "Actian UX Team"
   },

--- a/plugins/actian-design-system/scripts/vendor/vendor-snapshot.js
+++ b/plugins/actian-design-system/scripts/vendor/vendor-snapshot.js
@@ -47,8 +47,110 @@ function parseArgs(argv) {
   var out = {};
   for (var i = 0; i < argv.length; i++) {
     if (argv[i] === "--sha") out.sha = argv[++i];
+    // Move A2: resolve via semver range (e.g., "~0.1.0") instead of SHA.
+    // Range is read from vendored.json.knowledge_repo_version_range when
+    // --range is passed without a value (or omit --range entirely).
+    else if (argv[i] === "--range") out.range = argv[++i];
+    // Resolve-only mode: print the resolved tag + SHA and exit. Used by
+    // vendor-snapshot.yml to log which tag it's about to pull.
+    else if (argv[i] === "--resolve-only") out.resolveOnly = true;
   }
   return out;
+}
+
+// Pure semver range resolver. Supports tilde (~), caret (^), and exact
+// version strings. Pre-1.0 caret behaves like tilde (patches only) per
+// npm convention.
+function matchesRange(version, range) {
+  var parseV = function (v) {
+    return String(v).split(".").map(Number);
+  };
+  var reqMajor, reqMinor, reqPatch;
+  if (range.charAt(0) === "~") {
+    var parts = parseV(range.slice(1));
+    reqMajor = parts[0];
+    reqMinor = parts[1];
+    reqPatch = parts[2] || 0;
+    var v = parseV(version);
+    return v[0] === reqMajor && v[1] === reqMinor && v[2] >= reqPatch;
+  }
+  if (range.charAt(0) === "^") {
+    var cparts = parseV(range.slice(1));
+    reqMajor = cparts[0];
+    reqMinor = cparts[1];
+    reqPatch = cparts[2] || 0;
+    var cv = parseV(version);
+    if (reqMajor === 0) {
+      // Pre-1.0: caret = tilde (only patches)
+      return cv[0] === reqMajor && cv[1] === reqMinor && cv[2] >= reqPatch;
+    }
+    return (
+      cv[0] === reqMajor &&
+      (cv[1] > reqMinor || (cv[1] === reqMinor && cv[2] >= reqPatch))
+    );
+  }
+  return version === range;
+}
+
+// Compare two semver strings; returns -1, 0, or 1.
+function compareSemver(a, b) {
+  var pa = String(a).split(".").map(Number);
+  var pb = String(b).split(".").map(Number);
+  for (var i = 0; i < 3; i++) {
+    if (pa[i] !== pb[i]) return pa[i] - pb[i] < 0 ? -1 : 1;
+  }
+  return 0;
+}
+
+// Filter, validate, and select the highest tag matching a range.
+// Returns the tag name (with "v" prefix) or null.
+function resolveTargetTag(tags, range) {
+  var candidates = tags
+    .map(function (t) {
+      return String(t).replace(/^v/, "");
+    })
+    .filter(function (v) {
+      // Strict semver (X.Y.Z numeric), no pre-release suffix
+      return /^[0-9]+\.[0-9]+\.[0-9]+$/.test(v);
+    })
+    .filter(function (v) {
+      return matchesRange(v, range);
+    });
+  if (candidates.length === 0) return null;
+  candidates.sort(compareSemver);
+  return "v" + candidates[candidates.length - 1];
+}
+
+// Fetch all tags from a public GitHub repo via the API. No auth needed
+// for public repos; uses curl which is always available in CI runners.
+function fetchTagsFromGitHub(repo) {
+  var url = "https://api.github.com/repos/" + repo + "/tags?per_page=100";
+  var raw = execFileSync("curl", ["-sSL", url], { encoding: "utf8" });
+  var parsed = JSON.parse(raw);
+  if (!Array.isArray(parsed)) {
+    throw new Error(
+      "GitHub tags API returned non-array: " +
+        JSON.stringify(parsed).slice(0, 200),
+    );
+  }
+  return parsed.map(function (t) {
+    return t.name;
+  });
+}
+
+// Resolve a tag name → SHA via GitHub API. Tag must exist.
+function resolveTagSha(repo, tag) {
+  var versionOnly = tag.replace(/^v/, "");
+  var url =
+    "https://api.github.com/repos/" + repo + "/git/refs/tags/v" + versionOnly;
+  var raw = execFileSync("curl", ["-sSL", url], { encoding: "utf8" });
+  var parsed = JSON.parse(raw);
+  if (!parsed || !parsed.object || !parsed.object.sha) {
+    throw new Error(
+      "Cannot resolve tag '" + tag + "' to SHA. Response: " + raw.slice(0, 200),
+    );
+  }
+  return parsed.object.sha;
 }
 
 function readVendoredJson() {
@@ -136,13 +238,59 @@ function vendorContent(extractedRepoRoot) {
 function main() {
   var args = parseArgs(process.argv.slice(2));
   var current = readVendoredJson();
-  var sha = args.sha || current.knowledge_repo_sha;
+
+  // Move A2: tag-range resolution. Precedence:
+  //   1. --sha <sha>     → use SHA directly (back-compat for manual override)
+  //   2. --range <range> → resolve via that range
+  //   3. vendored.json.knowledge_repo_version_range → resolve via stored range
+  //   4. vendored.json.knowledge_repo_sha → legacy fallback (deprecated)
+  var sha = args.sha;
+  var resolvedVersion = null;
+  var resolvedRange =
+    args.range || current.knowledge_repo_version_range || null;
+
+  if (!sha && resolvedRange) {
+    var tags = fetchTagsFromGitHub(KNOWLEDGE_REPO);
+    var matchedTag = resolveTargetTag(tags, resolvedRange);
+    if (!matchedTag) {
+      process.stderr.write(
+        "[vendor] no tag matches range '" +
+          resolvedRange +
+          "'. Available: " +
+          tags.join(", ") +
+          "\n",
+      );
+      process.exit(1);
+    }
+    sha = resolveTagSha(KNOWLEDGE_REPO, matchedTag);
+    resolvedVersion = matchedTag;
+    process.stdout.write(
+      "[vendor] resolved range '" +
+        resolvedRange +
+        "' → " +
+        matchedTag +
+        " (" +
+        sha.slice(0, 7) +
+        ")\n",
+    );
+  }
+
+  if (!sha) {
+    sha = current.knowledge_repo_sha; // legacy fallback
+  }
 
   if (!sha) {
     process.stderr.write(
-      "[vendor] no SHA available — pass --sha <sha> or populate vendored.json\n",
+      "[vendor] no SHA available — pass --sha, --range, or set knowledge_repo_version_range in vendored.json\n",
     );
     process.exit(1);
+  }
+
+  if (args.resolveOnly) {
+    process.stdout.write("range=" + (resolvedRange || "") + "\n");
+    process.stdout.write("version=" + (resolvedVersion || "") + "\n");
+    process.stdout.write("sha=" + sha + "\n");
+    return;
   }
 
   // Fetch + extract into a tempdir so we don't pollute the plugin tree on
@@ -166,12 +314,15 @@ function main() {
 
     var manifest = {
       knowledge_repo: KNOWLEDGE_REPO,
-      knowledge_repo_sha: sha,
-      knowledge_repo_short_sha: sha.slice(0, 7),
+      knowledge_repo_version_range: resolvedRange || null,
+      knowledge_repo_resolved_version: resolvedVersion || null,
+      knowledge_repo_resolved_sha: sha,
       vendored_at: new Date().toISOString(),
       vendored_entries: vendored.sort(),
       excluded_entries: Array.from(EXCLUDE_TOP_LEVEL).sort(),
-      vendor_url: "https://github.com/" + KNOWLEDGE_REPO + "/tree/" + sha,
+      vendor_url: resolvedVersion
+        ? "https://github.com/" + KNOWLEDGE_REPO + "/tree/" + resolvedVersion
+        : "https://github.com/" + KNOWLEDGE_REPO + "/tree/" + sha,
     };
     writeVendoredJson(manifest);
     process.stdout.write("[vendor] wrote " + VENDORED_JSON_PATH + "\n");
@@ -190,4 +341,9 @@ if (require.main === module) {
   }
 }
 
-module.exports = { main: main };
+module.exports = {
+  main: main,
+  matchesRange: matchesRange,
+  compareSemver: compareSemver,
+  resolveTargetTag: resolveTargetTag,
+};

--- a/plugins/actian-design-system/tests/vendor/version-range-resolution.test.js
+++ b/plugins/actian-design-system/tests/vendor/version-range-resolution.test.js
@@ -1,0 +1,73 @@
+"use strict";
+
+const test = require("node:test");
+const assert = require("node:assert/strict");
+
+const {
+  matchesRange,
+  resolveTargetTag,
+  compareSemver,
+} = require("../../scripts/vendor/vendor-snapshot.js");
+
+test("vendor-snapshot range resolution", async (t) => {
+  await t.test("~ range matches same minor, any patch >=", () => {
+    assert.equal(matchesRange("0.1.0", "~0.1.0"), true);
+    assert.equal(matchesRange("0.1.5", "~0.1.0"), true);
+    assert.equal(matchesRange("0.1.99", "~0.1.0"), true);
+    assert.equal(matchesRange("0.2.0", "~0.1.0"), false);
+    assert.equal(matchesRange("1.1.0", "~0.1.0"), false);
+    assert.equal(matchesRange("0.0.9", "~0.1.0"), false);
+  });
+
+  await t.test("^ range on pre-1.0 behaves like ~ (patches only)", () => {
+    assert.equal(matchesRange("0.1.0", "^0.1.0"), true);
+    assert.equal(matchesRange("0.1.5", "^0.1.0"), true);
+    assert.equal(matchesRange("0.2.0", "^0.1.0"), false);
+  });
+
+  await t.test("^ range on >=1.0 allows minor + patch", () => {
+    assert.equal(matchesRange("1.1.0", "^1.0.0"), true);
+    assert.equal(matchesRange("1.5.3", "^1.0.0"), true);
+    assert.equal(matchesRange("2.0.0", "^1.0.0"), false);
+    assert.equal(matchesRange("0.9.0", "^1.0.0"), false);
+  });
+
+  await t.test("exact version range matches only that version", () => {
+    assert.equal(matchesRange("0.1.1", "0.1.1"), true);
+    assert.equal(matchesRange("0.1.2", "0.1.1"), false);
+  });
+
+  await t.test("compareSemver orders correctly", () => {
+    assert.equal(compareSemver("0.1.0", "0.1.1"), -1);
+    assert.equal(compareSemver("0.1.1", "0.1.0"), 1);
+    assert.equal(compareSemver("0.1.0", "0.1.0"), 0);
+    assert.equal(compareSemver("0.2.0", "0.1.99"), 1);
+    assert.equal(compareSemver("1.0.0", "0.99.99"), 1);
+  });
+
+  await t.test("resolveTargetTag returns highest matching", () => {
+    const tags = ["v0.1.0", "v0.1.1", "v0.1.2", "v0.2.0"];
+    assert.equal(resolveTargetTag(tags, "~0.1.0"), "v0.1.2");
+    assert.equal(resolveTargetTag(tags, "~0.2.0"), "v0.2.0");
+  });
+
+  await t.test("resolveTargetTag returns null when no tag matches", () => {
+    const tags = ["v0.1.0", "v0.1.1"];
+    assert.equal(resolveTargetTag(tags, "~0.2.0"), null);
+  });
+
+  await t.test("resolveTargetTag ignores tags with invalid semver", () => {
+    const tags = ["v0.1.0", "garbage", "v0.1.1", "not-a-tag"];
+    assert.equal(resolveTargetTag(tags, "~0.1.0"), "v0.1.1");
+  });
+
+  await t.test("resolveTargetTag ignores pre-release suffixed tags", () => {
+    const tags = ["v0.1.0", "v0.1.1-beta", "v0.1.0-rc.1", "v0.1.2-pre"];
+    assert.equal(resolveTargetTag(tags, "~0.1.0"), "v0.1.0");
+  });
+
+  await t.test("resolveTargetTag handles tags without v prefix", () => {
+    const tags = ["0.1.0", "0.1.1"];
+    assert.equal(resolveTargetTag(tags, "~0.1.0"), "v0.1.1");
+  });
+});

--- a/plugins/actian-design-system/vendored.json
+++ b/plugins/actian-design-system/vendored.json
@@ -1,7 +1,8 @@
 {
   "knowledge_repo": "volivarii/actian-ds-knowledge",
-  "knowledge_repo_sha": "e9c5668ee7994bafec897e942c6451d7c9570a13",
-  "knowledge_repo_short_sha": "e9c5668",
+  "knowledge_repo_version_range": "~0.1.0",
+  "knowledge_repo_resolved_version": null,
+  "knowledge_repo_resolved_sha": "e9c5668ee7994bafec897e942c6451d7c9570a13",
   "vendored_at": "2026-05-10T10:11:59.177Z",
   "vendored_entries": [
     "accessibility",


### PR DESCRIPTION
## Summary

Move A2 of the manifest+tag-pin migration. Plugin's vendor-snapshot now resolves a semver range from \`vendored.json\` to a knowledge-repo tag, instead of pulling \`main\` HEAD by SHA.

## Why

Industry-default version isolation. Carbon, Polaris, Stripe, Anthropic — every team owning two repos uses semver, never bare SHA. With this change, future structural changes upstream don't auto-propagate; plugin opts in via range bump.

## Changes

- \`scripts/vendor/vendor-snapshot.js\`: \`matchesRange()\`, \`compareSemver()\`, \`resolveTargetTag()\` — hand-rolled, no npm dep. \`--range\` + \`--resolve-only\` CLI flags. Updated vendored.json shape.
- \`vendored.json\`: schema migration — \`knowledge_repo_sha\` + \`knowledge_repo_short_sha\` retired; \`knowledge_repo_version_range\` + \`knowledge_repo_resolved_version\` + \`knowledge_repo_resolved_sha\` added.
- \`vendor-snapshot.yml\`: \`workflow_dispatch\` gains optional \`range\` input; resolves via \`--resolve-only\` then pulls.
- \`tests/vendor/version-range-resolution.test.js\`: 11 unit tests covering ~/^/exact ranges, comparison, pre-release filtering, tag-without-v-prefix handling.

## Test plan

- [x] All 770 tests pass (11 new + 759 existing) via \`node --test\`.
- [ ] Depends on Move A1 (\`actian-ds-knowledge\` PR #11) being merged + bootstrap tag v0.1.1 pushed. This PR's CI runs unit tests only; first vendor-snapshot run happens after merge.
- [ ] Post-merge: \`gh workflow run vendor-snapshot.yml\`. Verify it resolves \`~0.1.0\` → \`v0.1.1\` and pulls (or reports no-diff if already at that SHA).

## Depends on

Knowledge repo PR #11 (Move A1) merged AND bootstrap tag \`v0.1.1\` pushed.

## Spec

\`plugins/actian-design-system/docs/superpowers/specs/2026-05-10-manifest-and-tag-pin-design.md\` (gitignored).

🤖 Generated with [Claude Code](https://claude.com/claude-code)