### PR TITLE
fix(tests): derive a11y known-slug from index, not hardcoded value

### DIFF
--- a/plugins/actian-design-system/.claude-plugin/plugin.json
+++ b/plugins/actian-design-system/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "actian-design-system",
   "description": "Actian Design System toolkit — generate wireframe flows with prototype wiring, create component briefs, audit designs, compare flows, and build presentations. 8 skills (with tiered generation: recognized / adapted / improvised), 8 agents, 155 tokens (3 themes, 8 collections), WCAG 2.1 AA. DS knowledge vendored from volivarii/actian-ds-knowledge.",
-  "version": "1.87.3",
+  "version": "1.87.4",
   "author": {
     "name": "Actian UX Team"
   },

--- a/plugins/actian-design-system/tests/transformers/category-defaults-loader.test.js
+++ b/plugins/actian-design-system/tests/transformers/category-defaults-loader.test.js
@@ -110,10 +110,24 @@ test("resolveMotionRef — null input returns null", function () {
 
 // --- resolveAccessibilityRef ---
 
+// The a11y index restructures across knowledge releases — the Accessibility
+// v1.3.0 rework (knowledge v0.19.4+) replaced the old "aria-guidance"
+// section with finer-grained slugs. Derive the "known slug" from the
+// vendored index itself so this test survives upstream restructures; a
+// hardcoded content slug breaks on every vendor refresh that renames it.
+var fs = require("fs");
+var PATHS = require("../../scripts/lib/paths.js");
+var a11yIndex = JSON.parse(fs.readFileSync(PATHS.accessibility.index, "utf8"));
+var knownA11ySlug = ((a11yIndex.sections || [])[0] || {}).slug;
+
 test("resolveAccessibilityRef — known slug returns section object", function () {
-  var section = loader.resolveAccessibilityRef("aria-guidance");
-  assert.ok(section);
-  assert.equal(section.slug, "aria-guidance");
+  assert.ok(
+    knownA11ySlug,
+    "vendored a11y-index.json must carry at least one section",
+  );
+  var section = loader.resolveAccessibilityRef(knownA11ySlug);
+  assert.ok(section, "known slug '" + knownA11ySlug + "' must resolve");
+  assert.equal(section.slug, knownA11ySlug);
   assert.ok(section.title);
 });
 


### PR DESCRIPTION
## Problem

Vendor refresh PRs to knowledge v0.19.x fail one plugin test —
`category-defaults-loader.test.js` "resolveAccessibilityRef — known slug
returns section object".

The test hardcoded the accessibility slug `aria-guidance`. The
Accessibility v1.3.0 rework (knowledge v0.19.4+) restructured the a11y
index, splitting `aria-guidance` into finer-grained slugs
(`aria-labels`, `focus-keyboard`, …). `resolveAccessibilityRef("aria-guidance")`
then returns `null` and `assert.ok(section)` fails.

It's a brittle test fixture, not a runtime bug — `aria-guidance` appears
nowhere else in the plugin, and the real category-defaults
`accessibility.ref` values still resolve.

## Fix

Derive the "known slug" from `sections[0].slug` of the vendored
a11y-index instead of hardcoding a content value, so the test survives
upstream restructures.

Verified green against both the current vendor and the v0.19.9 refresh
index. Full suite: 855/855 pass.

Bumps plugin.json patch.