### PR TITLE
fix(preview): previews read vendored tokens instead of hardcoded brand color

### DIFF
--- a/plugins/actian-design-system/.claude-plugin/plugin.json
+++ b/plugins/actian-design-system/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "actian-design-system",
   "description": "Actian Design System toolkit — generate wireframe flows with prototype wiring, create component briefs, audit designs, compare flows, and build presentations. 8 skills (with tiered generation: recognized / adapted / improvised), 8 agents, 155 tokens (3 themes, 8 collections), WCAG 2.1 AA. DS knowledge vendored from volivarii/actian-ds-knowledge.",
-  "version": "1.89.5",
+  "version": "1.89.6",
   "author": {
     "name": "Actian UX Team"
   },

--- a/plugins/actian-design-system/references/component-brief/data-schema.md
+++ b/plugins/actian-design-system/references/component-brief/data-schema.md
@@ -138,8 +138,8 @@ Sentence case for both, per Figma content guideline (section/page headers are se
     {
       "state": "Focused",
       "columns": [
-        { "header": "Border", "token": "theme-primary", "hex": "#0550DC" },
-        { "header": "Label", "token": "theme-primary", "hex": "#0550DC" },
+        { "header": "Border", "token": "theme-primary", "hex": "#0F5FDC" },
+        { "header": "Label", "token": "theme-primary", "hex": "#0F5FDC" },
         { "header": "Input text", "token": "text-primary", "hex": "#000000" },
         { "header": "Background", "token": "bg-default", "hex": "#FFFFFF" }
       ]

--- a/plugins/actian-design-system/references/component-brief/render-table-tool.md
+++ b/plugins/actian-design-system/references/component-brief/render-table-tool.md
@@ -171,9 +171,9 @@ For grid-shaped color layouts (one row per state, multiple swatch columns), use 
     {
       "cells": [
         { "type": "text", "value": "Default", "weight": "semibold" },
-        { "type": "color-swatch", "color": "#0550DC", "tokenName": "--zen-color-bg-emphasis" },
+        { "type": "color-swatch", "color": "#0F5FDC", "tokenName": "--zen-color-bg-emphasis" },
         { "type": "color-swatch", "color": "#FFFFFF", "tokenName": "--zen-color-fg-on-emphasis" },
-        { "type": "color-swatch", "color": "#0550DC", "tokenName": "--zen-color-border-emphasis" }
+        { "type": "color-swatch", "color": "#0F5FDC", "tokenName": "--zen-color-border-emphasis" }
       ]
     }
   ]

--- a/plugins/actian-design-system/references/context/companion-context.md
+++ b/plugins/actian-design-system/references/context/companion-context.md
@@ -38,7 +38,7 @@ Read this on every companion activation. For detailed info, read the full refere
 
 | Token | Hex | Use |
 |-------|-----|-----|
-| theme-primary | #0550DC | Primary actions, links, selected states |
+| theme-primary | #0F5FDC | Primary actions, links, selected states |
 | text-primary | #000000 | Body text, headings |
 | text-secondary | #3F3F4A | Secondary labels |
 | text-tertiary | #595968 | Captions, hints |

--- a/plugins/actian-design-system/scripts/renderers/assemble-preview.js
+++ b/plugins/actian-design-system/scripts/renderers/assemble-preview.js
@@ -239,7 +239,9 @@ function main() {
 
   // Read static assets
   process.stderr.write("Loading assets for type: " + args.type + "\n");
-  var cssParts = [];
+  var cssParts = [
+    readFileChecked(path.join(PLUGIN_ROOT, "vendor", "tokens", "tokens.css")),
+  ];
   var cssPaths = Array.isArray(config.css) ? config.css : [config.css];
   for (var c = 0; c < cssPaths.length; c++) {
     cssParts.push(readFileChecked(cssPaths[c]));

--- a/plugins/actian-design-system/scripts/renderers/assemble-preview.js
+++ b/plugins/actian-design-system/scripts/renderers/assemble-preview.js
@@ -19,6 +19,7 @@
 
 var fs = require("fs");
 var path = require("path");
+var PATHS = require("../lib/paths");
 
 // ---------------------------------------------------------------------------
 // Paths
@@ -239,9 +240,7 @@ function main() {
 
   // Read static assets
   process.stderr.write("Loading assets for type: " + args.type + "\n");
-  var cssParts = [
-    readFileChecked(path.join(PLUGIN_ROOT, "vendor", "tokens", "tokens.css")),
-  ];
+  var cssParts = [readFileChecked(PATHS.tokens.css)];
   var cssPaths = Array.isArray(config.css) ? config.css : [config.css];
   for (var c = 0; c < cssPaths.length; c++) {
     cssParts.push(readFileChecked(cssPaths[c]));

--- a/plugins/actian-design-system/scripts/renderers/html-renderers/brief-renderer.css
+++ b/plugins/actian-design-system/scripts/renderers/html-renderers/brief-renderer.css
@@ -326,7 +326,7 @@ td code {
   padding: 2px 6px;
   border-radius: 3px;
   background: #f0f2fa;
-  color: #0550dc;
+  color: var(--zen-color-text-link-default, #0f5fdc);
   font-family:
     "JetBrains Mono", ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
   font-size: 12px;

--- a/plugins/actian-design-system/scripts/renderers/html-renderers/brief-renderer.js
+++ b/plugins/actian-design-system/scripts/renderers/html-renderers/brief-renderer.js
@@ -394,7 +394,7 @@
       esc(header.name) +
       renderSourceBadge(header) +
       "</div>" +
-      '<svg class="card-logo" width="40" height="40" viewBox="0 0 40 40"><rect width="40" height="40" rx="4" fill="#0550DC"/></svg>' +
+      '<svg class="card-logo" width="40" height="40" viewBox="0 0 40 40"><rect width="40" height="40" rx="4" style="fill:var(--zen-color-primary-500,#0f5fdc)"/></svg>' +
       "</div>" +
       '<p class="card-body">' +
       esc(header.description) +

--- a/plugins/actian-design-system/scripts/renderers/html-renderers/presentation-renderer.css
+++ b/plugins/actian-design-system/scripts/renderers/html-renderers/presentation-renderer.css
@@ -2,30 +2,36 @@
 
 /* ── Presentation Token Palette ── */
 :root {
-  --pres-bg:          #E8E8EE;
-  --pres-slide-bg:    #FFFFFF;
-  --pres-dark-800:    #2D3648;
-  --pres-dark-700:    #4A5468;
-  --pres-dark-600:    #717D96;
-  --pres-dark-500:    #A0ABC0;
-  --pres-dark-400:    #CBD2E0;
-  --pres-dark-300:    #E2E7F0;
-  --pres-dark-200:    #EDF0F7;
-  --pres-dark-100:    #F5F5FA;
-  --pres-brand:       #0550DC;
-  --pres-brand-dark:  #0029A9;
-  --pres-brand-light: #EDF6FF;
-  --pres-text-primary:   #101828;
-  --pres-text-secondary: #2D3648;
-  --pres-text-tertiary:  #475467;
-  --pres-text-light:     #6D6D6D;
+  --pres-bg: #e8e8ee;
+  --pres-slide-bg: #ffffff;
+  --pres-dark-800: #2d3648;
+  --pres-dark-700: #4a5468;
+  --pres-dark-600: #717d96;
+  --pres-dark-500: #a0abc0;
+  --pres-dark-400: #cbd2e0;
+  --pres-dark-300: #e2e7f0;
+  --pres-dark-200: #edf0f7;
+  --pres-dark-100: #f5f5fa;
+  --pres-brand: var(--zen-color-primary-500, #0f5fdc);
+  --pres-brand-dark: var(--zen-color-primary-700, #0047bc);
+  --pres-brand-light: var(--zen-color-primary-25, #edf6ff);
+  --pres-text-primary: #101828;
+  --pres-text-secondary: #2d3648;
+  --pres-text-tertiary: #475467;
+  --pres-text-light: #6d6d6d;
   --pres-shadow: 0 8px 32px rgba(0, 0, 0, 0.18);
 }
 
-*, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
 
 body {
-  font-family: 'Roboto', sans-serif;
+  font-family: "Roboto", sans-serif;
   background: var(--pres-bg);
   padding: 40px 40px 120px;
   min-height: 100vh;
@@ -56,7 +62,7 @@ body {
   color: var(--pres-text-light);
   letter-spacing: 1.2px;
   text-transform: uppercase;
-  font-family: 'Roboto', sans-serif;
+  font-family: "Roboto", sans-serif;
 }
 
 /* ── Slide ── */
@@ -75,15 +81,15 @@ body {
 
 /* ── Slide variants — match Actian presentation templates ── */
 .slide--cover {
-  background: linear-gradient(80deg, #090952 2%, #1414B8 107%);
-  color: #FFFFFF;
+  background: linear-gradient(80deg, #090952 2%, #1414b8 107%);
+  color: #ffffff;
   justify-content: flex-end;
   padding: 88px 80px;
 }
 
 .slide--section {
-  background: linear-gradient(80deg, #EEEEFD 2%, #CBDAFF 107%);
-  color: #12131F;
+  background: linear-gradient(80deg, #eeeefd 2%, #cbdaff 107%);
+  color: #12131f;
   justify-content: center;
   padding: 80px 69px;
 }
@@ -158,7 +164,7 @@ body {
   padding: 64px 80px 32px;
   font-size: 56px;
   font-weight: 400;
-  color: #12131F;
+  color: #12131f;
   line-height: 1.2;
 }
 
@@ -169,7 +175,7 @@ body {
   display: flex;
   flex-direction: column;
   gap: 20px;
-  background: #F5F5FA;
+  background: #f5f5fa;
   margin: 0 79px 64px;
   border-radius: 4px;
 }
@@ -201,7 +207,7 @@ body {
   display: flex;
   align-items: stretch;
   justify-content: center;
-  background: #F5F5FA;
+  background: #f5f5fa;
   margin: 0 79px 64px 0;
   border-radius: 4px;
 }
@@ -218,7 +224,7 @@ body {
   position: absolute;
   border-radius: 20px;
   opacity: 0.12;
-  background: #FFFFFF;
+  background: #ffffff;
 }
 
 .geo-rect--1 {
@@ -248,7 +254,7 @@ body {
 }
 
 .geo-pattern--light .geo-rect {
-  background: #0029A9;
+  background: #0029a9;
   opacity: 0.06;
 }
 
@@ -370,15 +376,33 @@ body {
 }
 
 /* Series colors 1-9 */
-.bar-chart__fill--1 { background: #0550DC; }
-.bar-chart__fill--2 { background: #7C3AED; }
-.bar-chart__fill--3 { background: #059669; }
-.bar-chart__fill--4 { background: #D97706; }
-.bar-chart__fill--5 { background: #DC2626; }
-.bar-chart__fill--6 { background: #0891B2; }
-.bar-chart__fill--7 { background: #DB2777; }
-.bar-chart__fill--8 { background: #65A30D; }
-.bar-chart__fill--9 { background: #9333EA; }
+.bar-chart__fill--1 {
+  background: var(--pres-brand);
+}
+.bar-chart__fill--2 {
+  background: #7c3aed;
+}
+.bar-chart__fill--3 {
+  background: #059669;
+}
+.bar-chart__fill--4 {
+  background: #d97706;
+}
+.bar-chart__fill--5 {
+  background: #dc2626;
+}
+.bar-chart__fill--6 {
+  background: #0891b2;
+}
+.bar-chart__fill--7 {
+  background: #db2777;
+}
+.bar-chart__fill--8 {
+  background: #65a30d;
+}
+.bar-chart__fill--9 {
+  background: #9333ea;
+}
 
 .bar-chart__value {
   width: 60px;
@@ -463,7 +487,7 @@ body {
 }
 
 .timeline::before {
-  content: '';
+  content: "";
   position: absolute;
   left: 7px;
   top: 8px;

--- a/plugins/actian-design-system/scripts/renderers/html-renderers/presentation-renderer.css
+++ b/plugins/actian-design-system/scripts/renderers/html-renderers/presentation-renderer.css
@@ -12,6 +12,10 @@
   --pres-dark-300: #e2e7f0;
   --pres-dark-200: #edf0f7;
   --pres-dark-100: #f5f5fa;
+  /* Brand palette resolves from the vendored DS tokens inlined at build time
+     (vendor/tokens/tokens.css). The fallback hexes are the canonical post-rebrand
+     values (royal-blue 500/700; primary-25 kept pre-Proposed) and apply only if the
+     token block is absent — do NOT "correct" them to the older #0550dc-era values. */
   --pres-brand: var(--zen-color-primary-500, #0f5fdc);
   --pres-brand-dark: var(--zen-color-primary-700, #0047bc);
   --pres-brand-light: var(--zen-color-primary-25, #edf6ff);
@@ -254,7 +258,7 @@ body {
 }
 
 .geo-pattern--light .geo-rect {
-  background: #0029a9;
+  background: var(--zen-color-primary-700, #0047bc);
   opacity: 0.06;
 }
 

--- a/plugins/actian-design-system/skills/design-audit/SKILL.md
+++ b/plugins/actian-design-system/skills/design-audit/SKILL.md
@@ -89,7 +89,7 @@ When `--scope` is set, run only the listed dimensions; otherwise run all.
 ### Findings
 | # | Severity | Confidence | Finding | Rule | Fix |
 |---|----------|------------|---------|------|-----|
-| 1 | P0 | 0.95 | Button uses hardcoded #0550DC | Zero hardcoded hex | Bind theme-primary variable |
+| 1 | P0 | 0.95 | Button uses hardcoded #0F5FDC | Zero hardcoded hex | Bind theme-primary variable |
 ```
 
 ## Step 5.5 — Fix gate (interactive)

--- a/plugins/actian-design-system/tests/renderers/preview-tokens-inlined.test.js
+++ b/plugins/actian-design-system/tests/renderers/preview-tokens-inlined.test.js
@@ -78,7 +78,7 @@ describe("preview-tokens-inlined", function () {
       var r = run([BRIEF_FIXTURE, "--type", "brief"]);
       assert.strictEqual(r.status, 0, "exits cleanly");
       assert.ok(
-        r.html.includes("var(--zen-color-text-link-default"),
+        r.html.includes("var(--zen-color-text-link-default"), // prefix match — the resolved value comes from vendored tokens
         "brief HTML contains var(--zen-color-text-link-default for token-pill color",
       );
     });
@@ -98,7 +98,7 @@ describe("preview-tokens-inlined", function () {
       var r = run([PRES_FIXTURE, "--type", "presentation"]);
       assert.strictEqual(r.status, 0, "exits cleanly");
       assert.ok(
-        r.html.includes("var(--zen-color-primary-500"),
+        r.html.includes("var(--zen-color-primary-500"), // prefix match — the resolved value comes from vendored tokens
         "presentation HTML contains var(--zen-color-primary-500 for brand binding",
       );
     });

--- a/plugins/actian-design-system/tests/renderers/preview-tokens-inlined.test.js
+++ b/plugins/actian-design-system/tests/renderers/preview-tokens-inlined.test.js
@@ -1,0 +1,106 @@
+#!/usr/bin/env node
+"use strict";
+
+/**
+ * preview-tokens-inlined.test.js — Asserts that assembled previews inline
+ * vendor/tokens/tokens.css and bind brand colors to --zen-color-* variables.
+ *
+ * Run with: node --test tests/renderers/preview-tokens-inlined.test.js
+ */
+
+var { describe, it } = require("node:test");
+var assert = require("node:assert/strict");
+var spawnSync = require("child_process").spawnSync;
+var path = require("path");
+var os = require("os");
+var fs = require("fs");
+
+// ---------------------------------------------------------------------------
+// Paths
+// ---------------------------------------------------------------------------
+
+var SCRIPT = path.join(
+  __dirname,
+  "..",
+  "..",
+  "scripts",
+  "renderers",
+  "assemble-preview.js",
+);
+var FIXTURES = path.join(__dirname, "..", "fixtures");
+var BRIEF_FIXTURE = path.join(FIXTURES, "button-brief-data.json");
+var PRES_FIXTURE = path.join(FIXTURES, "sample-presentation.json");
+
+// ---------------------------------------------------------------------------
+// Helper: run the script and return { status, stdout, stderr, html }
+// ---------------------------------------------------------------------------
+
+function run(args) {
+  var outputFile = path.join(
+    os.tmpdir(),
+    "preview-tokens-test-" +
+      Date.now() +
+      "-" +
+      Math.random().toString(36).slice(2, 8) +
+      ".html",
+  );
+  var fullArgs = [SCRIPT].concat(args).concat(["-o", outputFile]);
+  var result = spawnSync("node", fullArgs, { encoding: "utf8" });
+  var html = "";
+  if (fs.existsSync(outputFile)) {
+    html = fs.readFileSync(outputFile, "utf8");
+    fs.unlinkSync(outputFile);
+  }
+  return {
+    status: result.status,
+    stdout: result.stdout,
+    stderr: result.stderr,
+    html: html,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("preview-tokens-inlined", function () {
+  describe("Brief preview", function () {
+    it("inlines vendored tokens.css (--zen-color-primary-500 present)", function () {
+      var r = run([BRIEF_FIXTURE, "--type", "brief"]);
+      assert.strictEqual(r.status, 0, "exits cleanly");
+      assert.ok(
+        r.html.includes("--zen-color-primary-500"),
+        "HTML contains --zen-color-primary-500 from vendor/tokens/tokens.css",
+      );
+    });
+
+    it("token-pill color is bound to var(--zen-color-text-link-default", function () {
+      var r = run([BRIEF_FIXTURE, "--type", "brief"]);
+      assert.strictEqual(r.status, 0, "exits cleanly");
+      assert.ok(
+        r.html.includes("var(--zen-color-text-link-default"),
+        "brief HTML contains var(--zen-color-text-link-default for token-pill color",
+      );
+    });
+  });
+
+  describe("Presentation preview", function () {
+    it("inlines vendored tokens.css (--zen-color-primary-500 present)", function () {
+      var r = run([PRES_FIXTURE, "--type", "presentation"]);
+      assert.strictEqual(r.status, 0, "exits cleanly");
+      assert.ok(
+        r.html.includes("--zen-color-primary-500"),
+        "HTML contains --zen-color-primary-500 from vendor/tokens/tokens.css",
+      );
+    });
+
+    it("brand palette var binds to var(--zen-color-primary-500", function () {
+      var r = run([PRES_FIXTURE, "--type", "presentation"]);
+      assert.strictEqual(r.status, 0, "exits cleanly");
+      assert.ok(
+        r.html.includes("var(--zen-color-primary-500"),
+        "presentation HTML contains var(--zen-color-primary-500 for brand binding",
+      );
+    });
+  });
+});


### PR DESCRIPTION
Plugin HTML previews painted brand color from hardcoded `#0550dc` literals in the renderer CSS, never reading vendored `tokens.css` — so they couldn't track the substrate (showed the pre-rebrand blue). Move 1b of the substrate→plugin reinforcement program (Move 1a = knowledge #187, the upstream token sync).

**Changes**
- `assemble-preview.js` inlines vendored `tokens.css` (via `PATHS.tokens.css`) into every preview `<style>`.
- `brief-renderer.css` / `presentation-renderer.css` / the brief SVG logo bind brand color to real vendored vars (`--zen-color-text-link-default`, `--zen-color-primary-500/-700/-25`) — there is no `--zen-color-theme-primary` in vendored tokens.
- **Bind-to-vendor, not a value edit:** previews now track the vendored snapshot and will show `#0F5FDC` automatically once #187 re-vendors. No hardcoded `#0F5FDC` (only `var(…, fallback)`).
- New value-agnostic test (`preview-tokens-inlined.test.js`); docs that present the brand primary now say `#0F5FDC`.

**Deferred:** token-pill annotation chrome (4 sandbox-bound copies in `token-tag.js` / `render-figma.js` / `push-patterns.md`); `fm-base.css --fm-brand` (FM palette, must-not-approximate).

859/859 tests. Built via subagent-driven development (implementer → spec review → code-quality review → nits).

🤖 Generated with [Claude Code](https://claude.com/claude-code)