### PR TITLE
feat(perf): Sprint Alpha — createAutoLayout + Set-based font dedup + node.screenshot adoption

### DIFF
--- a/plugins/actian-design-system/.claude-plugin/plugin.json
+++ b/plugins/actian-design-system/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "actian-design-system",
   "description": "Actian Design System toolkit — generate wireframe flows with prototype wiring, create component briefs, audit designs, compare flows, and build presentations. 8 skills (with tiered generation: recognized / adapted / improvised), 8 agents, 155 tokens (3 themes, 8 collections), WCAG 2.1 AA. DS knowledge vendored from volivarii/actian-ds-knowledge.",
-  "version": "1.86.2",
+  "version": "1.87.0",
   "author": {
     "name": "Actian UX Team"
   },

--- a/plugins/actian-design-system/evals/component-brief/grader.md
+++ b/plugins/actian-design-system/evals/component-brief/grader.md
@@ -98,9 +98,11 @@ The interpreter produces diagnostic frame names that no inlined
 construction would emit:
 
 - `"Table (renderTable)"` — exactly one per table render (top-level
-  table frame, see `scripts/renderers/figma-table/render-figma.js:434`).
-- `"Token: --zen-…"` — one per token-pill cell (see
-  `scripts/renderers/figma-table/render-figma.js:651`).
+  table frame, emitted by the `emit` function's outer `createAutoLayout`
+  call in `scripts/renderers/figma-table/render-figma.js`).
+- `"Token: --zen-…"` — one per token-pill cell (emitted by
+  `emitTokenPillCell` in
+  `scripts/renderers/figma-table/render-figma.js`).
 
 These literal strings are pinned by
 `tests/renderers/diagnostic-names.test.js`. Drift in the interpreter

--- a/plugins/actian-design-system/references/component-brief/push-patterns.md
+++ b/plugins/actian-design-system/references/component-brief/push-patterns.md
@@ -243,8 +243,12 @@ Section 1 is ONE card with four nested sub-frames inside, not three separate car
 // Inputs from data: briefData.card_component, .card_anatomy, .card_tokens
 // Use cardTitle "Anatomy, variation, tokens & specs" (default in renderer; recipe-overridable).
 
-await figma.loadFontAsync({ family: "Inter", style: "Regular" });
-await figma.loadFontAsync({ family: "Inter", style: "Semibold" });
+// v1.87.0: Promise.all parallelizes the font fetches — one round-trip vs N sequential.
+// "Semi Bold" with a space — Inter's registered style name (figma-use gotchas).
+await Promise.all([
+  { family: "Inter", style: "Regular" },
+  { family: "Inter", style: "Semi Bold" },
+].map(fn => figma.loadFontAsync(fn)));
 
 const slot = await figma.getNodeByIdAsync("<contentSlotId>");
 
@@ -259,7 +263,7 @@ async function appendSubFrame(label, sourceCard) {
 
   // Heading row — label + optional Draft badge
   const heading = figma.createText();
-  heading.fontName = { family: "Inter", style: "Semibold" };
+  heading.fontName = { family: "Inter", style: "Semi Bold" };
   heading.fontSize = 16;
   heading.characters = label;
 
@@ -278,7 +282,7 @@ async function appendSubFrame(label, sourceCard) {
     headerRow.name = "Heading + DRAFT tag";
     headerRow.appendChild(heading);
     const tag = figma.createText();
-    tag.fontName = { family: "Inter", style: "Semibold" };
+    tag.fontName = { family: "Inter", style: "Semi Bold" };
     tag.fontSize = 10;
     tag.characters = "DRAFT";
     tag.fills = [{ type: "SOLID", color: { r: 0.44, g: 0.49, b: 0.59 } }];
@@ -380,9 +384,12 @@ function hexToRgb(hex) {
   return { r: parseInt(h.substring(0,2),16)/255, g: parseInt(h.substring(2,4),16)/255, b: parseInt(h.substring(4,6),16)/255 };
 }
 
-await figma.loadFontAsync({ family: "Inter", style: "Regular" });
-await figma.loadFontAsync({ family: "Inter", style: "Semi Bold" });
-await figma.loadFontAsync({ family: "Fira Code", style: "Regular" });
+// v1.87.0: Promise.all parallelizes the font fetches — one round-trip vs N sequential
+await Promise.all([
+  { family: "Inter", style: "Regular" },
+  { family: "Inter", style: "Semi Bold" },
+  { family: "Fira Code", style: "Regular" },
+].map(fn => figma.loadFontAsync(fn)));
 
 const parent = await figma.getNodeByIdAsync("<contentSlotId>");
 
@@ -567,8 +574,12 @@ return { createdNodeIds: [pair.id], mutatedNodeIds: ["<contentSlotId>"] };
 **Layout (v1.66.3+):** Requirements render as a **simple vertical bulleted list** — bold title + plain body, one per row. The previous 2×3 a11y-card grid is retired (visual noise without proportional information density). This matches the simplified HTML renderer (Brief Refresh v2 Phase 1).
 
 ```js
-await figma.loadFontAsync({ family: "Inter", style: "Regular" });
-await figma.loadFontAsync({ family: "Inter", style: "Semibold" });
+// v1.87.0: Promise.all parallelizes the font fetches — one round-trip vs N sequential
+// "Semi Bold" with a space — Inter's registered style name (figma-use gotchas).
+await Promise.all([
+  { family: "Inter", style: "Regular" },
+  { family: "Inter", style: "Semi Bold" },
+].map(fn => figma.loadFontAsync(fn)));
 
 function hexToRgb(hex) {
   const h = hex.replace("#", "");
@@ -602,7 +613,7 @@ for (const req of requirements) {
   const sep = " — ";
   t.characters = req.title + sep + req.body;
   // Bold + darker color for the title portion only.
-  t.setRangeFontName(0, req.title.length, { family: "Inter", style: "Semibold" });
+  t.setRangeFontName(0, req.title.length, { family: "Inter", style: "Semi Bold" });
   t.setRangeFills(0, req.title.length, [{ type: "SOLID", color: hexToRgb("#101828") }]);
   list.appendChild(t);
   t.layoutSizingHorizontal = "FILL";
@@ -705,11 +716,16 @@ if (colorCol) {
 > The CALLER of `appendVariationCell` MUST preload the instance's fonts before passing it
 > to this function. Use the pattern:
 > ```js
-> const _fonts = instance.findAll(n => n.type === "TEXT")
->   .map(t => t.fontName)
->   .filter((fn, i, arr) =>
-    fn && typeof fn === 'object' &&
-    arr.findIndex(x => JSON.stringify(x) === JSON.stringify(fn)) === i);
+> // v1.87.0: O(n) Set-based dedup; see figma-push-patterns.md Rule 8 canonical template
+> const _seen = new Set();
+> const _fonts = [];
+> instance.findAll(n => n.type === "TEXT").forEach(t => {
+>   const fn = t.fontName;
+>   if (!fn || typeof fn !== 'object') return;
+>   const key = fn.family + '|' + fn.style;
+>   if (_seen.has(key)) return;
+>   _seen.add(key); _fonts.push(fn);
+> });
 > await Promise.all(_fonts.map(fn => figma.loadFontAsync(fn)));
 > await appendVariationCell(parentRow, instance);
 > ```
@@ -784,11 +800,16 @@ const inst = variantComp.createInstance();
 // may be unloaded. Collect unique fontNames from the instance subtree and load them
 // all before appending. Without this, Figma silently fails on text operations inside
 // the instance (intermittent failures on supercards with pre-existing instances).
-const _instFonts = inst.findAll(n => n.type === "TEXT")
-  .map(t => t.fontName)
-  .filter((fn, i, arr) =>
-    fn && typeof fn === 'object' &&
-    arr.findIndex(x => JSON.stringify(x) === JSON.stringify(fn)) === i);
+// v1.87.0: O(n) Set-based dedup (was O(n²) JSON.stringify) — see figma-push-patterns.md Rule 8.
+const _seenP9 = new Set();
+const _instFonts = [];
+inst.findAll(n => n.type === "TEXT").forEach(t => {
+  const fn = t.fontName;
+  if (!fn || typeof fn !== 'object') return;
+  const key = fn.family + '|' + fn.style;
+  if (_seenP9.has(key)) return;
+  _seenP9.add(key); _instFonts.push(fn);
+});
 await Promise.all(_instFonts.map(fn => figma.loadFontAsync(fn)));
 
 container.appendChild(inst);
@@ -1090,8 +1111,11 @@ const researchFrame = figma.createAutoLayout('VERTICAL', {
 });
 researchFrame.name = "ResearchInsights";
 
-await figma.loadFontAsync({ family: "Inter", style: "Semi Bold" });
-await figma.loadFontAsync({ family: "Inter", style: "Regular" });
+// v1.87.0: Promise.all parallelizes the font fetches
+await Promise.all([
+  { family: "Inter", style: "Semi Bold" },
+  { family: "Inter", style: "Regular" },
+].map(fn => figma.loadFontAsync(fn)));
 
 const title = figma.createText();
 title.characters = "Cross-DS research";
@@ -1113,8 +1137,11 @@ function hexToRgb(hex) {
   const h = hex.replace("#", "");
   return { r: parseInt(h.substring(0,2),16)/255, g: parseInt(h.substring(2,4),16)/255, b: parseInt(h.substring(4,6),16)/255 };
 }
-await figma.loadFontAsync({ family: "Inter", style: "Semi Bold" });
-await figma.loadFontAsync({ family: "Inter", style: "Regular" });
+// v1.87.0: Promise.all parallelizes the font fetches
+await Promise.all([
+  { family: "Inter", style: "Semi Bold" },
+  { family: "Inter", style: "Regular" },
+].map(fn => figma.loadFontAsync(fn)));
 
 const insights = card.research_insights; // from brief-data.json
 const researchFrame = await figma.getNodeByIdAsync("<researchFrameId>");
@@ -1163,8 +1190,11 @@ return { createdNodeIds: createdSubIds, mutatedNodeIds: ["<researchFrameId>"] };
 
 ```js
 // 3. Divergences frame (only if non-empty) + Sources line
-await figma.loadFontAsync({ family: "Inter", style: "Semi Bold" });
-await figma.loadFontAsync({ family: "Inter", style: "Regular" });
+// v1.87.0: Promise.all parallelizes the font fetches
+await Promise.all([
+  { family: "Inter", style: "Semi Bold" },
+  { family: "Inter", style: "Regular" },
+].map(fn => figma.loadFontAsync(fn)));
 
 const insights = card.research_insights;
 const researchFrame = await figma.getNodeByIdAsync("<researchFrameId>");
@@ -1445,11 +1475,16 @@ const inst = variantComp.createInstance();
 // Rule 8 (figma-use v2.1.26): font preload before appendChild on component instance.
 // The instance carries the target component's fonts which may be unloaded.
 // Collect unique fontNames from inst subtree and preload before appending.
-const _instFonts14 = inst.findAll(n => n.type === "TEXT")
-  .map(t => t.fontName)
-  .filter((fn, i, arr) =>
-    fn && typeof fn === 'object' &&
-    arr.findIndex(x => JSON.stringify(x) === JSON.stringify(fn)) === i);
+// v1.87.0: O(n) Set-based dedup (was O(n²) JSON.stringify) — see figma-push-patterns.md Rule 8.
+const _seenP14 = new Set();
+const _instFonts14 = [];
+inst.findAll(n => n.type === "TEXT").forEach(t => {
+  const fn = t.fontName;
+  if (!fn || typeof fn !== 'object') return;
+  const key = fn.family + '|' + fn.style;
+  if (_seenP14.has(key)) return;
+  _seenP14.add(key); _instFonts14.push(fn);
+});
 await Promise.all(_instFonts14.map(fn => figma.loadFontAsync(fn)));
 
 container.appendChild(inst);

--- a/plugins/actian-design-system/references/figma/figma-push-patterns.md
+++ b/plugins/actian-design-system/references/figma/figma-push-patterns.md
@@ -62,12 +62,19 @@ for prominence; the rules below are the rest of the canonical set.
 > carry unloaded fonts. Reference fix shape:
 >
 > ```js
-> const fonts = subtree.findAll(n => n.type === 'TEXT')
->   .map(t => t.fontName)
->   .filter((fn, i, arr) =>
->     fn && typeof fn === 'object' &&
->     arr.findIndex(x => JSON.stringify(x) === JSON.stringify(fn)) === i
->   );
+> // v1.87.0: Set-based dedup keyed by family|style — O(n) vs the prior
+> // O(n²) JSON.stringify filter. Same correctness (figma.mixed excluded
+> // by the typeof guard), much cheaper on large text-bearing subtrees.
+> const seen = new Set();
+> const fonts = [];
+> subtree.findAll(n => n.type === 'TEXT').forEach(t => {
+>   const fn = t.fontName;
+>   if (!fn || typeof fn !== 'object') return;  // excludes figma.mixed
+>   const key = fn.family + '|' + fn.style;
+>   if (seen.has(key)) return;
+>   seen.add(key);
+>   fonts.push(fn);
+> });
 > await Promise.all(fonts.map(fn => figma.loadFontAsync(fn)));
 > parent.appendChild(subtree);
 > ```

--- a/plugins/actian-design-system/references/figma/parity-check.md
+++ b/plugins/actian-design-system/references/figma/parity-check.md
@@ -8,7 +8,15 @@ Immediately after all `use_figma` calls complete, before presenting results to t
 
 ### 1. Screenshot each pushed element
 
-Call `get_screenshot` on every node ID that was created or modified during the push. Capture each screenshot individually so it can be compared against the HTML source.
+**Preferred (v1.87.0+): inline screenshot from the same `use_figma` call that created/modified the node.** Per `figma-use` SKILL.md v2.2.3 Section 5, `await node.screenshot()` returns the PNG inline in the tool response — eliminating the separate `get_screenshot` MCP round-trip per node. Confirmed via Spike 1 (2026-05-18): payload is delivered out-of-band as `output_image`, does not count against the 50K code budget or the structured return.
+
+```js
+// At the end of any push call that creates/mutates a card-sized node:
+await node.screenshot();  // agent sees image inline in the tool response
+return { createdNodeIds: [...], mutatedNodeIds: [...] };
+```
+
+**Fallback (still required for prior sessions or out-of-band review):** when there is no live `use_figma` context for the node (e.g., the push completed in a prior session), call `get_screenshot` per node:
 
 ```
 get_screenshot({ fileKey: "<figma-file-key>", nodeId: "<node-id>" })

--- a/plugins/actian-design-system/scripts/renderers/figma-table/render-figma.js
+++ b/plugins/actian-design-system/scripts/renderers/figma-table/render-figma.js
@@ -392,6 +392,33 @@ function jsString(s) {
   return JSON.stringify(s);
 }
 
+// Emits a `figma.createAutoLayout(direction, { ...props })` call as one line.
+// Per figma-use SKILL.md v2.2.3 Section 5: createAutoLayout sets layoutMode +
+// HUG sizing on both axes by default, collapsing 5-7 lines of manual setup.
+// `propPairs` is an array of [key, jsCodeString] tuples — values are emitted
+// as JS expressions verbatim, so callers control quoting (e.g. fills carrying
+// hexLit() calls embed raw JS, not JSON).
+function emitAutoLayout(varName, direction, propPairs) {
+  var propsStr =
+    propPairs && propPairs.length
+      ? ", { " +
+        propPairs
+          .map(function (p) {
+            return p[0] + ": " + p[1];
+          })
+          .join(", ") +
+        " }"
+      : "";
+  return (
+    "var " +
+    varName +
+    " = figma.createAutoLayout(" +
+    jsString(direction) +
+    propsStr +
+    ");"
+  );
+}
+
 function emit(spec, parentIdPlaceholder) {
   var parentId = parentIdPlaceholder || "<contentSlotId>";
   var lines = [];
@@ -405,19 +432,21 @@ function emit(spec, parentIdPlaceholder) {
   lines.push(
     "// renderTable — deterministic emit (schema " + spec.schemaVersion + ")",
   );
+  // Promise.all the font loads — parallel network/disk transit beats sequential
+  // awaits at ~5 sites per table (Inter Regular/Medium/Semi Bold + optional Fira Code).
+  var fontLines = [
+    '{ family: "Inter", style: "Regular" }',
+    '{ family: "Inter", style: "Medium" }',
+    '{ family: "Inter", style: "Semi Bold" }',
+  ];
+  if (spec.rows.some(rowHasCellType(spec, "code"))) {
+    fontLines.push('{ family: "Fira Code", style: "Regular" }');
+  }
   lines.push(
-    'await figma.loadFontAsync({ family: "Inter", style: "Regular" });',
+    "await Promise.all([" +
+      fontLines.join(", ") +
+      "].map(function (fn) { return figma.loadFontAsync(fn); }));",
   );
-  lines.push(
-    'await figma.loadFontAsync({ family: "Inter", style: "Medium" });',
-  );
-  lines.push(
-    'await figma.loadFontAsync({ family: "Inter", style: "Semi Bold" });',
-  );
-  if (spec.rows.some(rowHasCellType(spec, "code")))
-    lines.push(
-      'await figma.loadFontAsync({ family: "Fira Code", style: "Regular" });',
-    );
   lines.push("");
   lines.push("function hexToRgb(hex) {");
   lines.push('  var h = hex.replace("#", "");');
@@ -429,14 +458,14 @@ function emit(spec, parentIdPlaceholder) {
   lines.push('var parent = await figma.getNodeByIdAsync("' + parentId + '");');
   lines.push("");
 
-  // Outer table frame
-  lines.push("var table = figma.createFrame();");
-  lines.push('table.name = "Table (renderTable)";');
-  lines.push('table.layoutMode = "VERTICAL";');
-  lines.push("table.itemSpacing = 0;");
-  lines.push('table.primaryAxisSizingMode = "AUTO";');
-  lines.push('table.counterAxisSizingMode = "AUTO";');
-  lines.push("table.fills = [];");
+  // Outer table frame — createAutoLayout sets layoutMode + HUG on both axes by default
+  lines.push(
+    emitAutoLayout("table", "VERTICAL", [
+      ["name", jsString("Table (renderTable)")],
+      ["itemSpacing", "0"],
+      ["fills", "[]"],
+    ]),
+  );
   lines.push("parent.appendChild(table);");
   lines.push('table.layoutSizingHorizontal = "FILL";');
   lines.push("");
@@ -501,23 +530,21 @@ function rowHasCellType(spec, type) {
 
 function emitRow(lines, varSuffix, headerStrings, isHeader, alignments) {
   var v = "row_" + varSuffix;
-  lines.push("var " + v + " = figma.createFrame();");
-  lines.push(v + '.name = "Header Row";');
-  lines.push(v + '.layoutMode = "HORIZONTAL";');
-  lines.push(v + ".itemSpacing = 0;");
   lines.push(
-    v +
-      '.fills = [{ type: "SOLID", color: ' +
-      hexLit(STYLE.HEADER_FILL) +
-      " }];",
+    emitAutoLayout(v, "HORIZONTAL", [
+      ["name", jsString("Header Row")],
+      ["itemSpacing", "0"],
+      [
+        "fills",
+        '[{ type: "SOLID", color: ' + hexLit(STYLE.HEADER_FILL) + " }]",
+      ],
+      ["paddingTop", "8"],
+      ["paddingBottom", "8"],
+      ["paddingLeft", "12"],
+      ["paddingRight", "12"],
+      ["counterAxisAlignItems", jsString("CENTER")],
+    ]),
   );
-  lines.push(v + ".paddingTop = 8;");
-  lines.push(v + ".paddingBottom = 8;");
-  lines.push(v + ".paddingLeft = 12;");
-  lines.push(v + ".paddingRight = 12;");
-  lines.push(v + '.primaryAxisSizingMode = "AUTO";');
-  lines.push(v + '.counterAxisSizingMode = "AUTO";');
-  lines.push(v + '.counterAxisAlignItems = "CENTER";');
   lines.push("table.appendChild(" + v + ");");
   lines.push(v + '.layoutSizingHorizontal = "FILL";');
 
@@ -552,19 +579,21 @@ function emitRow(lines, varSuffix, headerStrings, isHeader, alignments) {
 
 function emitDataRow(lines, varSuffix, row, alignments, stats) {
   var v = "row_" + varSuffix;
-  lines.push("var " + v + " = figma.createFrame();");
-  lines.push(v + '.name = "Data Row";');
-  lines.push(v + '.layoutMode = "HORIZONTAL";');
-  lines.push(v + ".itemSpacing = 0;");
-  lines.push(v + ".fills = [];");
-  lines.push(v + ".paddingTop = 8;");
-  lines.push(v + ".paddingBottom = 8;");
-  lines.push(v + ".paddingLeft = 12;");
-  lines.push(v + ".paddingRight = 12;");
-  // CRITICAL — the load-bearing fix from v1.70.4 audit. parent row HUGs its tallest child.
-  lines.push(v + '.primaryAxisSizingMode = "AUTO";');
-  lines.push(v + '.counterAxisSizingMode = "AUTO";');
-  lines.push(v + '.counterAxisAlignItems = "CENTER";');
+  // CRITICAL — the load-bearing fix from v1.70.4 audit: parent row HUGs its tallest child.
+  // createAutoLayout's default AUTO/AUTO sizing preserves this; FILL on the horizontal
+  // axis is set AFTER appendChild per figma-use Critical Rule 12.
+  lines.push(
+    emitAutoLayout(v, "HORIZONTAL", [
+      ["name", jsString("Data Row")],
+      ["itemSpacing", "0"],
+      ["fills", "[]"],
+      ["paddingTop", "8"],
+      ["paddingBottom", "8"],
+      ["paddingLeft", "12"],
+      ["paddingRight", "12"],
+      ["counterAxisAlignItems", jsString("CENTER")],
+    ]),
+  );
   lines.push("table.appendChild(" + v + ");");
   lines.push(v + '.layoutSizingHorizontal = "FILL";');
 
@@ -602,12 +631,12 @@ function emitTextCell(lines, cellVar, parentVar, cell, alignment) {
   // Wrap text in a frame with FILL horizontal so column widths distribute evenly,
   // and HUG vertical so the row grows to fit multi-line content.
   var wrap = cellVar + "_w";
-  lines.push("var " + wrap + " = figma.createFrame();");
-  lines.push(wrap + '.name = "Cell — text";');
-  lines.push(wrap + ".fills = [];");
-  lines.push(wrap + '.layoutMode = "VERTICAL";');
-  lines.push(wrap + '.primaryAxisSizingMode = "AUTO";');
-  lines.push(wrap + '.counterAxisSizingMode = "AUTO";');
+  lines.push(
+    emitAutoLayout(wrap, "VERTICAL", [
+      ["name", jsString("Cell — text")],
+      ["fills", "[]"],
+    ]),
+  );
   lines.push(parentVar + ".appendChild(" + wrap + ");");
   lines.push(wrap + '.layoutSizingHorizontal = "FILL";');
 
@@ -643,31 +672,29 @@ function emitTextCell(lines, cellVar, parentVar, cell, alignment) {
 function emitTokenPillCell(lines, cellVar, parentVar, cell) {
   // Wrap so the column width distributes; pill HUGs its content inside the wrap.
   var wrap = cellVar + "_w";
-  lines.push("var " + wrap + " = figma.createFrame();");
-  lines.push(wrap + '.name = "Cell — token-pill";');
-  lines.push(wrap + ".fills = [];");
-  lines.push(wrap + '.layoutMode = "HORIZONTAL";');
-  lines.push(wrap + '.primaryAxisSizingMode = "AUTO";');
-  lines.push(wrap + '.counterAxisSizingMode = "AUTO";');
+  lines.push(
+    emitAutoLayout(wrap, "HORIZONTAL", [
+      ["name", jsString("Cell — token-pill")],
+      ["fills", "[]"],
+    ]),
+  );
   lines.push(parentVar + ".appendChild(" + wrap + ");");
   lines.push(wrap + '.layoutSizingHorizontal = "FILL";');
 
   var pillVar = cellVar + "_p";
-  lines.push("var " + pillVar + " = figma.createFrame();");
-  lines.push(pillVar + '.name = "Token: " + ' + jsString(cell.value) + ";");
-  lines.push(pillVar + '.layoutMode = "HORIZONTAL";');
-  lines.push(pillVar + '.primaryAxisSizingMode = "AUTO";');
-  lines.push(pillVar + '.counterAxisSizingMode = "AUTO";');
-  lines.push(pillVar + ".paddingLeft = 5;");
-  lines.push(pillVar + ".paddingRight = 5;");
-  lines.push(pillVar + ".paddingTop = 2;");
-  lines.push(pillVar + ".paddingBottom = 2;");
-  lines.push(pillVar + ".cornerRadius = 3;");
   lines.push(
-    pillVar +
-      '.fills = [{ type: "SOLID", color: ' +
-      hexLit(STYLE.TOKEN_PILL_BG) +
-      " }];",
+    emitAutoLayout(pillVar, "HORIZONTAL", [
+      ["name", '"Token: " + ' + jsString(cell.value)],
+      ["paddingLeft", "5"],
+      ["paddingRight", "5"],
+      ["paddingTop", "2"],
+      ["paddingBottom", "2"],
+      ["cornerRadius", "3"],
+      [
+        "fills",
+        '[{ type: "SOLID", color: ' + hexLit(STYLE.TOKEN_PILL_BG) + " }]",
+      ],
+    ]),
   );
   lines.push("var " + cellVar + " = figma.createText();");
   lines.push(cellVar + '.fontName = { family: "Inter", style: "Medium" };');
@@ -685,22 +712,17 @@ function emitTokenPillCell(lines, cellVar, parentVar, cell) {
 
 function emitCodeCell(lines, cellVar, parentVar, cell) {
   var wrap = cellVar + "_w";
-  lines.push("var " + wrap + " = figma.createFrame();");
-  lines.push(wrap + '.name = "Cell — code";');
   lines.push(
-    wrap +
-      '.fills = [{ type: "SOLID", color: ' +
-      hexLit(STYLE.CODE_BG) +
-      " }];",
+    emitAutoLayout(wrap, "HORIZONTAL", [
+      ["name", jsString("Cell — code")],
+      ["fills", '[{ type: "SOLID", color: ' + hexLit(STYLE.CODE_BG) + " }]"],
+      ["paddingLeft", "6"],
+      ["paddingRight", "6"],
+      ["paddingTop", "2"],
+      ["paddingBottom", "2"],
+      ["cornerRadius", "3"],
+    ]),
   );
-  lines.push(wrap + '.layoutMode = "HORIZONTAL";');
-  lines.push(wrap + ".paddingLeft = 6;");
-  lines.push(wrap + ".paddingRight = 6;");
-  lines.push(wrap + ".paddingTop = 2;");
-  lines.push(wrap + ".paddingBottom = 2;");
-  lines.push(wrap + ".cornerRadius = 3;");
-  lines.push(wrap + '.primaryAxisSizingMode = "AUTO";');
-  lines.push(wrap + '.counterAxisSizingMode = "AUTO";');
   lines.push(parentVar + ".appendChild(" + wrap + ");");
   lines.push(wrap + '.layoutSizingHorizontal = "FILL";');
 
@@ -727,27 +749,26 @@ function emitBadgeCell(lines, cellVar, parentVar, cell) {
   var label = cell.label || cell.variant.toUpperCase();
 
   var wrap = cellVar + "_w";
-  lines.push("var " + wrap + " = figma.createFrame();");
-  lines.push(wrap + '.name = "Cell — badge";');
-  lines.push(wrap + ".fills = [];");
-  lines.push(wrap + '.layoutMode = "HORIZONTAL";');
-  lines.push(wrap + '.primaryAxisSizingMode = "AUTO";');
-  lines.push(wrap + '.counterAxisSizingMode = "AUTO";');
+  lines.push(
+    emitAutoLayout(wrap, "HORIZONTAL", [
+      ["name", jsString("Cell — badge")],
+      ["fills", "[]"],
+    ]),
+  );
   lines.push(parentVar + ".appendChild(" + wrap + ");");
   lines.push(wrap + '.layoutSizingHorizontal = "FILL";');
 
   var badgeVar = cellVar + "_b";
-  lines.push("var " + badgeVar + " = figma.createFrame();");
-  lines.push(badgeVar + '.layoutMode = "HORIZONTAL";');
-  lines.push(badgeVar + '.primaryAxisSizingMode = "AUTO";');
-  lines.push(badgeVar + '.counterAxisSizingMode = "AUTO";');
-  lines.push(badgeVar + ".paddingLeft = 6;");
-  lines.push(badgeVar + ".paddingRight = 6;");
-  lines.push(badgeVar + ".paddingTop = 2;");
-  lines.push(badgeVar + ".paddingBottom = 2;");
-  lines.push(badgeVar + ".cornerRadius = 3;");
   lines.push(
-    badgeVar + '.fills = [{ type: "SOLID", color: ' + hexLit(bg) + " }];",
+    emitAutoLayout(badgeVar, "HORIZONTAL", [
+      ["name", '"Badge — " + ' + jsString(cell.variant)],
+      ["paddingLeft", "6"],
+      ["paddingRight", "6"],
+      ["paddingTop", "2"],
+      ["paddingBottom", "2"],
+      ["cornerRadius", "3"],
+      ["fills", '[{ type: "SOLID", color: ' + hexLit(bg) + " }]"],
+    ]),
   );
   lines.push("var " + cellVar + " = figma.createText();");
   lines.push(cellVar + '.fontName = { family: "Inter", style: "Semi Bold" };');
@@ -762,14 +783,14 @@ function emitBadgeCell(lines, cellVar, parentVar, cell) {
 
 function emitColorSwatchCell(lines, cellVar, parentVar, cell) {
   var wrap = cellVar + "_w";
-  lines.push("var " + wrap + " = figma.createFrame();");
-  lines.push(wrap + '.name = "Cell — color-swatch";');
-  lines.push(wrap + ".fills = [];");
-  lines.push(wrap + '.layoutMode = "HORIZONTAL";');
-  lines.push(wrap + ".itemSpacing = 8;");
-  lines.push(wrap + '.primaryAxisSizingMode = "AUTO";');
-  lines.push(wrap + '.counterAxisSizingMode = "AUTO";');
-  lines.push(wrap + '.counterAxisAlignItems = "CENTER";');
+  lines.push(
+    emitAutoLayout(wrap, "HORIZONTAL", [
+      ["name", jsString("Cell — color-swatch")],
+      ["fills", "[]"],
+      ["itemSpacing", "8"],
+      ["counterAxisAlignItems", jsString("CENTER")],
+    ]),
+  );
   lines.push(parentVar + ".appendChild(" + wrap + ");");
   lines.push(wrap + '.layoutSizingHorizontal = "FILL";');
 
@@ -794,35 +815,31 @@ function emitColorSwatchCell(lines, cellVar, parentVar, cell) {
 
   // Text stack
   var stackVar = cellVar + "_stack";
-  lines.push("var " + stackVar + " = figma.createFrame();");
-  lines.push(stackVar + '.name = "Swatch stack";');
-  lines.push(stackVar + ".fills = [];");
-  lines.push(stackVar + '.layoutMode = "VERTICAL";');
-  lines.push(stackVar + ".itemSpacing = 2;");
-  lines.push(stackVar + '.primaryAxisSizingMode = "AUTO";');
-  lines.push(stackVar + '.counterAxisSizingMode = "AUTO";');
+  lines.push(
+    emitAutoLayout(stackVar, "VERTICAL", [
+      ["name", jsString("Swatch stack")],
+      ["fills", "[]"],
+      ["itemSpacing", "2"],
+    ]),
+  );
   lines.push(wrap + ".appendChild(" + stackVar + ");");
 
   // Token pill (if tokenName)
   if (cell.tokenName) {
     var pillVar = cellVar + "_pill";
-    lines.push("var " + pillVar + " = figma.createFrame();");
     lines.push(
-      pillVar + '.name = "Token: " + ' + jsString(cell.tokenName) + ";",
-    );
-    lines.push(pillVar + '.layoutMode = "HORIZONTAL";');
-    lines.push(pillVar + '.primaryAxisSizingMode = "AUTO";');
-    lines.push(pillVar + '.counterAxisSizingMode = "AUTO";');
-    lines.push(pillVar + ".paddingLeft = 5;");
-    lines.push(pillVar + ".paddingRight = 5;");
-    lines.push(pillVar + ".paddingTop = 2;");
-    lines.push(pillVar + ".paddingBottom = 2;");
-    lines.push(pillVar + ".cornerRadius = 3;");
-    lines.push(
-      pillVar +
-        '.fills = [{ type: "SOLID", color: ' +
-        hexLit(STYLE.TOKEN_PILL_BG) +
-        " }];",
+      emitAutoLayout(pillVar, "HORIZONTAL", [
+        ["name", '"Token: " + ' + jsString(cell.tokenName)],
+        ["paddingLeft", "5"],
+        ["paddingRight", "5"],
+        ["paddingTop", "2"],
+        ["paddingBottom", "2"],
+        ["cornerRadius", "3"],
+        [
+          "fills",
+          '[{ type: "SOLID", color: ' + hexLit(STYLE.TOKEN_PILL_BG) + " }]",
+        ],
+      ]),
     );
     lines.push("var " + cellVar + "_tn = figma.createText();");
     lines.push(
@@ -862,12 +879,17 @@ function emitColorSwatchCell(lines, cellVar, parentVar, cell) {
 }
 
 function emitEmptyCell(lines, cellVar, parentVar) {
-  lines.push("var " + cellVar + " = figma.createFrame();");
-  lines.push(cellVar + '.name = "Cell — empty";');
-  lines.push(cellVar + ".fills = [];");
-  lines.push(cellVar + '.layoutMode = "HORIZONTAL";');
-  lines.push(cellVar + '.primaryAxisSizingMode = "AUTO";');
-  lines.push(cellVar + '.counterAxisSizingMode = "AUTO";');
+  // Pre-refactor (createFrame + HORIZONTAL + AUTO/AUTO) and post-refactor (createAutoLayout
+  // defaults) both produce a 0-height frame because there are no children. The cell stretches
+  // horizontally via FILL but contributes 0 to the row's height — the parent row's other
+  // cells govern row height. This is the intended spacer behavior; the validator's
+  // cell-count enforcement prevents an all-empty row from collapsing entirely.
+  lines.push(
+    emitAutoLayout(cellVar, "HORIZONTAL", [
+      ["name", jsString("Cell — empty")],
+      ["fills", "[]"],
+    ]),
+  );
   lines.push(parentVar + ".appendChild(" + cellVar + ");");
   lines.push(cellVar + '.layoutSizingHorizontal = "FILL";');
 }

--- a/plugins/actian-design-system/tests/renderers/diagnostic-names.test.js
+++ b/plugins/actian-design-system/tests/renderers/diagnostic-names.test.js
@@ -68,10 +68,14 @@ describe("render-figma diagnostic names", function () {
       0,
       "renderer exited non-zero. stderr=" + result.stderr,
     );
+    // v1.87.0: name now lives inside createAutoLayout's props object (object-property form),
+    // not the prior `.name = "X";` assignment form. Runtime .name at Figma is unchanged —
+    // createAutoLayout({ name: ... }) sets the property identically — so the A8 grader
+    // (which reads via get_metadata) still works.
     assert.match(
       result.stdout,
-      /\.name\s*=\s*"Table \(renderTable\)";/,
-      'stdout must contain `.name = "Table (renderTable)";` exactly — the eval-lane A8 assertion depends on this literal.',
+      /name:\s*"Table \(renderTable\)"/,
+      'stdout must contain `name: "Table (renderTable)"` in the createAutoLayout props — the eval-lane A8 assertion reads the runtime value via get_metadata.',
     );
   });
 
@@ -99,10 +103,13 @@ describe("render-figma diagnostic names", function () {
     // emits; any change to the emit form (e.g. inlining the literal)
     // will trip this regex and force a coordinated update with the
     // grader procedure in evals/component-brief/grader.md.
+    // v1.87.0: name now lives inside createAutoLayout's props object — the concatenation
+    // expression `"Token: " + tokenName` is unchanged, but the leading `.name =` is now
+    // `name:`. Runtime .name at Figma is identical.
     assert.match(
       result.stdout,
-      /\.name\s*=\s*"Token: "\s*\+\s*"--zen-spacing-lg";/,
-      'stdout must contain a `.name = "Token: " + "--zen-…";` concatenation — the eval-lane A8 assertion reads the runtime concatenated value via get_metadata, but the test pins the source emit form.',
+      /name:\s*"Token: "\s*\+\s*"--zen-spacing-lg"/,
+      'stdout must contain a `name: "Token: " + "--zen-…"` concatenation in the createAutoLayout props — the eval-lane A8 assertion reads the runtime concatenated value via get_metadata.',
     );
   });
 
@@ -157,10 +164,11 @@ describe("render-figma diagnostic names", function () {
     };
     var result = runRendererWithSpec(spec, "0:1");
     assert.strictEqual(result.status, 0);
+    // v1.87.0: name now lives inside createAutoLayout's props object.
     assert.match(
       result.stdout,
-      /\.name\s*=\s*"Swatch stack";/,
-      'stdout must contain `.name = "Swatch stack";` — the vertical text-stack inside emitColorSwatchCell.',
+      /name:\s*"Swatch stack"/,
+      'stdout must contain `name: "Swatch stack"` in the createAutoLayout props — the vertical text-stack inside emitColorSwatchCell.',
     );
   });
 
@@ -184,10 +192,15 @@ describe("render-figma diagnostic names", function () {
     };
     var result = runRendererWithSpec(spec, "0:1");
     assert.strictEqual(result.status, 0);
+    // v1.87.0: name now lives inside the createAutoLayout(...) call for _pill.
+    // The matcher is loosened (no leading `_pill\.`) because the createAutoLayout
+    // call assigns the result to `var <cellVar>_pill`, so the `name:` line appears
+    // in the createAutoLayout props rather than as a separate `_pill.name = ...`
+    // statement. The "Token: ..." concatenation is unchanged.
     assert.match(
       result.stdout,
-      /_pill\.name\s*=\s*"Token: "\s*\+\s*"--zen-color-bg-default";/,
-      'stdout must contain `_pill.name = "Token: " + "--zen-color-bg-default";` — keeps the swatch pill consistent with emitTokenPillCell so A8\'s secondary "Token: --zen-…" pill count is uniform.',
+      /name:\s*"Token: "\s*\+\s*"--zen-color-bg-default"/,
+      'stdout must contain `name: "Token: " + "--zen-color-bg-default"` inside the swatch-cell pill\'s createAutoLayout props — keeps it consistent with emitTokenPillCell so A8\'s secondary pill count is uniform.',
     );
   });
 });

--- a/plugins/actian-design-system/tests/renderers/figma-table.test.js
+++ b/plugins/actian-design-system/tests/renderers/figma-table.test.js
@@ -165,17 +165,25 @@ test("emit Figma code: header row + data rows wired into table parent", function
     },
   ]);
   var out = figma.emit(s, "<contentSlotId>");
-  // Outer table frame, both rows appended
-  assert.match(out.code, /var table = figma.createFrame/);
+  // Outer table frame uses createAutoLayout (v1.87.0 — VERTICAL with AUTO/AUTO sizing default).
+  assert.match(out.code, /var table = figma\.createAutoLayout\("VERTICAL"/);
   assert.match(out.code, /table\.appendChild\(row_header\)/);
   assert.match(out.code, /table\.appendChild\(row_data0\)/);
-  // Header row hugs (interpreter sets the load-bearing modes)
-  assert.match(out.code, /row_header\.counterAxisSizingMode = "AUTO"/);
-  // Data row hugs (load-bearing fix from v1.70.4 audit)
-  assert.match(out.code, /row_data0\.counterAxisSizingMode = "AUTO"/);
+  // Header row hugs via createAutoLayout's default AUTO/AUTO sizing.
+  assert.match(
+    out.code,
+    /var row_header = figma\.createAutoLayout\("HORIZONTAL"/,
+  );
+  // Data row hugs (load-bearing fix from v1.70.4 audit) — createAutoLayout defaults preserve AUTO/AUTO.
+  assert.match(
+    out.code,
+    /var row_data0 = figma\.createAutoLayout\("HORIZONTAL"/,
+  );
+  // FILL on horizontal axis must STILL be set after appendChild (Critical Rule 12).
   assert.match(out.code, /row_data0\.layoutSizingHorizontal = "FILL"/);
-  // Token pill correctly named (matches v1.70.4 registry probe pattern)
-  assert.match(out.code, /\.name = "Token: " \+ "--zen-spacing-lg"/);
+  // Token pill correctly named (matches v1.70.4 registry probe pattern).
+  // v1.87.0: name now lives inside the createAutoLayout props object.
+  assert.match(out.code, /name: "Token: " \+ "--zen-spacing-lg"/);
   // Manifest counts
   assert.equal(out.manifest.rowsEmitted, 1);
   assert.equal(out.manifest.cellsByType["text"], 2);
@@ -192,7 +200,9 @@ test("emit Figma code: code cells trigger Fira Code font load", function () {
     { headers: ["Type"] },
   );
   var out = figma.emit(s, "<contentSlotId>");
-  assert.match(out.code, /loadFontAsync.+Fira Code/);
+  // v1.87.0: fonts are batched into a single Promise.all([...].map(loadFontAsync)) call,
+  // so "Fira Code" appears in the array BEFORE the loadFontAsync invocation. Match both.
+  assert.match(out.code, /Fira Code.+loadFontAsync|loadFontAsync.+Fira Code/);
 });
 
 test("emit Figma code: row data wrappers prevent the v1.70.x squash class", function () {


### PR DESCRIPTION
## Summary

Sprint Alpha of the Figma performance sprint. Two pre-flight spikes ran first; this PR adopts the results.

**Highlights:**
- **26% byte reduction** on `render-figma.js` emitted output (12,158 → 8,947 chars on a 3-row mixed spec) via `createAutoLayout` adoption
- **O(n²) → O(n)** font-dedup across canonical template + Patterns 8/9/14
- **`Promise.all`** parallelizes 6 sequential `loadFontAsync` sites
- **`await node.screenshot()`** adopted in parity-check (Spike 1 confirmed sideband payload, no 50K budget hit)
- **Bump v1.86.2 → v1.87.0** MINOR (new API adoption)

## Spike inputs

| Spike | Result | Adopted? |
|---|---|---|
| 1: `node.screenshot()` payload viability | PASSED — payload is sideband, ~1.3s round-trip | ✅ in parity-check.md |
| 2: detach-then-mutate (Tokens Studio #3641) | SKIPPED — 1.05×–3.54× in our profile, not the reported 50-60× | ❌ — mutation profile differs (we don't do bulk setBoundVariable rebinding) |

## Changes

| File | What |
|---|---|
| `scripts/renderers/figma-table/render-figma.js` | New `emitAutoLayout()` helper. 13 `createFrame()` sites → `createAutoLayout()`. Font-load block in `Promise.all`. Badge pill now named. 12×12 swatch dot intentionally kept as `createFrame` (no children). |
| `references/figma/figma-push-patterns.md` | Rule 8 canonical template: Set-based font dedup keyed by `family\|style`. |
| `references/component-brief/push-patterns.md` | Patterns 8/9/14 font-dedup converted. 5 sequential `loadFontAsync` sites → `Promise.all`. **Fixed pre-existing `\"Semibold\"` → `\"Semi Bold\"` inconsistency** (Pattern 1d + Pattern 6) — Inter's registered style name has a space. |
| `references/figma/parity-check.md` | Step 1 recommends inline `await node.screenshot()`; `get_screenshot` retained as documented fallback for out-of-band review. |
| `tests/renderers/figma-table.test.js` | 2 assertions updated for `createAutoLayout` source form. |
| `tests/renderers/diagnostic-names.test.js` | 4 A8-grader tripwire assertions updated. Runtime `.name` at Figma is unchanged — `createAutoLayout({ name })` sets the property identically. |
| `evals/component-brief/grader.md` | Stale line-number citations (\`:434\`, \`:651\`) replaced with function-name references (drift-proof for next refactor). |
| `.claude-plugin/plugin.json` | v1.86.2 → v1.87.0 |

## Critical Rule 12 preservation

Every converted site still sets `layoutSizingHorizontal = \"FILL\"` AFTER `appendChild()`. Verified by `tests/renderers/figma-table.test.js`.

## Deferred to Sprint Beta-rest (doc-only follow-up)

- Rule-cite renumbering (rule cites by topic + bracketed upstream # to prevent next-refresh rot)
- Cross-call appendChild audit
- Broader Rule 8 font-preload audit

## Test plan

- [x] 855/855 unit tests pass
- [x] Byte-reduction measurement on 3-row mixed spec (12,158 → 8,947 = 26%)
- [x] Code reviewer pass (must-fix items addressed)
- [ ] CI green
- [ ] Smoke test on a fresh brief render in Figma to verify visual parity post-refactor