### PR TITLE
chore(figma-use): bump cited version to v2.2.3

### DIFF
--- a/plugins/actian-design-system/.claude-plugin/plugin.json
+++ b/plugins/actian-design-system/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "actian-design-system",
   "description": "Actian Design System toolkit — generate wireframe flows with prototype wiring, create component briefs, audit designs, compare flows, and build presentations. 8 skills (with tiered generation: recognized / adapted / improvised), 8 agents, 155 tokens (3 themes, 8 collections), WCAG 2.1 AA. DS knowledge vendored from volivarii/actian-ds-knowledge.",
-  "version": "1.86.1",
+  "version": "1.86.2",
   "author": {
     "name": "Actian UX Team"
   },

--- a/plugins/actian-design-system/references/figma/figma-push-patterns.md
+++ b/plugins/actian-design-system/references/figma/figma-push-patterns.md
@@ -42,7 +42,7 @@ Each registry entry contains: `key`, `importMethod` ("set" for `importComponentS
 
 ## Critical Rules
 
-These rules come from `figma-use` SKILL.md (current version, 2026-04-28).
+These rules come from `figma-use` SKILL.md (v2.2.3, 2026-05-15).
 Skipping any of them produces hard-to-debug failures. The rules in `## 2.
 Core Patterns` above (skillNames mandatory-load, never-reparent, return
 all node IDs) are also Critical Rules and remain in their current position
@@ -146,7 +146,7 @@ Loading them one at a time is wasteful and fragments the agent's context
 window. Load all at the start of the work; each schema costs ~1-2K tokens
 once.
 
-(Source: figma-use/SKILL.md v2.1.30)
+(Source: figma-use/SKILL.md v2.2.3)
 
 ### Working with Design Systems — start at `wwds.md`
 


### PR DESCRIPTION
## Summary

Vendor-refresh of the upstream `figma-use` SKILL.md citations from v2.1.30 (2026-04-28) → v2.2.3 (2026-05-15). Docs-only chore; no behavioral changes.

- `references/figma/figma-push-patterns.md` — bump the two version pins
- `.claude-plugin/plugin.json` — PATCH bump 1.86.0 → 1.86.1

## Smoke check

All cited rule numbers and section anchors are stable across the bump:

- Rules 3a, 8, 13, 14, 16, 17 — same positions in v2.2.3 ✓
- Section 4 (Editor Mode) — same name + content ✓
- Section 5 (Efficient APIs — `createAutoLayout`, `node.set`) — same anchors ✓

The four \`figma-use v2.1.26\` historical citations in \`references/component-brief/push-patterns.md\` are intentionally left as-is — they document *when* Rule 8 expanded, not the current upstream version.

## Deferred to Sprint Alpha

The bigger v2.1.56→v2.2.3 deltas need a deliberate doc rewrite and belong with the perf sprint's renumbering pass:

- \`skillNames\` reframe — upstream now says \"logging parameter ... does not affect execution\", contradicting our \"load-bearing\" framing
- Adopt new Section 5 APIs: \`node.placeholder\` (shimmer) + \`await node.screenshot(opts?)\` (inline screenshots)
- Rule 8 v2.2.3 additions: \`getStyledTextSegments(['fontName'])\` for current-font discovery + \`listAvailableFontsAsync()\` callout
- Section 9 (Discover Conventions Before Creating) — new in v2.x
- Slides editor mode + \`figma-use-slides\` skill reference

## Test plan

- [ ] CI green
- [ ] Spot-check rendered docs (no broken anchors)