### PR TITLE
fix(tests): update KNOWN_CATEGORIES + scope category-defaults test (ζ.2 follow-up, v1.83.2)

### DIFF
--- a/plugins/actian-design-system/.claude-plugin/plugin.json
+++ b/plugins/actian-design-system/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "actian-design-system",
   "description": "Actian Design System toolkit — generate wireframe flows with prototype wiring, create component briefs, audit designs, compare flows, and build presentations. 8 skills (with tiered generation: recognized / adapted / improvised), 8 agents, 155 tokens (3 themes, 8 collections), WCAG 2.1 AA. DS knowledge vendored from volivarii/actian-ds-knowledge.",
-  "version": "1.83.1",
+  "version": "1.83.2",
   "author": {
     "name": "Actian UX Team"
   },

--- a/plugins/actian-design-system/tests/integration/categories.test.js
+++ b/plugins/actian-design-system/tests/integration/categories.test.js
@@ -25,13 +25,38 @@ const PATHS = require("../../scripts/lib/paths");
 // KNOWN_CATEGORIES in the knowledge repo's
 // scripts/transformers/transform-categories.js. Keep in sync when the
 // design team adds a new category in Figma.
-const KNOWN_CATEGORIES = new Set([
+//
+// COMPONENTS-section categories — these have curated *-defaults.json
+// files under vendor/components/dist/categories/. The
+// category-defaults-loader test enforces that mapping.
+const COMPONENTS_CATEGORIES = new Set([
   "Action",
   "Form (input & selection)",
   "Navigation",
   "Data Display",
   "Feedback",
   "Overlays",
+]);
+
+// ζ.2 (knowledge v0.7.0+, 2026-05-13) — `category` is now populated for
+// items outside the COMPONENTS section too: Foundations pages (icons,
+// breakpoints, etc.) and Brand assets pages. These values come straight
+// from the Figma page clean-name. No defaults files exist for them yet
+// (category-defaults are scoped to the curated Components set above);
+// the category-defaults-loader test below skips these by design.
+const NON_COMPONENTS_CATEGORIES = new Set([
+  "Breakpoint, grid & structure",
+  "Content guidelines",
+  "Icons",
+  "Illustrations & graphics",
+  "Local components",
+  "Product logos",
+  "White-label services",
+]);
+
+const KNOWN_CATEGORIES = new Set([
+  ...COMPONENTS_CATEGORIES,
+  ...NON_COMPONENTS_CATEGORIES,
 ]);
 
 function loadJSON(p) {
@@ -238,10 +263,16 @@ test("category-defaults — every accessibility ref slug resolves against a11y-i
   );
 });
 
-test("category-defaults — every dskit registry category label normalizes to an existing defaults slug", () => {
+test("category-defaults — every COMPONENTS-section category normalizes to an existing defaults slug", () => {
+  // ζ.2 (2026-05-13): scoped to COMPONENTS-section categories. Foundations
+  // and Brand-section categories (Icons, Marketing icons, etc.) intentionally
+  // have no defaults file — the loader falls through to null and per-component
+  // guideline content still renders cleanly. Add to COMPONENTS_CATEGORIES if
+  // we author defaults for any of the new Foundations/Brand categories.
   const c = loadJSON(PATHS.components.categories);
   const unmapped = [];
   for (const label of Object.keys(c.categories)) {
+    if (!COMPONENTS_CATEGORIES.has(label)) continue;
     const slug = loader.normalizeCategorySlug(label);
     const d = loader.loadDefaultsForCategory(slug);
     if (!d) unmapped.push(`'${label}' → '${slug}' (no defaults file)`);
@@ -249,6 +280,6 @@ test("category-defaults — every dskit registry category label normalizes to an
   assert.deepEqual(
     unmapped,
     [],
-    `dskit category labels with no matching defaults file:\n  ${unmapped.join("\n  ")}`,
+    `COMPONENTS-section category labels with no matching defaults file:\n  ${unmapped.join("\n  ")}`,
   );
 });


### PR DESCRIPTION
## Fixes

PR #82 (vendor refresh to knowledge v0.8.1) blocked on two test failures in \`tests/integration/categories.test.js\`:

- \`every category is in KNOWN_CATEGORIES\` — failed on \`'Breakpoint, grid & structure'\` (new ζ.2 value for Foundations items that pre-ζ.2 had \`category: null\`)
- \`every dskit registry category label normalizes to an existing defaults slug\` — failed because Foundations/Brand-section categories correctly have no \`*-defaults.json\` file (defaults are scoped to the 6 curated Components categories only)

## Root cause

ζ.2 (knowledge v0.7.0, 2026-05-13) populated \`category\` for items outside the COMPONENTS section — Foundations pages (Icons, Breakpoint grid & structure, Content guidelines) and Brand assets (Product logos, Illustrations, Local components, White-label services). The plugin's hardcoded \`KNOWN_CATEGORIES\` Set was authored for the original 6 values and didn't anticipate the additive expansion. This is the plugin-side catch-up the earlier ecosystem audit flagged.

## Changes

1. **Split \`KNOWN_CATEGORIES\` into two sub-sets** in the test:
   - \`COMPONENTS_CATEGORIES\` — the 6 originals (Action / Form / Navigation / Data Display / Feedback / Overlays) — these have curated \`*-defaults.json\` files.
   - \`NON_COMPONENTS_CATEGORIES\` — the 7 Foundations/Brand values added by ζ.2.
   - \`KNOWN_CATEGORIES\` = union → the membership assertion now passes against v0.8.x vendor data.

2. **Scope the category-defaults-loader test to COMPONENTS_CATEGORIES only.** Foundations/Brand items correctly get null defaults via the loader's graceful fallback; per-component guideline content still renders cleanly without category-level defaults. Inline comment documents when to extend \`COMPONENTS_CATEGORIES\` if we author defaults for new categories later.

## Verification

v0.8.0 category set verified against [knowledge categories.json](https://raw.githubusercontent.com/volivarii/actian-ds-knowledge/v0.8.0/components/dist/categories.json) — 13 values total, all covered by the union.

10 tests pass against current vendor (v0.6.1) locally. After this PR lands, PR #82's test suite re-runs and the vendor refresh to v0.8.1 unblocks.

## Version

Plugin v1.83.1 → v1.83.2 (patch — test-only fix).

## Out of scope

\`references/context/companion-context.md:115-124\` still documents the 6-category enum and was flagged in the ecosystem audit before ζ.2 shipped. That's documentation drift (not CI-gated). Separate follow-up.