### PR TITLE
feat(brief-sourcing): extract prose from new {prose} and {bullets} shapes

### DIFF
--- a/plugins/actian-design-system/.claude-plugin/plugin.json
+++ b/plugins/actian-design-system/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "actian-design-system",
   "description": "Actian Design System toolkit — generate wireframe flows with prototype wiring, create component briefs, audit designs, compare flows, and build presentations. 8 skills (with tiered generation: recognized / adapted / improvised), 8 agents, 155 tokens (3 themes, 8 collections), WCAG 2.1 AA. DS knowledge vendored from volivarii/actian-ds-knowledge.",
-  "version": "1.85.2",
+  "version": "1.85.3",
   "author": {
     "name": "Actian UX Team"
   },

--- a/plugins/actian-design-system/scripts/transformers/brief-sourcing.js
+++ b/plugins/actian-design-system/scripts/transformers/brief-sourcing.js
@@ -282,12 +282,23 @@ function formatForBrief(cardKey, sourceResult, ctx) {
     var terminology = [];
 
     function proseOf(items) {
+      // Concat the narrative bits of a section into one description string.
+      // Handles all parser shapes that carry prose-like text:
+      //   - {prose}              standalone paragraph (current parser)
+      //   - {bullets:[...]}      one list, items joined (current parser)
+      //   - {note}               blockquote/callout (current + legacy)
+      //   - string               legacy bare bullet (pre-prose JSON)
+      // Other shapes (do/dont/term/table/example) are not narrative and are
+      // handled by the caller's ingest() walk below.
       var bits = [];
       for (var n = 0; n < items.length; n++) {
         var it = items[n];
         if (typeof it === "string") bits.push(it);
-        else if (it && typeof it === "object" && it.note != null)
-          bits.push(it.note);
+        else if (it && typeof it === "object") {
+          if (typeof it.prose === "string") bits.push(it.prose);
+          else if (Array.isArray(it.bullets)) bits.push(it.bullets.join(" "));
+          else if (it.note != null) bits.push(it.note);
+        }
       }
       return bits.join(" ");
     }

--- a/plugins/actian-design-system/tests/transformers/brief-sourcing.test.js
+++ b/plugins/actian-design-system/tests/transformers/brief-sourcing.test.js
@@ -355,6 +355,47 @@ test("formatForBrief — content card maps guideline sections into rules + termi
   assert.equal(result._source, "figma");
 });
 
+test("formatForBrief — content card extracts prose from new {prose} and {bullets} shapes", function () {
+  // Knowledge parser v2 emits {prose} (was {note}) for paragraphs and
+  // {bullets:[...]} (was bare strings) for lists. The plugin reads vendored
+  // JSON which will eventually carry these new shapes — proseOf() must
+  // surface them as section descriptions, not silently drop them.
+  var doc = {
+    _schema_version: 1,
+    slug: "x",
+    component: "X",
+    meta: { category: "action" },
+    domains: {
+      content: {
+        status: "approved",
+        markdown: "",
+        sections: [
+          {
+            heading: "Stepper labels",
+            content: [
+              { prose: "Use the following label terminology consistently:" },
+              { bullets: ["Back for previous.", "Next for intermediate."] },
+              { prose: "Do not mix Continue and Next in the same flow." },
+            ],
+          },
+        ],
+      },
+    },
+  };
+  var ctx = { component: "X", slug: "x", guidelinesJson: doc };
+  var content = sourcing.transcribeContentGuidelines(doc).content;
+  var result = sourcing.formatForBrief(
+    "card_content",
+    { source: "figma", content: content },
+    ctx,
+  );
+  assert.equal(result.rules.length, 1);
+  var desc = result.rules[0].description;
+  assert.match(desc, /label terminology consistently/);
+  assert.match(desc, /Back for previous\./);
+  assert.match(desc, /Do not mix Continue and Next/);
+});
+
 test("transcribeContentGuidelines / isStubGuideline — registry-alias copy is handled like any other doc", function () {
   // Knowledge ships registry-key alias copies, e.g. checkbox-with-label.json
   // carrying `_alias_of: "checkbox"`. The plugin loads it by slug like any


### PR DESCRIPTION
## Summary

Companion to https://github.com/volivarii/actian-ds-knowledge/pull/74. Once knowledge v0.12 lands and vendor-snapshot picks it up, the per-component derived JSON starts carrying `{prose}` (was `{note}` for paragraphs) and `{bullets:[…]}` (was bare strings for lists). `brief-sourcing.proseOf()` must extract from both new shapes so component-brief content rules don't silently lose their description text.

## Change

`proseOf()` now reads:
- `{prose}` — standalone paragraph (new)
- `{bullets:[…]}` — joined as description sentences (new)
- `{note}` — blockquote/callout (current + legacy)
- bare `string` — legacy bullet

The plugin already shipped + landed (v1.85.2 on main) ahead of the knowledge release — that bump migrated to the post-Phase-5 vendored shape. This PR is the second forward-compat extension before knowledge v0.12.

## Compatibility

Backwards compatible. Legacy vendored JSON still works (paragraphs come in as `{note}` → callout, bullets as strings → joined). When vendor-snapshot picks up knowledge v0.12, the new shapes start arriving and they extract correctly.

## Version

PATCH bump v1.85.2 → v1.85.3.

## Test plan

- [x] `node --test tests/**/*.test.js` — 853/853 pass
- [x] +1 regression test verifying `proseOf` extracts text from `{prose}` and `{bullets}` (in `tests/transformers/brief-sourcing.test.js`)
- [ ] After knowledge v0.12 vendor-refresh, smoke component-brief on sticky-footer: Steppers section description should include the lede paragraph + bullets + closing paragraph, not lose any of them