### PR TITLE
chore(docs): depersonalize test fixture creators (v1.81.3)

### DIFF
--- a/plugins/actian-design-system/.claude-plugin/plugin.json
+++ b/plugins/actian-design-system/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "actian-design-system",
   "description": "Actian Design System toolkit — generate wireframe flows with prototype wiring, create component briefs, audit designs, compare flows, and build presentations. 8 skills (with tiered generation: recognized / adapted / improvised), 8 agents, 155 tokens (3 themes, 8 collections), WCAG 2.1 AA. DS knowledge vendored from volivarii/actian-ds-knowledge.",
-  "version": "1.81.2",
+  "version": "1.81.3",
   "author": {
     "name": "Actian UX Team"
   },

--- a/plugins/actian-design-system/tests/fixtures/sample-presentation.json
+++ b/plugins/actian-design-system/tests/fixtures/sample-presentation.json
@@ -16,7 +16,7 @@
       "title": "Design System Progress",
       "subtitle": "Q1 2026 Update",
       "date": "April 2026",
-      "creators": "Vincent Olivari"
+      "creators": "Actian UX Team"
     },
     {
       "type": "body-full",


### PR DESCRIPTION
## Summary

Replaces \`Vincent Olivari\` with \`Actian UX Team\` in the \`sample-presentation.json\` test fixture. Matches the plugin.json \`author.name\` field already in use elsewhere.

## Companion PR

Knowledge repo: volivarii/actian-ds-knowledge#24 — same depersonalization pass across knowledge-repo docs (README, CONTRIBUTING, CLAUDE.md, paths-manifest descriptions, AUTHORING files, foundations/dist/README, one guideline JSON's notes field).

## Version

1.81.2 → 1.81.3 (patch).

## Test plan

- [x] \`Test suite\` — should pass (fixture text change only, no schema/behavior change)
- [x] \`JSON syntax\` — should pass (valid JSON preserved)
- [x] \`plugin.json bumped\` — should pass (1.81.3 > 1.81.2)