### PR TITLE
fix(vendor): v1.82.1 — vendor-snapshot CI/local parity fix

### DIFF
--- a/plugins/actian-design-system/.claude-plugin/plugin.json
+++ b/plugins/actian-design-system/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "actian-design-system",
   "description": "Actian Design System toolkit — generate wireframe flows with prototype wiring, create component briefs, audit designs, compare flows, and build presentations. 8 skills (with tiered generation: recognized / adapted / improvised), 8 agents, 155 tokens (3 themes, 8 collections), WCAG 2.1 AA. DS knowledge vendored from volivarii/actian-ds-knowledge.",
-  "version": "1.82.0",
+  "version": "1.82.1",
   "author": {
     "name": "Actian UX Team"
   },

--- a/plugins/actian-design-system/scripts/vendor/vendor-snapshot.js
+++ b/plugins/actian-design-system/scripts/vendor/vendor-snapshot.js
@@ -19,7 +19,7 @@
 var fs = require("fs");
 var path = require("path");
 var os = require("os");
-var { execFileSync } = require("child_process");
+var { execFileSync, spawnSync } = require("child_process");
 
 var PLUGIN_ROOT = path.resolve(__dirname, "..", "..");
 var VENDORED_JSON_PATH = path.join(PLUGIN_ROOT, "vendored.json");
@@ -250,6 +250,50 @@ function clearVendorDir() {
   fs.rmSync(VENDOR_DIR, { recursive: true, force: true });
 }
 
+// CI parity: vendor-snapshot.yml runs render-component-reference.js as a
+// separate step AFTER the snapshot copy to regenerate the three plugin-side
+// component mirrors (dskit-components.md, fm-components.md, meta-kit/
+// components.md). Local invocations of this script bypassed that step and
+// left fresh clones with missing mirrors, which broke path-validation
+// tests. Run the renderer here so CI and local behave identically.
+//
+// If the renderer fails, the vendor tree on disk is still useful — we log a
+// warning and set a non-zero exitCode rather than rolling back.
+function runComponentReferenceRenderer() {
+  var rendererPath = path.join(
+    PLUGIN_ROOT,
+    "scripts",
+    "renderers",
+    "render-component-reference.js",
+  );
+  if (!fs.existsSync(rendererPath)) {
+    process.stderr.write(
+      "[vendor] WARNING: renderer not found at " +
+        rendererPath +
+        " — skipping mirror regeneration (rare; check plugin install)\n",
+    );
+    return false;
+  }
+  process.stdout.write(
+    "[vendor] regenerating component mirrors via render-component-reference.js --kit all\n",
+  );
+  var result = spawnSync(process.execPath, [rendererPath, "--kit", "all"], {
+    stdio: "inherit",
+  });
+  if (result.status !== 0) {
+    process.stderr.write(
+      "[vendor] WARNING: render-component-reference.js exited with status " +
+        result.status +
+        ". Vendor snapshot is on disk but component mirrors " +
+        "(dskit-components.md / fm-components.md / meta-kit/components.md) " +
+        "may be stale. Run the renderer manually to recover.\n",
+    );
+    process.exitCode = 1;
+    return false;
+  }
+  return true;
+}
+
 function vendorContent(extractedRepoRoot) {
   fs.mkdirSync(VENDOR_DIR, { recursive: true });
   var entries = fs.readdirSync(extractedRepoRoot, { withFileTypes: true });
@@ -360,6 +404,11 @@ function main() {
     };
     writeVendoredJson(manifest);
     process.stdout.write("[vendor] wrote " + VENDORED_JSON_PATH + "\n");
+
+    // CI/local parity — regenerate the three plugin-side component mirrors
+    // that vendor-snapshot.yml regenerates in a separate step.
+    runComponentReferenceRenderer();
+
     process.stdout.write("[vendor] OK\n");
   } finally {
     fs.rmSync(tmpRoot, { recursive: true, force: true });


### PR DESCRIPTION
## Summary

Small follow-up to PR ε (v1.82.0). Eliminates a CI/local parity gap that bit us during that PR's execution.

## Problem

`scripts/vendor/vendor-snapshot.js --range` pulls the knowledge snapshot but does NOT regenerate the 3 plugin-side component-mirror MDs (`dskit-components.md`, `fm-components.md`, `meta-kit/components.md`). Those are produced by `scripts/renderers/render-component-reference.js`. CI's `vendor-snapshot.yml` workflow runs the renderer as a separate post-snapshot step — local invocation didn't have this step.

Result: anyone running `vendor-snapshot.js --range` locally ends up with a tree missing the 3 mirrors, which triggers 17 path-validation test failures because plugin prose docs reference them. PR ε Task 1 hit this and patched by hand (the regenerated MDs landed in commit `03a2d81`).

## Fix

`vendor-snapshot.js` now spawns `render-component-reference.js --kit all` at the end of `--range` and `--sha` success paths, matching CI behavior. `--resolve-only` mode is unaffected (early-returns before the call). Renderer failure logs a warning and sets `process.exitCode = 1` but does NOT roll back the snapshot — the on-disk tree is still useful.

## Verification

Clean-mirror smoke flow:
1. Delete the 3 mirror MDs
2. Run `vendor-snapshot.js --range` — resolved range `~0.5.0` → v0.5.1, snapshot copied, renderer auto-invoked, 3 mirrors regenerated (dskit 322 / fm 287 / meta-kit 28 components)
3. Run `tests/integration/path-validation.test.js` — passes 1/1

Full test suite still green (839/839, 140 suites).

## Bump

Plugin: 1.82.0 → 1.82.1 (patch — internal-only fix, no public API change).

## Cross-refs

- `feature(brief)` PR #76 (v1.82.0) — the PR ε that surfaced this parity gap
- `project_next_session_pickup.md` — flagged this fix as a small follow-up worth landing before Q2 work
