### PR TITLE
chore(ci): vendor-snapshot uses actian-ds-bot App identity (v1.81.1)

### DIFF
--- a/.github/workflows/vendor-snapshot.yml
+++ b/.github/workflows/vendor-snapshot.yml
@@ -49,6 +49,19 @@ jobs:
         with:
           node-version: '22'
 
+      # Mint a token from the actian-ds-bot GitHub App so the PR appears
+      # authored by the App, not by github-actions[bot]. The default
+      # GITHUB_TOKEN suppresses downstream workflow triggers (flakily —
+      # see specs/2026-05-11-plugin-vendor-bot-identity.md for forensics),
+      # leaving bot PRs in BLOCKED state when the ruleset requires named
+      # status checks. App-authored PRs fire pull_request events normally.
+      - name: Mint App token
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ vars.BOT_APP_ID }}
+          private-key: ${{ secrets.BOT_APP_PRIVATE_KEY }}
+
       - name: Pull vendor snapshot
         working-directory: plugins/actian-design-system
         run: |
@@ -126,6 +139,10 @@ jobs:
         id: cpr
         uses: peter-evans/create-pull-request@v7
         with:
+          # App token (not default GITHUB_TOKEN) so the PR fires
+          # pull_request workflows like pr-checks.yml against its head
+          # SHA. Required for the ruleset's named status checks.
+          token: ${{ steps.app-token.outputs.token }}
           commit-message: "vendor(knowledge): refresh to ${{ steps.target.outputs.label }} + bump"
           title: "vendor(knowledge): refresh to ${{ steps.target.outputs.label }}"
           body: |
@@ -145,7 +162,8 @@ jobs:
       - name: Enable auto-merge
         if: steps.diff.outputs.changed == 'true' && steps.cpr.outputs.pull-request-number
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # Same App token — gh CLI auto-merge call attributes to the App.
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
           gh pr merge "${{ steps.cpr.outputs.pull-request-number }}" --auto --squash --repo "${{ github.repository }}"
 

--- a/plugins/actian-design-system/.claude-plugin/plugin.json
+++ b/plugins/actian-design-system/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "actian-design-system",
   "description": "Actian Design System toolkit — generate wireframe flows with prototype wiring, create component briefs, audit designs, compare flows, and build presentations. 8 skills (with tiered generation: recognized / adapted / improvised), 8 agents, 155 tokens (3 themes, 8 collections), WCAG 2.1 AA. DS knowledge vendored from volivarii/actian-ds-knowledge.",
-  "version": "1.81.0",
+  "version": "1.81.1",
   "author": {
     "name": "Actian UX Team"
   },


### PR DESCRIPTION
## Summary

- Switches `vendor-snapshot.yml` from default `GITHUB_TOKEN` to a token minted from the `actian-ds-bot` GitHub App (`BOT_APP_ID` + `BOT_APP_PRIVATE_KEY`) for PR creation + auto-merge.
- App-authored PRs fire `pull_request` workflows deterministically; default `GITHUB_TOKEN` PRs do not (flakily).
- v1.81.0 → v1.81.1 patch bump.

## Why

PR #70 (vendor refresh to v0.3.7) sat with `statusCheckRollup: null` and `mergeStateStatus: BLOCKED`. Ruleset on `main` requires `Test suite` + `JSON syntax` checks attached to the PR head SHA. No CI fired → checks never appeared → auto-merge can't proceed.

Empirically the trigger gap is **flaky**, not deterministic:

| PR | Same author, same workflow | CI fired? |
|---|---|---|
| #67 | `github-actions[bot]` at 14:09 | yes — merged 14:19 |
| #70 | `github-actions[bot]` at 15:09 | no — BLOCKED |

App identity bypasses the suppression mechanism entirely.

## Why App (not PAT, not inline pre-flight)

- **PAT:** explicitly rejected by Track B spec — rotation pain, personal-scope leakage, audit-finding risk.
- **Inline pre-flight in vendor-snapshot.yml:** checks would attach to vendor-snapshot's workflow run, not the PR head SHA. Ruleset doesn't accept them.
- **`workflow_run` listener:** would need Checks API to back-attach status; complex, fragile.
- **App:** scoped permissions, just-in-time tokens, auditable identity, industry-standard pattern (Renovate, Dependabot, Stripe's polaris-migrator-bot).

Spec's prohibition on PAT does NOT apply to Apps — different threat model. Full rationale in working memo at `plugins/actian-design-system/docs/superpowers/specs/2026-05-11-plugin-vendor-bot-identity.md` (untracked per `feedback_no_commit_specs`).

## Setup state (already in place)

- GitHub App `actian-ds-bot` created on `volivari` personal account (App ID `3678502`)
- Permissions: Contents r/w, Pull requests r/w, Workflows r/w, Actions r, Metadata r
- Installed on `Actian-DS-Claude-plugin` (only-select-repos scope)
- Repo secret `BOT_APP_PRIVATE_KEY` set (key was rotated after accidental IDE exposure)
- Repo variable `BOT_APP_ID` set to `3678502`

## Test plan

After merge:

- [ ] Close stale PR #70 (will go conflicting once `main` has v1.81.1)
- [ ] Manually trigger `vendor-snapshot.yml` via `workflow_dispatch`
- [ ] Verify new PR author = `actian-ds-bot[bot]` (not `github-actions[bot]`)
- [ ] Verify `pr-checks.yml` fires within ~30s of PR creation
- [ ] Verify all 3 checks (`Test suite`, `JSON syntax`, `plugin.json bumped`) green on PR head SHA
- [ ] Verify auto-merge completes without manual intervention
- [ ] Plugin lands at v1.81.2 with v0.3.7 vendored knowledge

## Future work

Same App reusable for `sync-from-figma.yml` in `actian-ds-knowledge` (Phase 2, paired with Track B B2). Install App on knowledge repo when that work starts; no new App needed.

## Ownership / transfer policy

App ownership follows repo ownership per `project_federation_repo_location.md`. When repos transfer to Actian org, transfer the App too (Settings → Transfer ownership; App ID + installations persist). Rotate private key post-transfer for clean-slate hygiene.