### PR TITLE
chore(ci): remove paths: filter from pr-checks.yml

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -6,15 +6,19 @@ name: PR checks
 #   2. json-syntax     — validates that all checked-in JSON files parse
 #   3. version-bump    — ensures plugin.json is bumped when source changes
 #
-# Path-filtered to plugins/actian-design-system/** so unrelated PRs (docs/,
-# comms/, .github/ on its own) don't waste CI minutes.
+# Runs on EVERY PR (no paths: filter). Avoids the path-filtered-required-
+# check dead-PR gotcha: required status checks with paths: filters create a
+# permanent "pending" state for unrelated PRs (e.g., docs-only or root-file-
+# only changes) that don't trigger the workflow.
+#
+# version-bump is graceful — returns early when no plugin source files
+# changed (see scripts/check-version-bump.js:111). json-syntax + test suite
+# both run quickly (~2s combined); cost on non-plugin PRs is negligible.
 #
 # Tiered plan + rationale: see memory/project_ci_pr_checks.md.
 
 on:
   pull_request:
-    paths:
-      - 'plugins/actian-design-system/**'
 
 jobs:
   test:


### PR DESCRIPTION
## Summary

Removes the `paths:` filter from `.github/workflows/pr-checks.yml` so all three jobs (Test suite, JSON syntax, plugin.json bumped) run on every PR.

## Why

Same fix as knowledge-repo PR #16 (`validate-manifest.yml`). Closes the **path-filtered-required-check dead-PR gotcha**: required-status-checks with `paths:` filters never fire for unrelated PRs (docs-only, root-only, .github/-only) → those PRs sit "pending" forever and can never merge.

This unblocks marking these checks as required in branch protection.

## Cost

Pure docs-only or root-only PRs now run pr-checks. Total runtime:
- Test suite: ~2s
- JSON syntax: ~100ms
- plugin.json bumped: ~50ms (returns early when no plugin source files changed — see `scripts/check-version-bump.js:111-116`)

Negligible.

## Diff

```diff
 on:
   pull_request:
-    paths:
-      - 'plugins/actian-design-system/**'
```

Plus expanded comment block explaining the rationale.

## No version bump

Workflow file at repo root — not plugin source per `check-version-bump.js#IGNORED_PREFIXES`. No bump needed.

## Post-merge admin (manual)

Configure branch protection on `main`:
1. Settings → Branches → main → Edit rule
2. Enable "Require status checks to pass"
3. Mark **`Test suite`** + **`JSON syntax`** as required
4. **Skip `plugin.json bumped`** per prior friction memo (`memory/project_ci_version_bump_gate.md` — flagged as over-aggressive on chore PRs)

## Test plan

- [x] Diff is minimal (8 lines, comment-only changes outside the filter removal)
- [ ] CI green on this PR (validates the new "runs-on-all-PRs" behavior on a real chore-class PR)
- [ ] Post-merge: configure required-status gates

🤖 Generated with [Claude Code](https://claude.com/claude-code)