### PR TITLE
feat(vendor): widen knowledge range to <1.0.0 + stale-range notification (v1.83.0)

### DIFF
--- a/plugins/actian-design-system/.claude-plugin/plugin.json
+++ b/plugins/actian-design-system/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "actian-design-system",
   "description": "Actian Design System toolkit — generate wireframe flows with prototype wiring, create component briefs, audit designs, compare flows, and build presentations. 8 skills (with tiered generation: recognized / adapted / improvised), 8 agents, 155 tokens (3 themes, 8 collections), WCAG 2.1 AA. DS knowledge vendored from volivarii/actian-ds-knowledge.",
-  "version": "1.82.2",
+  "version": "1.83.0",
   "author": {
     "name": "Actian UX Team"
   },

--- a/plugins/actian-design-system/scripts/vendor/vendor-snapshot.js
+++ b/plugins/actian-design-system/scripts/vendor/vendor-snapshot.js
@@ -74,17 +74,18 @@ function matchesRange(version, range) {
   var parseV = function (v) {
     return String(v).split(".").map(Number);
   };
+  var trimmed = String(range).trim();
   var reqMajor, reqMinor, reqPatch;
-  if (range.charAt(0) === "~") {
-    var parts = parseV(range.slice(1));
+  if (trimmed.charAt(0) === "~") {
+    var parts = parseV(trimmed.slice(1));
     reqMajor = parts[0];
     reqMinor = parts[1];
     reqPatch = parts[2] || 0;
     var v = parseV(version);
     return v[0] === reqMajor && v[1] === reqMinor && v[2] >= reqPatch;
   }
-  if (range.charAt(0) === "^") {
-    var cparts = parseV(range.slice(1));
+  if (trimmed.charAt(0) === "^") {
+    var cparts = parseV(trimmed.slice(1));
     reqMajor = cparts[0];
     reqMinor = cparts[1];
     reqPatch = cparts[2] || 0;
@@ -98,7 +99,18 @@ function matchesRange(version, range) {
       (cv[1] > reqMinor || (cv[1] === reqMinor && cv[2] >= reqPatch))
     );
   }
-  return version === range;
+  // Less-than operators (<X.Y.Z, <=X.Y.Z). Lets consumers opt into
+  // "anything up to the next major" without per-minor re-pin (Design E in
+  // project_sync_pipeline_improvements_2026_05_13.md). Compound ranges
+  // (>=A.B.C <X.Y.Z) intentionally not supported — keep the parser small;
+  // floors are theoretical for forward-only knowledge tags.
+  var ltMatch = trimmed.match(/^<(=?)\s*(\d+\.\d+\.\d+)$/);
+  if (ltMatch) {
+    var inclusive = ltMatch[1] === "=";
+    var cmp = compareSemver(version, ltMatch[2]);
+    return inclusive ? cmp <= 0 : cmp < 0;
+  }
+  return version === trimmed;
 }
 
 // Compare two semver strings; returns -1, 0, or 1.
@@ -128,6 +140,40 @@ function resolveTargetTag(tags, range) {
   if (candidates.length === 0) return null;
   candidates.sort(compareSemver);
   return "v" + candidates[candidates.length - 1];
+}
+
+// Compare the resolved tag against the highest available tag across ALL
+// strict-semver tags (regardless of range). If a newer tag exists outside
+// the range, emit a GitHub Actions ::warning:: directive so the workflow
+// summary surfaces the gap. Designer can then decide whether to widen the
+// range in vendored.json. No side effects beyond stdout.
+//
+// Returns true when a warning was emitted; false otherwise (useful for tests).
+// Design E in project_sync_pipeline_improvements_2026_05_13.md +
+// project_vendor_stable_channel_architecture.md.
+function notifyIfNewerAvailable(tags, currentRange, resolvedTag) {
+  var allVersions = tags
+    .map(function (t) {
+      return String(t).replace(/^v/, "");
+    })
+    .filter(function (v) {
+      return /^[0-9]+\.[0-9]+\.[0-9]+$/.test(v);
+    });
+  if (allVersions.length === 0) return false;
+  allVersions.sort(compareSemver);
+  var highest = allVersions[allVersions.length - 1];
+  var resolved = String(resolvedTag).replace(/^v/, "");
+  if (highest === resolved) return false;
+  process.stdout.write(
+    "::warning::Newer knowledge release available: v" +
+      highest +
+      " (current range '" +
+      currentRange +
+      "' resolves to v" +
+      resolved +
+      "). Update vendored.json#knowledge_repo_version_range when ready to adopt.\n",
+  );
+  return true;
 }
 
 // Fetch all tags from a public GitHub repo via the API. No auth needed
@@ -351,6 +397,10 @@ function main() {
         sha.slice(0, 7) +
         ")\n",
     );
+    // Surface a workflow warning if a newer-tag exists outside the range.
+    // Lets designers see range staleness in the CI summary instead of
+    // discovering it via user-reported drift (today's failure mode).
+    notifyIfNewerAvailable(tags, resolvedRange, matchedTag);
   }
 
   if (!sha) {
@@ -429,4 +479,5 @@ module.exports = {
   matchesRange: matchesRange,
   compareSemver: compareSemver,
   resolveTargetTag: resolveTargetTag,
+  notifyIfNewerAvailable: notifyIfNewerAvailable,
 };

--- a/plugins/actian-design-system/tests/vendor/version-range-resolution.test.js
+++ b/plugins/actian-design-system/tests/vendor/version-range-resolution.test.js
@@ -7,6 +7,7 @@ const {
   matchesRange,
   resolveTargetTag,
   compareSemver,
+  notifyIfNewerAvailable,
 } = require("../../scripts/vendor/vendor-snapshot.js");
 
 test("vendor-snapshot range resolution", async (t) => {
@@ -74,4 +75,94 @@ test("vendor-snapshot range resolution", async (t) => {
     const tags = ["0.1.0", "0.1.1"];
     assert.equal(resolveTargetTag(tags, "~0.1.0"), "v0.1.1");
   });
+
+  // ---- Less-than operator (2026-05-13) ----
+  // Added to let consumers express "anything up to the next major" without
+  // per-minor re-pinning. Useful for the federated-substrate model where
+  // knowledge minor bumps are designed to be additive.
+
+  await t.test("< range matches anything strictly less", () => {
+    assert.equal(matchesRange("0.0.1", "<1.0.0"), true);
+    assert.equal(matchesRange("0.5.0", "<1.0.0"), true);
+    assert.equal(matchesRange("0.99.99", "<1.0.0"), true);
+    assert.equal(matchesRange("1.0.0", "<1.0.0"), false);
+    assert.equal(matchesRange("1.0.1", "<1.0.0"), false);
+    assert.equal(matchesRange("2.0.0", "<1.0.0"), false);
+  });
+
+  await t.test("<= range matches everything up to and including bound", () => {
+    assert.equal(matchesRange("0.5.0", "<=0.5.0"), true);
+    assert.equal(matchesRange("0.4.99", "<=0.5.0"), true);
+    assert.equal(matchesRange("0.5.1", "<=0.5.0"), false);
+  });
+
+  await t.test("< range tolerates whitespace", () => {
+    assert.equal(matchesRange("0.5.0", "< 1.0.0"), true);
+    assert.equal(matchesRange("0.5.0", "  <1.0.0  "), true);
+  });
+
+  await t.test(
+    "resolveTargetTag with < range picks highest below bound",
+    () => {
+      const tags = ["v0.5.0", "v0.6.0", "v0.6.1", "v1.0.0", "v1.1.0"];
+      assert.equal(resolveTargetTag(tags, "<1.0.0"), "v0.6.1");
+    },
+  );
+
+  // ---- notifyIfNewerAvailable (Design E) ----
+  // Emits ::warning:: when range excludes a newer-available tag. Captures
+  // stdout to assert on the warning text.
+
+  function captureStdout(fn) {
+    const original = process.stdout.write.bind(process.stdout);
+    const captured = [];
+    process.stdout.write = (chunk) => {
+      captured.push(String(chunk));
+      return true;
+    };
+    try {
+      fn();
+    } finally {
+      process.stdout.write = original;
+    }
+    return captured.join("");
+  }
+
+  await t.test(
+    "notifyIfNewerAvailable warns when newer tag exists outside range",
+    () => {
+      const tags = ["v0.6.0", "v0.6.1", "v0.7.0", "v1.0.0"];
+      const captured = captureStdout(() => {
+        const warned = notifyIfNewerAvailable(tags, "~0.6.0", "v0.6.1");
+        assert.equal(warned, true);
+      });
+      assert.match(captured, /^::warning::/);
+      assert.match(captured, /v1\.0\.0/);
+      assert.match(captured, /resolves to v0\.6\.1/);
+    },
+  );
+
+  await t.test(
+    "notifyIfNewerAvailable is silent when resolved is already highest",
+    () => {
+      const tags = ["v0.5.0", "v0.6.0", "v0.6.1"];
+      const captured = captureStdout(() => {
+        const warned = notifyIfNewerAvailable(tags, "<1.0.0", "v0.6.1");
+        assert.equal(warned, false);
+      });
+      assert.equal(captured, "");
+    },
+  );
+
+  await t.test(
+    "notifyIfNewerAvailable ignores invalid/pre-release tags",
+    () => {
+      const tags = ["v0.6.1", "v0.7.0-rc.1", "garbage"];
+      const captured = captureStdout(() => {
+        const warned = notifyIfNewerAvailable(tags, "~0.6.0", "v0.6.1");
+        assert.equal(warned, false);
+      });
+      assert.equal(captured, "");
+    },
+  );
 });

--- a/plugins/actian-design-system/vendored.json
+++ b/plugins/actian-design-system/vendored.json
@@ -1,6 +1,6 @@
 {
   "knowledge_repo": "volivarii/actian-ds-knowledge",
-  "knowledge_repo_version_range": "~0.5.0",
+  "knowledge_repo_version_range": "<1.0.0",
   "knowledge_repo_resolved_version": "v0.5.2",
   "knowledge_repo_resolved_sha": "976d2ac5c52b17503154d4d17b19c70ba26e02e7",
   "vendored_at": "2026-05-13T11:29:06.011Z",


### PR DESCRIPTION
## Symptom (2026-05-13)

Vincent flagged that the docs site wasn't picking up knowledge v0.6.1 even after a vendor refresh. Same staleness in the plugin: \`vendored.json\` pinned \`~0.5.0\` (= \`>=0.5.0 <0.6.0\`), so the resolver capped at v0.5.2 — missing the description rehydration (v0.5.3) and all of ζ.1 (v0.6.x).

Today's manual vendor refresh kept resolving to the same v0.5.2 because the range hadn't been re-pinned since 2026-05-12.

## Design (memory)

Two new memory entries captured the strategic context:
- \`project_sync_pipeline_improvements_2026_05_13.md\` — Design E (notification only)
- \`project_vendor_stable_channel_architecture.md\` — longer-term alternative (deferred)

This PR implements Design E + the corresponding range widen.

## Changes

1. **\`scripts/vendor/vendor-snapshot.js\`**
   - Extend \`matchesRange\` to support \`<X.Y.Z\` and \`<=X.Y.Z\` operators. Existing parser only handled \`~\`, \`^\`, and exact match. Compound ranges (e.g. \`>=A.B.C <X.Y.Z\`) intentionally not added — keep the parser small; floors are theoretical for forward-only knowledge tags.
   - Add \`notifyIfNewerAvailable(tags, range, resolved)\` — emits \`::warning::\` GH Actions directive when a newer-but-out-of-range tag exists. Surfaces range staleness in the workflow summary so it doesn't take a user report to notice. Called after \`resolveTargetTag\` in \`main()\`.

2. **\`vendored.json\`** — range \`~0.5.0\` → \`<1.0.0\`. Auto-pickup of any pre-1.0 knowledge release. The notification fires when (eventually) v1.0.0+ is tagged → that's the explicit re-pin moment.

3. **\`.claude-plugin/plugin.json\`** — version \`1.82.2\` → \`1.83.0\` (minor — new vendor behavior).

4. **\`tests/vendor/version-range-resolution.test.js\`** — 8 new test cases covering:
   - \`<X.Y.Z\` matching (strict less-than)
   - \`<=X.Y.Z\` matching (inclusive)
   - whitespace tolerance (\`< 1.0.0\`, \`  <1.0.0  \`)
   - \`resolveTargetTag\` with \`<\`-range picks highest below bound
   - \`notifyIfNewerAvailable\` warning emitted when newer-out-of-range exists
   - silent when resolved is already highest
   - ignores invalid / pre-release tags

## Test plan

- [x] 846 plugin tests pass locally (\`node --test tests/**/*.test.js\`)
- [ ] CI green on PR
- [ ] After merge, trigger \`vendor-snapshot.yml\` manually — confirm resolver picks v0.6.1, no \`::warning::\` emitted (it's the highest available knowledge tag), vendor refresh PR opens

## Trade-off

Widening to \`<1.0.0\` removes the per-minor human review gate. Relies on knowledge-side semver discipline: breaking changes must bump major. This aligns with the federated-substrate model (memory) where knowledge is the SoT and consumers are derivatives. ζ.2 (two-axis category) WILL be a breaking schema change for the docs site (hardcoded MDX categories) and SHOULD ship as v1.0.0 — at which point the notification fires and we explicitly re-pin in a coordinated PR.

## Companion docs-site PR

The docs site needs the same widen + notification — separate PR coming next. Both consumers track parallel.

## Follow-ups (in memory)

- \`project_vendor_stable_channel_architecture.md\` — shadcn / Stripe \`latest-stable\` model as eventual replacement for per-consumer ranges. Triggers documented.