### PR TITLE
feat(brief-sourcing): accept 'synthesized' status alongside approved/draft

### DIFF
--- a/plugins/actian-design-system/.claude-plugin/plugin.json
+++ b/plugins/actian-design-system/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "actian-design-system",
   "description": "Actian Design System toolkit — generate wireframe flows with prototype wiring, create component briefs, audit designs, compare flows, and build presentations. 8 skills (with tiered generation: recognized / adapted / improvised), 8 agents, 155 tokens (3 themes, 8 collections), WCAG 2.1 AA. DS knowledge vendored from volivarii/actian-ds-knowledge.",
-  "version": "1.85.4",
+  "version": "1.86.0",
   "author": {
     "name": "Actian UX Team"
   },

--- a/plugins/actian-design-system/scripts/transformers/brief-sourcing.js
+++ b/plugins/actian-design-system/scripts/transformers/brief-sourcing.js
@@ -30,18 +30,26 @@ function transcribeFigmaDescription(ctx) {
 }
 
 // Reads the `content` domain of the merged per-component guideline doc
-// (components/dist/guidelines/<slug>.json). Only `approved`/`draft` content
-// carries a body; `inherited`/`not-started` (or an absent domain) means there
-// is nothing to transcribe — the card falls through to Phase B.
+// (components/dist/guidelines/<slug>.json). Three content-bearing statuses:
+//   - approved: per-component authored, signed-off
+//   - draft:    per-component authored, unreviewed
+//   - synthesized: no per-component authored content; sections sourced entirely
+//                  from pattern fan-out (each section carries section.source =
+//                  "pattern:<slug>"). See knowledge v0.15.0 +
+//                  scripts/content/fanout-patterns.js.
+// inherited / not-started (or an absent domain) means there is nothing to
+// transcribe — the card falls through to Phase B.
 // NOTE: `source: "figma"` is a legacy value name. It marks "transcribed from
 // curated source material" (vs "generated"); the source is now the knowledge
 // repo's authored markdown, not the Figma file. The schema's _source enum
 // (validate-schema.js BRIEF_VALID_SOURCES) keeps the historical value.
+var CONTENT_BEARING_STATUSES = new Set(["approved", "draft", "synthesized"]);
+
 function transcribeContentGuidelines(guidelinesJson) {
   if (!guidelinesJson || !guidelinesJson.domains) return null;
   var content = guidelinesJson.domains.content;
   if (!content) return null;
-  if (content.status !== "approved" && content.status !== "draft") return null;
+  if (!CONTENT_BEARING_STATUSES.has(content.status)) return null;
   var sections = content.sections;
   if (!Array.isArray(sections) || sections.length === 0) return null;
   return { source: "figma", content: { sections: sections } };
@@ -123,18 +131,20 @@ var CATEGORY_DEFAULTS_PHASE_B_CARDS = {
 
 // A guideline is a "stub" — no curated content to transcribe — when there is
 // no doc at all (ctx.guidelinesJson null, a component with no entry in
-// components/dist/guidelines/) or the doc's `content` domain is not
-// approved/draft (inherited / not-started). Replaces the `_stub` boolean from
-// the retired Figma-scraped guideline layer. Used by the component-brief skill
-// to set `meta._stubGuideline` (drives the "Guidance pending curation" footer
-// cue). Note: resolveSection's all-cards-to-Phase-B short-circuit fires only
-// for the *present-but-stub* case — see the guard there for why a fully absent
-// doc is handled per-card instead.
+// components/dist/guidelines/) or the doc's `content` domain is not in one
+// of the content-bearing statuses (approved/draft/synthesized — synthesized
+// added in knowledge v0.15.0 for pattern-fan-out-only components). Replaces
+// the `_stub` boolean from the retired Figma-scraped guideline layer. Used
+// by the component-brief skill to set `meta._stubGuideline` (drives the
+// "Guidance pending curation" footer cue). Note: resolveSection's
+// all-cards-to-Phase-B short-circuit fires only for the *present-but-stub*
+// case — see the guard there for why a fully absent doc is handled per-card
+// instead.
 function isStubGuideline(guidelinesJson) {
   if (!guidelinesJson || !guidelinesJson.domains) return true;
   var content = guidelinesJson.domains.content;
   if (!content) return true;
-  return content.status !== "approved" && content.status !== "draft";
+  return !CONTENT_BEARING_STATUSES.has(content.status);
 }
 
 // ---------------------------------------------------------------------------
@@ -195,8 +205,9 @@ function resolveSection(cardKey, ctx, recipe) {
   } else if (cardKey === "card_content") {
     primary = transcribeContentGuidelines(ctx && ctx.guidelinesJson);
     fallbackReason =
-      "content domain not approved/draft in the component guideline doc — " +
-      "author components/src/<slug>/content.md in the knowledge repo";
+      "content domain has no content-bearing status in the component guideline doc — " +
+      "author components/src/<slug>/content.md in the knowledge repo " +
+      "(or add the slug to a pattern's relatedComponents frontmatter)";
   } else if (cardKey === "card_motion") {
     var motionResult = transcribeMotionPattern(
       ctx && ctx.guidelinesJson,

--- a/plugins/actian-design-system/tests/transformers/brief-sourcing.test.js
+++ b/plugins/actian-design-system/tests/transformers/brief-sourcing.test.js
@@ -19,6 +19,15 @@ function guidelineDoc(contentStatus, sections) {
     content.owner = "content-team";
     content.markdown = "# Stub markdown";
     content.sections = sections || [];
+  } else if (contentStatus === "synthesized") {
+    // Pattern fan-out (knowledge v0.15.0+) emits sections with
+    // section.source markers, no markdown, no owner.
+    content.sections = (sections || []).map(function (s) {
+      var out = { heading: s.heading, content: s.content };
+      out.source = s.source || "pattern:test";
+      if (s.subsections) out.subsections = s.subsections;
+      return out;
+    });
   }
   return {
     _schema_version: 1,
@@ -78,7 +87,7 @@ test("transcribeContentGuidelines — returns sections + figma source when conte
   assert.equal(result.content.sections.length, 2);
 });
 
-test("transcribeContentGuidelines — returns null when content domain is not approved/draft", function () {
+test("transcribeContentGuidelines — returns null when content domain has no content-bearing status", function () {
   // The "empty" fixture is a present doc whose content domain is not-started.
   var guidelines = loadFixture("button-component-guidelines-empty.json");
   assert.equal(sourcing.transcribeContentGuidelines(guidelines), null);
@@ -87,6 +96,40 @@ test("transcribeContentGuidelines — returns null when content domain is not ap
     sourcing.transcribeContentGuidelines(guidelineDoc("inherited")),
     null,
   );
+});
+
+test("transcribeContentGuidelines — returns sections when status is 'synthesized' (knowledge v0.15.0+ pattern fan-out)", function () {
+  // Pattern fan-out into a component with no per-component content.md
+  // produces a guideline doc with status=synthesized + sections carrying
+  // section.source markers. Brief-sourcing must surface those sections
+  // alongside approved/draft.
+  var guidelines = guidelineDoc("synthesized", [
+    {
+      heading: "Empty state",
+      source: "pattern:empty-and-system-states",
+      content: [{ prose: "Empty states explain what to do next." }],
+    },
+  ]);
+  var result = sourcing.transcribeContentGuidelines(guidelines);
+  assert.equal(result.source, "figma");
+  assert.equal(result.content.sections.length, 1);
+  assert.equal(
+    result.content.sections[0].source,
+    "pattern:empty-and-system-states",
+  );
+});
+
+test("isStubGuideline — treats 'synthesized' status as NON-stub", function () {
+  // Pattern fan-out content should drive the full transcribe flow, not the
+  // "Guidance pending curation" footer.
+  var doc = guidelineDoc("synthesized", [
+    {
+      heading: "X",
+      source: "pattern:y",
+      content: [{ prose: "z" }],
+    },
+  ]);
+  assert.equal(sourcing.isStubGuideline(doc), false);
 });
 
 test("transcribeContentGuidelines — returns null when domains / sections missing or empty", function () {


### PR DESCRIPTION
## Summary

Phase A consumer-coordination change for **volivarii/actian-ds-knowledge#83** (pattern fan-out to per-component guidelines).

Knowledge v0.15.0 introduces a new status `synthesized` for components whose `domains.content` is sourced entirely from pattern fan-out (no per-component `content.md`). Without this gate change, brief-sourcing would treat those components as stubs and skip the pattern content.

## Change

Two one-line gate updates in `scripts/transformers/brief-sourcing.js`:

- `transcribeContentGuidelines()` — extracts sections when status is `approved | draft | synthesized` (was: `approved | draft`)
- `isStubGuideline()` — treats `synthesized` as non-stub (so the *Guidance pending curation* footer doesn't fire when pattern-only content is present)

Both go through a shared `CONTENT_BEARING_STATUSES` Set so future status additions land in one place.

## Backward compatibility

This PR is a **no-op against current knowledge data**. No `synthesized` records exist until a pattern's frontmatter is edited to add `relatedComponents:` / `relatedCategories:`. Plugin can ship before, after, or alongside the knowledge PR per parallel-change rule (`feedback_migration_discipline`).

## Test plan

- [x] `npm test` — 855/855 pass locally
- [x] +2 brief-sourcing tests covering the synthesized status path
- [x] Extended `guidelineDoc()` test helper to construct synthesized doc shapes

## Related

- Knowledge PR: https://github.com/volivarii/actian-ds-knowledge/pull/83
- Docs PR: (next) — mirror change in `actian-ds-docs` `generate-component-pages.cjs`
- Spec: `plugins/actian-design-system/docs/superpowers/specs/2026-05-18-pattern-fanout-to-components-design.md` (untracked per `feedback_no_commit_specs`)

## Version

MINOR bump `v1.85.4 → v1.86.0` (additive behavior).