### PR TITLE
feat: category-aware brief routing + companion awareness + schema test (v1.81.0)

### DIFF
--- a/plugins/actian-design-system/.claude-plugin/plugin.json
+++ b/plugins/actian-design-system/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "actian-design-system",
   "description": "Actian Design System toolkit — generate wireframe flows with prototype wiring, create component briefs, audit designs, compare flows, and build presentations. 8 skills (with tiered generation: recognized / adapted / improvised), 8 agents, 155 tokens (3 themes, 8 collections), WCAG 2.1 AA. DS knowledge vendored from volivarii/actian-ds-knowledge.",
-  "version": "1.80.2",
+  "version": "1.81.0",
   "author": {
     "name": "Actian UX Team"
   },

--- a/plugins/actian-design-system/agents/brief-researcher.md
+++ b/plugins/actian-design-system/agents/brief-researcher.md
@@ -41,26 +41,68 @@ You will receive:
 - **Scoped cards** — array of card keys to research (subset of `card_usage`, `card_content`, `card_accessibility`)
 - **Existing context** — files inlined:
   - `vendor/components/src/guidelines/<slug>.json` — component-specific brief context. Its embedded `content_guidelines` field is historical extracted notes; treat it as supplementary, not authoritative.
+  - `vendor/components/dist/categories.json` — DS Kit component categorization (Action, Form, Navigation, Data Display, Feedback, Overlays). Use to resolve the component's category for the topic-routing fallback (see below) and to surface mis-categorization in `research_quality`.
   - `vendor/foundations/src/foundations.md` (relevant excerpts)
   - `vendor/content/src/content-index.md` — inventory of UI-copy topic files
-  - `vendor/content/src/<topic-slug>.md` — per-topic UI-copy file. **This is the source of truth for component-specific copy guidance.** Use the content-index to map component → topic. See routing examples below.
+  - `vendor/content/src/<topic-slug>.md` — per-topic UI-copy file. **This is the source of truth for component-specific copy guidance.** Resolve via the routing rules below.
   - `vendor/content/dist/content.md` — consolidated reference. Use the `Global guidelines` section for cross-cutting voice/tone rules, and as fallback when no per-topic file matches.
   - `vendor/accessibility/accessibility.md`
 - **Output path** for the findings JSON
 
 ### Topic-file routing
 
-Map the component to its content topic via `content-index.md`. Examples:
+Resolve the per-topic content file deterministically — **slug match → category fallback → global**. The component's `category` field comes from `vendor/components/dist/categories.json` (DS Kit only; FM/Meta components fall through to the category fallback or global).
 
-| Component(s) | Topic file |
+#### Step 1 — Slug match (most specific wins)
+
+| Component slug(s) | Topic file |
 |---|---|
-| Button | `buttons.md` |
-| Checkbox, Checkbox-with-label | `checkboxes.md` |
-| Tag, Badge | `tags-badges-status-indicators.md` |
-| Dialog, Confirmation | `dialogs-and-confirmations.md` |
-| Empty / Error / Maintenance / Success state | `empty-and-system-states.md` |
+| `button` | `buttons.md` |
+| `link` | `links.md` |
+| `sticky-footer` | `sticky-footer.md` |
+| `checkbox-with-label` | `checkboxes.md` |
+| `dropdown-select-default` | `dropdown-select.md` |
+| `input`, `input-date`, `calendar`, `rich-text` | `text-input.md` |
+| `search`, `search-dropdown-menu` | `search.md` |
+| `search-filters` | `filters.md` |
+| `toglge` (sic — Toggle in Figma) | `switch.md` |
+| `radio-button` | `forms.md` |
+| `breadcrumbs`, `global-header`, `side-nav`, `tabs`, `account-dropdown`, `app-switcher-dropdown`, `traffic-light` | `navigation.md` |
+| `notification-dropdown`, `notification`, `alert-banner` | `notifications-and-messaging.md` *(alert-banner uses `alerts.md` when scope is alert-specific)* |
+| `stepper`, `stepper-buttons` | `stepper.md` |
+| `whats-new-dropdown` | `whats-new.md` |
+| `card`, `perimeter-card`, `search-result-card` | `cards.md` |
+| `table` | `tables.md` *(also reference `data-tables.md` for sort/filter/bulk-action specifics)* |
+| `tag-default`, `tag-catalog`, `tag-catalog-item-type`, `tag-glossary-item-type`, `tag-interactive`, `tag-stage`, `tag-status`, `tag-updated`, `badge` | `tags-badges-status-indicators.md` |
+| `lineage-connecting-line`, `lineage-grouped-node`, `lineage-individual-node` | `lineage-specific-ui.md` |
+| `progress-bar-small`, `loader`, `loader-with-logo`, `loading-skeleton`, `spinner` | `loading-and-progress.md` |
+| `confirmation` | `dialogs-and-confirmations.md` |
+| `empty-state`, `error-state`, `maintenance-banner`, `maintenance-state` | `empty-and-system-states.md` |
+| `modal` | `modal.md` |
+| `popover`, `tooltip` | `popover.md` |
 
-If no clean match exists for the component, omit the per-topic file, rely on `content/dist/content.md` for content rules, and add a note in the output's `research_quality` field (e.g., `"content_routing": "no per-topic file matched; consolidated only"`).
+#### Step 2 — Category fallback (when slug doesn't match)
+
+Look up the component's category in `vendor/components/dist/categories.json` and use the category's default topic:
+
+| Category | Default topic |
+|---|---|
+| Action | `buttons.md` |
+| Form (input & selection) | `forms.md` |
+| Navigation | `navigation.md` |
+| Feedback | `notifications-and-messaging.md` |
+| Overlays | `dialogs-and-confirmations.md` |
+| Data Display | *(no clean default — fall through to Step 3)* |
+
+#### Step 3 — Global fallback
+
+If neither Step 1 nor Step 2 yields a topic file, omit the per-topic file. Rely on `content/dist/content.md` (`Global guidelines` section) and add a note in `research_quality`:
+
+```
+"content_routing": "<slug>: no per-topic match, category=<cat or 'uncategorized'>; consolidated only"
+```
+
+The category is informational metadata even when no topic file is loaded — surface it in the output so designers can spot mis-categorization.
 
 ## Research targets
 

--- a/plugins/actian-design-system/references/context/companion-context.md
+++ b/plugins/actian-design-system/references/context/companion-context.md
@@ -110,6 +110,21 @@ Full context: `references/context/app-context.md`
 
 Before building custom frames, check: `vendor/components/dist/dskit-components.md`, `vendor/components/dist/fm-components.md`, `vendor/components/src/guidelines/{name}.json`
 
+### DS Kit Categories
+
+DS Kit components are grouped into 6 categories (synced from the design team's Figma Pages-panel naming). Use this when designers ask DS-org questions ("which components are in Form?", "what category is X?", "show me all Feedback components").
+
+| Category | Components | Examples |
+|---|---|---|
+| **Action** | 3 | button, link, sticky-footer |
+| **Form (input & selection)** | 11 | input, text-input, checkbox-with-label, radio-button, dropdown-select-default, search, toggle, calendar |
+| **Navigation** | 11 | breadcrumbs, side-nav, tabs, global-header, stepper, account-dropdown, app-switcher-dropdown |
+| **Data Display** | 31 | card, table, badge, tag-*, avatar, segmented-control, page-header, toolbar, lineage-*, line-graph |
+| **Feedback** | 11 | alert-banner, notification, empty-state, error-state, loader, spinner, loading-skeleton |
+| **Overlays** | 5 | modal, popover, tooltip, drawer-side-panel, chat-with-ai-steward |
+
+Counts and full membership: `vendor/components/dist/categories.json` (source of truth — synced from Figma). Some components carry `status` (`in-progress` ✍️, `deprecated` ⛔️, `warn` ⚠️) — surface this when answering questions about a component's readiness.
+
 **Common FM wireframe components:** fmButton, fmTextInput, fmDropdown, fmSearchInput, fmTableCell, fmCheckbox, fmRadioButton, fmToggle, fmAlert, fmBanner, fmDialog, fmEmptyState, fmPlaceholder, fmTab, fmStepper, fmBadge, fmTag, fmToast, fmPageHeader, fmAppHeader, fmNavItem
 
 ## Interactive Gates

--- a/plugins/actian-design-system/skills/component-brief/SKILL.md
+++ b/plugins/actian-design-system/skills/component-brief/SKILL.md
@@ -95,8 +95,9 @@ If the Step 1.5 response opted in to research (e.g., `research all`, `research u
    - Scoped cards (intersect requested research with research-applicable cards: card_usage, card_content, card_accessibility)
    - Existing context inlined:
      - `component-guidelines/<slug>.json` (component-specific brief context)
+     - `vendor/components/dist/categories.json` (DS Kit category lookup — feeds the brief-researcher's topic-routing fallback; see `agents/brief-researcher.md` for the resolution rules)
      - `vendor/foundations/src/foundations.md` (relevant excerpts)
-     - `vendor/content/src/content-index.md` + the matching `vendor/content/src/<topic-slug>.md` (canonical UI-copy guidance for the component — see `agents/brief-researcher.md` for the routing table)
+     - `vendor/content/src/content-index.md` + the matching `vendor/content/src/<topic-slug>.md` (canonical UI-copy guidance for the component — resolved via slug → category → global per `agents/brief-researcher.md`)
      - `vendor/content/dist/content.md` (fallback for cross-cutting voice/tone, and when no per-topic file matches)
      - `vendor/accessibility/accessibility.md`
    - Output path: `{project_working_directory}/components/[name]/[name]-research-findings.json`

--- a/plugins/actian-design-system/tests/integration/categories.test.js
+++ b/plugins/actian-design-system/tests/integration/categories.test.js
@@ -1,0 +1,126 @@
+"use strict";
+
+// Schema test for the component-category sync (Phase 0 in knowledge repo
+// v0.3.4–v0.3.6; Phase 1 consumption in plugin v1.81.0+).
+//
+// Asserts:
+//   1. categories.json structure is valid and matches the known shape.
+//   2. Every category name in categories.json is in KNOWN_CATEGORIES.
+//   3. Every component slug listed in categories.json exists in the
+//      DS Kit registry.
+//   4. Every DS Kit registry entry with a `category` field is
+//      cross-referenced in categories.json under that category.
+//   5. categories.json `uncategorized.count` + sum-of-categorized-counts
+//      equals the registry's total component count.
+//
+// Failure mode: surfaces drift between the registry and categories.json
+// (e.g., a manual edit to categories.json without re-running the sync,
+// or a vendor snapshot that pulled one file but not the other).
+
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const PATHS = require("../../scripts/lib/paths");
+
+// Source of truth for the closed set of categories. Mirrors
+// KNOWN_CATEGORIES in the knowledge repo's
+// scripts/transformers/transform-categories.js. Keep in sync when the
+// design team adds a new category in Figma.
+const KNOWN_CATEGORIES = new Set([
+  "Action",
+  "Form (input & selection)",
+  "Navigation",
+  "Data Display",
+  "Feedback",
+  "Overlays",
+]);
+
+function loadJSON(p) {
+  return JSON.parse(require("fs").readFileSync(p, "utf8"));
+}
+
+test("categories.json — structure", () => {
+  const c = loadJSON(PATHS.components.categories);
+  assert.equal(c.library, "ds", "categories.json is DS-Kit-only");
+  assert.ok(typeof c.generatedAt === "string", "generatedAt is set");
+  assert.ok(c.categories && typeof c.categories === "object", "categories present");
+  assert.ok(c.uncategorized && typeof c.uncategorized.count === "number", "uncategorized.count present");
+});
+
+test("categories.json — every category is in KNOWN_CATEGORIES", () => {
+  const c = loadJSON(PATHS.components.categories);
+  for (const name of Object.keys(c.categories)) {
+    assert.ok(
+      KNOWN_CATEGORIES.has(name),
+      `Unknown category '${name}'. Update KNOWN_CATEGORIES in tests/integration/categories.test.js AND knowledge repo's transform-categories.js if the design team intentionally added it.`,
+    );
+  }
+});
+
+test("categories.json — every listed slug exists in DS Kit registry", () => {
+  const c = loadJSON(PATHS.components.categories);
+  const reg = loadJSON(PATHS.components.registries.dskit);
+  const regSlugs = new Set(Object.keys(reg.components));
+
+  const missing = [];
+  for (const [catName, entry] of Object.entries(c.categories)) {
+    for (const slug of entry.components) {
+      if (!regSlugs.has(slug)) {
+        missing.push(`${catName} -> ${slug}`);
+      }
+    }
+  }
+  assert.equal(
+    missing.length,
+    0,
+    `categories.json lists ${missing.length} slug(s) not present in dskit registry: ${missing.join(", ")}`,
+  );
+});
+
+test("DS Kit registry — every component with a category is cross-referenced in categories.json", () => {
+  const c = loadJSON(PATHS.components.categories);
+  const reg = loadJSON(PATHS.components.registries.dskit);
+
+  const orphans = [];
+  for (const [slug, entry] of Object.entries(reg.components)) {
+    if (!entry.category) continue;
+    const cat = c.categories[entry.category];
+    if (!cat) {
+      orphans.push(`${slug} -> category='${entry.category}' (category absent from categories.json)`);
+      continue;
+    }
+    if (!cat.components.includes(slug)) {
+      orphans.push(`${slug} -> registry says '${entry.category}' but slug not in that category's components[]`);
+    }
+  }
+  assert.equal(
+    orphans.length,
+    0,
+    `${orphans.length} registry/categories.json drift: ${orphans.slice(0, 10).join("; ")}${orphans.length > 10 ? "; …" : ""}`,
+  );
+});
+
+test("categories.json — counts reconcile with registry", () => {
+  const c = loadJSON(PATHS.components.categories);
+  const reg = loadJSON(PATHS.components.registries.dskit);
+
+  const categorizedSum = Object.values(c.categories).reduce(
+    (sum, entry) => sum + entry.count,
+    0,
+  );
+  const total = categorizedSum + c.uncategorized.count;
+  const regTotal = Object.keys(reg.components).length;
+
+  assert.equal(
+    total,
+    regTotal,
+    `categories.json totals (${categorizedSum} categorized + ${c.uncategorized.count} uncategorized = ${total}) do not match registry component count (${regTotal})`,
+  );
+
+  for (const [name, entry] of Object.entries(c.categories)) {
+    assert.equal(
+      entry.count,
+      entry.components.length,
+      `category '${name}' has count=${entry.count} but components[].length=${entry.components.length}`,
+    );
+  }
+});


### PR DESCRIPTION
## Summary

Phase 1 of component-category sync — plugin consumption of the categorized data shipped in knowledge repo v0.3.4–v0.3.6 (PR [#19](https://github.com/volivarii/actian-ds-knowledge/pull/19), [#22](https://github.com/volivarii/actian-ds-knowledge/pull/22)).

72 of 322 DS Kit components now carry a `category` field; this PR wires the plugin to use it.

## What changes

| File | Change |
|---|---|
| `agents/brief-researcher.md` | Topic-routing: 5-row example table → deterministic 3-step cascade (slug match → category fallback → global). 24-row slug map covers every categorized component with a matching content topic; 6-row category map handles the rest. |
| `skills/component-brief/SKILL.md` | `categories.json` added to Step 1.6 context bundle passed to brief-researcher. |
| `references/context/companion-context.md` | New **DS Kit Categories** subsection — `/companion` can now answer DS-org questions deterministically (which components are in Form?, what category is X?). |
| `tests/integration/categories.test.js` | **New** — 5 schema tests: structure, `KNOWN_CATEGORIES` allowlist, slug ⇄ registry cross-reference, drift detection, count reconciliation. Architectural decay guard. |
| `.claude-plugin/plugin.json` | `1.80.2` → `1.81.0` (MINOR). |

## Architecture note

`PATHS.components.categories` is **already** auto-built from `vendor/paths-manifest.json` (the v1.79.5+ manifest walker creates the leaf for free). No code change to `paths.js` needed — verified via the new test consuming `PATHS.components.categories` directly.

## Routing strategy chosen

**Slug match → category fallback → global** (over category-only or generated routing JSON).

- Slug match preserves precision for the ~24 components with a clean content-topic match (e.g., `checkbox-with-label` → `checkboxes.md`).
- Category fallback handles new/uncovered components via the category default topic.
- A future Phase 1.5 could move the slug map into knowledge as a sibling artifact (`component-topic-map.json`) — out of scope here; current map lives in the agent prompt for visibility.

## Test plan

- [x] `node --test tests/integration/categories.test.js` — 5/5 pass against v0.3.6 vendor data
- [x] Full plugin suite — **809/809 pass**, no regressions
- [ ] Live smoke: trigger `/component-brief` on a categorized component (e.g., Modal) with `research all` — confirm researcher receives `categories.json` in context and routes to `modal.md`
- [ ] Live smoke: trigger `/component-brief` on an uncategorized component (e.g., Avatar) — confirm Step 2 category-fallback fires for Data-Display defaults / Step 3 global fallback for truly uncategorized

## Related

- Knowledge repo Phase 0: [#19](https://github.com/volivarii/actian-ds-knowledge/pull/19), [#22](https://github.com/volivarii/actian-ds-knowledge/pull/22)
- Vendor refresh PR [#68](https://github.com/volivarii/Actian-DS-Claude-plugin/pull/68) (v0.3.7) is independent — merges separately
- Phase 2 (category-aware brief recipe overlays) and Phase 3 (`/design-audit --scope heuristic` engine) are follow-ons

🤖 Generated with [Claude Code](https://claude.com/claude-code)