### PR TITLE
docs(figma): Sprint Beta-rest — Rule 8 audit + cite-by-topic citations

### DIFF
--- a/plugins/actian-design-system/.claude-plugin/plugin.json
+++ b/plugins/actian-design-system/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "actian-design-system",
   "description": "Actian Design System toolkit — generate wireframe flows with prototype wiring, create component briefs, audit designs, compare flows, and build presentations. 8 skills (with tiered generation: recognized / adapted / improvised), 8 agents, 155 tokens (3 themes, 8 collections), WCAG 2.1 AA. DS knowledge vendored from volivarii/actian-ds-knowledge.",
-  "version": "1.87.0",
+  "version": "1.87.1",
   "author": {
     "name": "Actian UX Team"
   },

--- a/plugins/actian-design-system/references/component-brief/push-patterns.md
+++ b/plugins/actian-design-system/references/component-brief/push-patterns.md
@@ -695,10 +695,28 @@ return { createdNodeIds: [inst.id], mutatedNodeIds: [] };
 
 For theme comparison frames, set `variableMode` after creating the frame:
 
+> **Rule 8 — Font preload required before `setExplicitVariableModeForCollection`** when the
+> frame's subtree contains text-bearing nodes with unloaded fonts. The mode switch walks the
+> subtree to re-resolve bound variables; if any text node still has unloaded fonts, the call
+> throws. Use the canonical Set-based dedup from `figma-push-patterns.md` Rule 8 before the
+> `setExplicitVariableModeForCollection` call below.
+
 ```js
 const frame = figma.createFrame();
 frame.name = "Theme: Actian";
 // ... add instance as child ...
+
+// Rule 8: preload fonts in the instance subtree before the mode switch.
+const _seenTC = new Set();
+const _fontsTC = [];
+frame.findAll(n => n.type === "TEXT").forEach(t => {
+  const fn = t.fontName;
+  if (!fn || typeof fn !== 'object') return;
+  const key = fn.family + '|' + fn.style;
+  if (_seenTC.has(key)) return;
+  _seenTC.add(key); _fontsTC.push(fn);
+});
+await Promise.all(_fontsTC.map(fn => figma.loadFontAsync(fn)));
 
 // Set variable mode for this frame's scope
 const collections = await figma.variables.getLocalVariableCollectionsAsync();

--- a/plugins/actian-design-system/references/create-component/push-patterns.md
+++ b/plugins/actian-design-system/references/create-component/push-patterns.md
@@ -100,8 +100,26 @@ return { setId: set.id };
 
 ## 5. Variable Scoping (optional)
 
+> **Rule 8 — Font preload required before `setExplicitVariableModeForCollection`** when the
+> component set's subtree has text-bearing nodes with unloaded fonts. The mode switch walks
+> the subtree to re-resolve bound variables; an unloaded font in any text descendant throws.
+> See `references/figma/figma-push-patterns.md` Rule 8 for the canonical Set-based preload.
+
 ```js
 const set = await figma.getNodeByIdAsync("<setId>");
+
+// Rule 8: preload fonts in the component set's subtree before the mode switch.
+const _seenVS = new Set();
+const _fontsVS = [];
+set.findAll(n => n.type === "TEXT").forEach(t => {
+  const fn = t.fontName;
+  if (!fn || typeof fn !== 'object') return;
+  const key = fn.family + '|' + fn.style;
+  if (_seenVS.has(key)) return;
+  _seenVS.add(key); _fontsVS.push(fn);
+});
+await Promise.all(_fontsVS.map(fn => figma.loadFontAsync(fn)));
+
 const collections = await figma.variables.getLocalVariableCollectionsAsync();
 const colorCol = collections.find(c => c.name === "Color");
 if (colorCol) {

--- a/plugins/actian-design-system/references/figma/figma-api-traps.md
+++ b/plugins/actian-design-system/references/figma/figma-api-traps.md
@@ -84,7 +84,11 @@ node.fills = [newPaint, ...node.fills.slice(1)];
 
 ## See also
 
-- `figma-use/SKILL.md` Critical Rules 1-17 — the canonical rule set
+- `figma-use/SKILL.md` Critical Rules 1-17 in v2.2.3 — the canonical rule
+  set. (When citing individual rules elsewhere in the docs, follow the
+  topic-leading convention from `references/figma/figma-push-patterns.md`
+  `## Critical Rules` — quote the upstream topic, bracket the rule number
+  with the version, so renumbering doesn't silently break citations.)
 - `figma-use/references/gotchas.md` — full pitfall catalogue with WRONG/
   CORRECT examples
 - `references/figma/figma-push-patterns.md` `## Critical Rules` section

--- a/plugins/actian-design-system/references/figma/figma-push-patterns.md
+++ b/plugins/actian-design-system/references/figma/figma-push-patterns.md
@@ -38,7 +38,7 @@ Each registry entry contains: `key`, `importMethod` ("set" for `importComponentS
 > Every push pattern MUST end with `return { createdNodeIds: [...], mutatedNodeIds: [...] };`.
 > The orchestrating skill uses these IDs to chain subsequent `use_figma` calls.
 > Single-ID returns like `{ frameId }` or `{ instanceId }` are a Rule 15 violation.
-> (Source: figma-use/SKILL.md:38)
+> (Source: figma-use/SKILL.md "Return IDs (CRITICAL)" [Rule 15 in v2.2.3])
 
 ## Critical Rules
 
@@ -48,13 +48,22 @@ Core Patterns` above (skillNames mandatory-load, never-reparent, return
 all node IDs) are also Critical Rules and remain in their current position
 for prominence; the rules below are the rest of the canonical set.
 
-> **Rule 3a — `getPluginData`/`setPluginData` are NOT supported in `use_figma`. Use `getSharedPluginData`/`setSharedPluginData` instead.**
+> **Citation convention (v1.87.1+):** rule citations lead with the upstream
+> *topic* (in quotes), with the version-pinned rule number in brackets — e.g.
+> `(Source: figma-use/SKILL.md "Font preload before appendChild" [Rule 8 in v2.2.3])`.
+> This pattern survives upstream renumbering: the topic remains stable across
+> Figma's rule reshuffles, and the bracketed `[Rule N in vX.Y.Z]` records
+> exactly where the rule lived at vendor-refresh time. When the next vendor
+> refresh lands, refresh the bracketed `[Rule N in vX.Y.Z]` tag and verify the
+> topic still matches; the rest of the citation stays untouched.
+
+> **`getSharedPluginData`/`setSharedPluginData` (not `getPluginData`/`setPluginData`) — the unprefixed variants throw inside `use_figma`.**
 > The shared variant takes a namespace + key and works inside `use_figma`.
 > If you need to persist plugin metadata on a node, always use the shared
 > variant.
-> (Source: figma-use/SKILL.md Rule 3a)
+> (Source: figma-use/SKILL.md "Shared plugin data" [Rule 3a in v2.2.3])
 
-> **Rule 8 — Font preload is mandatory before any operation on text-bearing subtrees.**
+> **Font preload before any operation on text-bearing subtrees.**
 > Per the v2.1.26 expansion (2026-04-27): you MUST `loadFontAsync` before
 > `appendChild`, `insertChild`, `setBoundVariable`, `setExplicitVariableModeForCollection`,
 > `setValueForMode`, AND `findAll` callbacks if any node in the touched
@@ -82,40 +91,40 @@ for prominence; the rules below are the rest of the canonical set.
 > The `typeof fn === 'object'` guard excludes `figma.mixed` (a Symbol) which
 > is truthy but produces `undefined` from `JSON.stringify`. Without the
 > guard, `loadFontAsync(figma.mixed)` throws.
-> (Source: figma-use/SKILL.md Rule 8 — expanded v2.1.26)
+> (Source: figma-use/SKILL.md "Canonical text-edit recipe" [Rule 8 in v2.2.3, expanded v2.1.26])
 
-> **Rule 13 — Position new top-level nodes away from (0,0).**
+> **Position new top-level nodes away from (0,0).**
 > Top-level nodes (children of `figma.currentPage`) must be positioned at
 > non-(0,0) coordinates — Figma reserves the origin region for collapsed
 > overlay state. Auto-layout-nested nodes (children of frames with
 > `layoutMode = "HORIZONTAL"` or `"VERTICAL"`) are exempt; only page-level
 > nodes need explicit positioning. Pattern 0 (wrapper frame) follows this
 > already by setting `wrapper.x = currentPage.maxY + 200`.
-> (Source: figma-use/SKILL.md Rule 13)
+> (Source: figma-use/SKILL.md "Position new top-level nodes away from (0,0)" [Rule 13 in v2.2.3])
 
-> **Rule 14 — Atomic on error: STOP, do not immediately retry.**
+> **Atomic on error: STOP, do not immediately retry.**
 > A failed `use_figma` script makes ZERO changes — Figma rolls back the
 > entire script. STOP, diagnose the error, then re-issue with the fix.
 > Retrying the same script on transient-looking errors is the wrong move:
 > if the script failed once it will fail again, and silent retries waste
 > tokens. Atomic-on-error is what makes diagnose-then-fix safe.
-> (Source: figma-use/SKILL.md Rule 14)
+> (Source: figma-use/SKILL.md "On `use_figma` error, STOP" [Rule 14 in v2.2.3])
 
-> **Rule 16 — Always set `variable.scopes` explicitly.**
+> **Always set `variable.scopes` explicitly.**
 > The default `ALL_SCOPES` "pollutes every property picker — almost never
 > what you want." Set scopes per the variable's intended use:
 > - Color tokens: `["FRAME_FILL", "SHAPE_FILL", "TEXT_FILL", "STROKE_COLOR"]`
 > - Spacing tokens: `["GAP", "WIDTH_HEIGHT"]`
 > - Typography tokens: see `figma-use/references/variable-patterns.md` for
 >   the full enumeration.
-> (Source: figma-use/SKILL.md Rule 16)
+> (Source: figma-use/SKILL.md "Always set `variable.scopes` explicitly" [Rule 16 in v2.2.3])
 
-> **Rule 17 — `await` every Promise.**
+> **`await` every Promise.**
 > Unawaited `loadFontAsync`, `setCurrentPageAsync`, `importComponentByKeyAsync`,
 > `setFillStyleIdAsync`, etc. cause silent failures. Use `await` even when
 > you don't read the return value. Promise.all is the right shape when
 > loading many things in parallel; never fire-and-forget.
-> (Source: figma-use/SKILL.md Rule 17)
+> (Source: figma-use/SKILL.md "`await` every Promise" [Rule 17 in v2.2.3])
 
 ### Editor Mode
 
@@ -137,7 +146,7 @@ or `figma.com/sites/` URL, hand off to the appropriate read-only flow
 (`get_figjam`, `get_design_context` with mode warning) — do not attempt
 `use_figma` writes.
 
-(Source: figma-use/SKILL.md Section 4)
+(Source: figma-use/SKILL.md "Editor Mode" [Section 4 in v2.2.3])
 
 ### ToolSearch batch-load
 


### PR DESCRIPTION
## Summary

Sprint Beta-rest — doc-only follow-up to Sprint Alpha (#97). Closes the items deferred from the perf sprint: cross-call appendChild audit, Rule 8 font-preload audit, and the cite-by-topic renumbering pass.

## Audit findings

**Cross-call \`appendChild\`: CLEAN.** Walked Patterns 0b, 1d, 8, 9, 13, 14 in \`component-brief/push-patterns.md\`. Every \`getNodeByIdAsync\`-fetched parent is followed by \`appendChild\` of freshly-created children — never a cross-call fetched node. No reparenting violations.

**Rule 8 font-preload: 2 gaps fixed.** Both sites were illustrative snippets missing the canonical preload before \`setExplicitVariableModeForCollection\`:
- \`component-brief/push-patterns.md\` theme-comparison block
- \`create-component/push-patterns.md\` Pattern 5 (variable scoping)

Both now use the Set-based dedup pattern from Sprint Alpha.

## Citation convention (drift-proofing)

Rule citations in \`figma-push-patterns.md\` now lead with the upstream *topic* (in quotes) and bracket the rule number with the pinned version:

\`\`\`
OLD: (Source: figma-use/SKILL.md Rule 8 — expanded v2.1.26)
NEW: (Source: figma-use/SKILL.md \"Canonical text-edit recipe\" [Rule 8 in v2.2.3, expanded v2.1.26])
\`\`\`

The topic survives upstream renumbering; the bracketed tag records exactly where the rule lived at vendor-refresh time. Added a convention block at the top of \`## Critical Rules\` so future edits stay consistent. \`figma-api-traps.md\` cross-references the convention.

The synthesis's instruction to rename \"Rule 3a → Rule 4\" was based on a stale assumption — upstream v2.2.3 still uses Rule 3a, so that rename was skipped. The \"3a\" position is recorded in the bracketed tag.

## Files

| File | Change |
|---|---|
| \`references/component-brief/push-patterns.md\` | Theme-comparison Rule 8 callout + Set-based preload |
| \`references/create-component/push-patterns.md\` | Pattern 5 Rule 8 callout + Set-based preload |
| \`references/figma/figma-push-patterns.md\` | 6 rule cites converted to topic-leading form + convention block |
| \`references/figma/figma-api-traps.md\` | Cross-references the new convention |
| \`.claude-plugin/plugin.json\` | v1.87.0 → v1.87.1 PATCH (doc-only) |

## Test plan

- [x] 855/855 unit tests pass (no code changes)
- [ ] CI green