### PR TITLE
feat: adopt shared consumption client — resolver import + snapshot copy+drift-guard (1.93.0)

### DIFF
--- a/plugins/actian-design-system/.claude-plugin/plugin.json
+++ b/plugins/actian-design-system/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "actian-design-system",
   "description": "Actian Design System toolkit — generate wireframe flows with prototype wiring, create component briefs, audit designs, compare flows, and build presentations. 8 skills (with tiered generation: recognized / adapted / improvised), 8 agents, 155 tokens (3 themes, 8 collections), WCAG 2.1 AA. DS knowledge vendored from volivarii/actian-ds-knowledge.",
-  "version": "1.92.2",
+  "version": "1.93.0",
   "author": {
     "name": "Actian UX Team"
   },

--- a/plugins/actian-design-system/ARCHITECTURE.md
+++ b/plugins/actian-design-system/ARCHITECTURE.md
@@ -69,7 +69,7 @@ Each row is a user-facing skill (slash command). Use this table to find every fi
 ### `scripts/` subdirs
 
 - `hooks/` — PreToolUse / PostToolUse shell guards (one `.sh` each). Wired in `hooks/hooks.json`. New PreToolUse guards go here.
-- `vendor/` — Vendor-snapshot tooling. `vendor-snapshot.js` pulls a pinned snapshot from `volivarii/actian-ds-knowledge` into `vendor/`. New vendor-pipeline code goes here.
+- `vendor/` — Vendor-snapshot tooling. `vendor-snapshot.js` is a thin entry (plugin config + CLI shell + the component-mirror `postVendorHook`) over `vendor-snapshot-core.js` — a byte-identical copy of the substrate's canonical `vendor/clients/vendor-snapshot.js`, drift-guarded by `tests/vendor/vendor-snapshot-core-drift.test.js`. It pulls a pinned snapshot from `volivarii/actian-ds-knowledge` into `vendor/`. New vendor-pipeline code goes here.
 - `validation/` — Pipeline validators (banned text, tokens, terminology, schema, avoid-word soft-check from `vendor/content/dist/words-to-avoid.json`). New validators go here.
 - `renderers/` — HTML/preview output. `assemble-preview.js`, the local preview server, the `html-renderers/` adapters, and `render-component-reference.js` (called post-vendor-pull to regenerate `*-components.md` mirrors).
 - `transformers/` — Data shape transformations between source formats (Figma → flow-data, flow-data → hifi, recipe partials → final).

--- a/plugins/actian-design-system/scripts/lib/paths.js
+++ b/plugins/actian-design-system/scripts/lib/paths.js
@@ -1,14 +1,19 @@
 "use strict";
 
 /**
- * paths.js — Manifest-driven vendor path resolver.
+ * paths.js — Manifest-driven vendor path resolver (thin wrapper).
  *
- * Reads vendor/paths-manifest.json at module load and builds the PATHS
- * object via dot-notation walker + collection function builders.
- * Plugin-derived overlays (component mirrors written post-vendor by
- * render-component-reference.js) are added on top.
+ * Reads vendor/paths-manifest.json at module load and builds the PATHS object.
+ * The GENERIC manifest→PATHS walker (schema-version check, dot-notation
+ * setNested, collection function builders) is single-sourced from the
+ * substrate's reference reader (vendor/clients/resolve-paths.js, imported
+ * below) — refreshed every vendor pull, zero drift. This wrapper adds the
+ * plugin-specific layers: the vendor-integrity check + the plugin-derived
+ * overlays (component mirrors written post-vendor by render-component-reference.js,
+ * byKit/bySlug ergonomics, convenience constants).
  *
- * Spec: docs/superpowers/specs/2026-05-10-manifest-and-tag-pin-design.md
+ * Spec: docs/superpowers/specs/2026-05-10-manifest-and-tag-pin-design.md +
+ *       docs/superpowers/specs/2026-06-02-shared-consumption-client-design.md
  *
  * Note on caching: PATHS is built once per Node process at module load.
  * Plugin processes are short-lived (per skill invocation), so vendor
@@ -23,7 +28,14 @@ var VENDOR = path.join(PLUGIN_ROOT, "vendor");
 var MANIFEST_PATH = path.join(VENDOR, "paths-manifest.json");
 var VENDORED_JSON_PATH = path.join(PLUGIN_ROOT, "vendored.json");
 
-var SUPPORTED_SCHEMA_VERSION = "v1";
+// Generic manifest→PATHS resolver core — single-sourced from the vendored
+// substrate reference reader. IMPORTING the vendored copy (vs maintaining our
+// own) is safe: it's read-only runtime code that doesn't mutate the tree, and
+// it's refreshed on every vendor pull. The plugin-specific integrity check +
+// overlays stay here in the wrapper.
+var resolverCore = require(path.join(VENDOR, "clients", "resolve-paths.js"));
+var buildPathsFromManifest = resolverCore.buildPathsFromManifest;
+var SUPPORTED_SCHEMA_VERSION = resolverCore.SUPPORTED_SCHEMA_VERSION;
 
 // Strip leading "v" so git tag "v0.3.1" compares equal to
 // package.json#version "0.3.1".
@@ -63,114 +75,6 @@ function verifyVendorIntegrity(manifest, vendoredJsonPath) {
         "of band. Re-run scripts/vendor/vendor-snapshot.js --range.",
     );
   }
-}
-
-function setNested(obj, parts, value) {
-  var cursor = obj;
-  for (var i = 0; i < parts.length - 1; i++) {
-    var part = parts[i];
-    if (cursor[part] !== undefined && typeof cursor[part] !== "object") {
-      throw new Error(
-        "paths.js: dot-notation key conflict — '" +
-          parts.join(".") +
-          "' cannot coexist with a leaf at '" +
-          parts.slice(0, i + 1).join(".") +
-          "'",
-      );
-    }
-    cursor[part] = cursor[part] || {};
-    cursor = cursor[part];
-  }
-  var leaf = parts[parts.length - 1];
-  if (cursor[leaf] !== undefined) {
-    throw new Error(
-      "paths.js: dot-notation key conflict — '" +
-        parts.join(".") +
-        "' is already set",
-    );
-  }
-  cursor[leaf] = value;
-}
-
-function buildPathsFromManifest(manifest, vendorRoot) {
-  if (manifest.manifest_schema_version !== SUPPORTED_SCHEMA_VERSION) {
-    throw new Error(
-      "paths.js: expected manifest_schema_version '" +
-        SUPPORTED_SCHEMA_VERSION +
-        "', found '" +
-        manifest.manifest_schema_version +
-        "'. Plugin must be upgraded.",
-    );
-  }
-
-  var out = {};
-  var paths = manifest.paths || {};
-  for (var name in paths) {
-    var entry = paths[name];
-    if (!entry.path) {
-      throw new Error("paths.js: entry '" + name + "' missing 'path' field");
-    }
-    if (!entry.type) {
-      throw new Error("paths.js: entry '" + name + "' missing 'type' field");
-    }
-    if (!entry.origin) {
-      throw new Error("paths.js: entry '" + name + "' missing 'origin' field");
-    }
-    if (!entry.description) {
-      throw new Error(
-        "paths.js: entry '" + name + "' missing 'description' field",
-      );
-    }
-    setNested(out, name.split("."), path.join(vendorRoot, entry.path));
-  }
-
-  var collections = manifest.collections || {};
-  for (var collName in collections) {
-    var coll = collections[collName];
-    if (!coll.dir) {
-      throw new Error(
-        "paths.js: collection '" + collName + "' missing 'dir' field",
-      );
-    }
-    if (!coll.pattern) {
-      throw new Error(
-        "paths.js: collection '" + collName + "' missing 'pattern' field",
-      );
-    }
-    var dir = path.join(vendorRoot, coll.dir);
-    setNested(
-      out,
-      collName.split("."),
-      (function (collDir, pattern) {
-        return function (slug) {
-          // Substitute {slug}; if no other placeholders remain, join + return.
-          var resolved = pattern.replace("{slug}", slug);
-          if (!/\{[^}]+\}/.test(resolved)) {
-            return path.join(collDir, resolved);
-          }
-          // Pattern has additional placeholders (e.g. {bucket}/{slug}.md for
-          // recursive collections). Walk one level of sub-dirs and return the
-          // first match. Slugs are unique across sub-buckets by convention —
-          // if that ever changes, this needs to return all matches instead.
-          var entries = fs.existsSync(collDir) ? fs.readdirSync(collDir) : [];
-          for (var i = 0; i < entries.length; i++) {
-            var entry = entries[i];
-            var sub = path.join(collDir, entry);
-            try {
-              if (!fs.statSync(sub).isDirectory()) continue;
-            } catch (e) {
-              continue;
-            }
-            var candidate = path.join(sub, slug + ".md");
-            if (fs.existsSync(candidate)) return candidate;
-          }
-          return null;
-        };
-      })(dir, coll.pattern),
-    );
-  }
-
-  return out;
 }
 
 function loadAndBuildPaths() {

--- a/plugins/actian-design-system/scripts/vendor/vendor-snapshot-core.js
+++ b/plugins/actian-design-system/scripts/vendor/vendor-snapshot-core.js
@@ -1,0 +1,490 @@
+"use strict";
+
+// vendor-snapshot.js — canonical vendor-snapshot core (the substrate's reference
+// reader, build-time half). Config-driven: a consumer passes
+//   { knowledgeRepo, vendorDir, vendoredJsonPath, excludeTopLevel, postVendorHook }
+// and runSnapshot() range-resolves a knowledge release → fetches the GitHub
+// tarball → selects the distributable surface (inclusion-first via
+// vendor-include.json, legacy exclude-set fallback) → copies it into vendorDir →
+// writes vendoredJsonPath.
+//
+// Factored verbatim from the plugin's scripts/vendor/vendor-snapshot.js. The
+// ONLY logic change is the module-constants → config parameterization: the
+// per-consumer module constants (KNOWLEDGE_REPO / VENDOR_DIR / VENDORED_JSON_PATH
+// / EXCLUDE_TOP_LEVEL) and the plugin-specific runComponentReferenceRenderer()
+// are gone — values are threaded in via `config`, and the post-vendor step is a
+// caller-supplied `config.postVendorHook`. The functions that consumed those
+// constants (fetchTarball / readVendoredJson / writeVendoredJson /
+// clearVendorDir / vendorContent) take the values as parameters instead. The
+// pure helpers (range/semver/tag resolution, include/exclude selection,
+// fetch/extract/copy) are byte-faithful.
+//
+// Adoption: a build tool must not import the bundle it produces (bootstrap), so
+// consumers COPY this core and keep a drift-guard test against their vendored
+// copy. See clients/README.md.
+
+var fs = require("fs");
+var path = require("path");
+var os = require("os");
+var { execFileSync } = require("child_process");
+
+function parseArgs(argv) {
+  var out = {};
+  for (var i = 0; i < argv.length; i++) {
+    if (argv[i] === "--sha") out.sha = argv[++i];
+    // Move A2: resolve via semver range (e.g., "~0.1.0") instead of SHA.
+    // Range is read from vendored.json.knowledge_repo_version_range when
+    // --range is passed without a value (or omit --range entirely).
+    else if (argv[i] === "--range") out.range = argv[++i];
+    // Resolve-only mode: print the resolved tag + SHA and exit. Used by
+    // vendor-snapshot.yml to log which tag it's about to pull.
+    else if (argv[i] === "--resolve-only") out.resolveOnly = true;
+  }
+  return out;
+}
+
+// Pure semver range resolver. Supports tilde (~), caret (^), and exact
+// version strings. Pre-1.0 caret behaves like tilde (patches only) per
+// npm convention.
+function matchesRange(version, range) {
+  var parseV = function (v) {
+    return String(v).split(".").map(Number);
+  };
+  var trimmed = String(range).trim();
+  var reqMajor, reqMinor, reqPatch;
+  if (trimmed.charAt(0) === "~") {
+    var parts = parseV(trimmed.slice(1));
+    reqMajor = parts[0];
+    reqMinor = parts[1];
+    reqPatch = parts[2] || 0;
+    var v = parseV(version);
+    return v[0] === reqMajor && v[1] === reqMinor && v[2] >= reqPatch;
+  }
+  if (trimmed.charAt(0) === "^") {
+    var cparts = parseV(trimmed.slice(1));
+    reqMajor = cparts[0];
+    reqMinor = cparts[1];
+    reqPatch = cparts[2] || 0;
+    var cv = parseV(version);
+    if (reqMajor === 0) {
+      // Pre-1.0: caret = tilde (only patches)
+      return cv[0] === reqMajor && cv[1] === reqMinor && cv[2] >= reqPatch;
+    }
+    return (
+      cv[0] === reqMajor &&
+      (cv[1] > reqMinor || (cv[1] === reqMinor && cv[2] >= reqPatch))
+    );
+  }
+  // Less-than operators (<X.Y.Z, <=X.Y.Z). Lets consumers opt into
+  // "anything up to the next major" without per-minor re-pin (Design E in
+  // project_sync_pipeline_improvements_2026_05_13.md). Compound ranges
+  // (>=A.B.C <X.Y.Z) intentionally not supported — keep the parser small;
+  // floors are theoretical for forward-only knowledge tags.
+  var ltMatch = trimmed.match(/^<(=?)\s*(\d+\.\d+\.\d+)$/);
+  if (ltMatch) {
+    var inclusive = ltMatch[1] === "=";
+    var cmp = compareSemver(version, ltMatch[2]);
+    return inclusive ? cmp <= 0 : cmp < 0;
+  }
+  return version === trimmed;
+}
+
+// Compare two semver strings; returns -1, 0, or 1.
+function compareSemver(a, b) {
+  var pa = String(a).split(".").map(Number);
+  var pb = String(b).split(".").map(Number);
+  for (var i = 0; i < 3; i++) {
+    if (pa[i] !== pb[i]) return pa[i] - pb[i] < 0 ? -1 : 1;
+  }
+  return 0;
+}
+
+// Filter, validate, and select the highest tag matching a range.
+// Returns the tag name (with "v" prefix) or null.
+function resolveTargetTag(tags, range) {
+  var candidates = tags
+    .map(function (t) {
+      return String(t).replace(/^v/, "");
+    })
+    .filter(function (v) {
+      // Strict semver (X.Y.Z numeric), no pre-release suffix
+      return /^[0-9]+\.[0-9]+\.[0-9]+$/.test(v);
+    })
+    .filter(function (v) {
+      return matchesRange(v, range);
+    });
+  if (candidates.length === 0) return null;
+  candidates.sort(compareSemver);
+  return "v" + candidates[candidates.length - 1];
+}
+
+// Compare the resolved tag against the highest available tag across ALL
+// strict-semver tags (regardless of range). If a newer tag exists outside
+// the range, emit a GitHub Actions ::warning:: directive so the workflow
+// summary surfaces the gap. Designer can then decide whether to widen the
+// range in vendored.json. No side effects beyond stdout.
+//
+// Returns true when a warning was emitted; false otherwise (useful for tests).
+// Design E in project_sync_pipeline_improvements_2026_05_13.md +
+// project_vendor_stable_channel_architecture.md.
+function notifyIfNewerAvailable(tags, currentRange, resolvedTag) {
+  var allVersions = tags
+    .map(function (t) {
+      return String(t).replace(/^v/, "");
+    })
+    .filter(function (v) {
+      return /^[0-9]+\.[0-9]+\.[0-9]+$/.test(v);
+    });
+  if (allVersions.length === 0) return false;
+  allVersions.sort(compareSemver);
+  var highest = allVersions[allVersions.length - 1];
+  var resolved = String(resolvedTag).replace(/^v/, "");
+  if (highest === resolved) return false;
+  process.stdout.write(
+    "::warning::Newer knowledge release available: v" +
+      highest +
+      " (current range '" +
+      currentRange +
+      "' resolves to v" +
+      resolved +
+      "). Update vendored.json#knowledge_repo_version_range when ready to adopt.\n",
+  );
+  return true;
+}
+
+// Fetch all tags from a public GitHub repo via the API. No auth needed
+// for public repos; uses curl which is always available in CI runners.
+function fetchTagsFromGitHub(repo) {
+  var url = "https://api.github.com/repos/" + repo + "/tags?per_page=100";
+  var raw = execFileSync("curl", ["-sSL", url], { encoding: "utf8" });
+  var parsed = JSON.parse(raw);
+  if (!Array.isArray(parsed)) {
+    throw new Error(
+      "GitHub tags API returned non-array: " +
+        JSON.stringify(parsed).slice(0, 200),
+    );
+  }
+  return parsed.map(function (t) {
+    return t.name;
+  });
+}
+
+// Resolve a tag name → COMMIT SHA via GitHub API. Tag must exist.
+// Handles lightweight tags (object.type === "commit") AND annotated tags
+// (object.type === "tag", requires a second hop to dereference to commit).
+function resolveTagSha(repo, tag) {
+  var versionOnly = tag.replace(/^v/, "");
+  var refUrl =
+    "https://api.github.com/repos/" + repo + "/git/refs/tags/v" + versionOnly;
+  var rawRef = execFileSync("curl", ["-sSL", refUrl], { encoding: "utf8" });
+  var parsedRef = JSON.parse(rawRef);
+  if (!parsedRef || !parsedRef.object || !parsedRef.object.sha) {
+    throw new Error(
+      "Cannot resolve tag '" +
+        tag +
+        "' to SHA. Response: " +
+        rawRef.slice(0, 200),
+    );
+  }
+  // Lightweight tag — points directly at a commit.
+  if (parsedRef.object.type !== "tag") {
+    return parsedRef.object.sha;
+  }
+  // Annotated tag — dereference the tag object to get the commit SHA.
+  var tagUrl =
+    "https://api.github.com/repos/" +
+    repo +
+    "/git/tags/" +
+    parsedRef.object.sha;
+  var rawTag = execFileSync("curl", ["-sSL", tagUrl], { encoding: "utf8" });
+  var parsedTag = JSON.parse(rawTag);
+  if (!parsedTag || !parsedTag.object || !parsedTag.object.sha) {
+    throw new Error(
+      "Cannot dereference annotated tag '" +
+        tag +
+        "' to commit SHA. Response: " +
+        rawTag.slice(0, 200),
+    );
+  }
+  return parsedTag.object.sha;
+}
+
+// Read the pinned vendor manifest, or a minimal default if none exists yet.
+// (Parameterized: vendoredJsonPath + knowledgeRepo come from config.)
+function readVendoredJson(vendoredJsonPath, knowledgeRepo) {
+  if (!fs.existsSync(vendoredJsonPath)) {
+    return {
+      knowledge_repo: knowledgeRepo,
+      knowledge_repo_sha: null,
+    };
+  }
+  return JSON.parse(fs.readFileSync(vendoredJsonPath, "utf8"));
+}
+
+// (Parameterized: vendoredJsonPath comes from config.)
+function writeVendoredJson(vendoredJsonPath, data) {
+  fs.writeFileSync(vendoredJsonPath, JSON.stringify(data, null, 2) + "\n");
+}
+
+// (Parameterized: repo comes from config.)
+function fetchTarball(repo, sha, destPath) {
+  // GitHub returns a tarball at this URL for any SHA on a public repo. No auth
+  // needed. The .tar.gz contains a single top-level directory like
+  // `actian-ds-knowledge-<full-sha>/` with the repo content inside.
+  var url = "https://github.com/" + repo + "/archive/" + sha + ".tar.gz";
+  process.stdout.write("[vendor] fetching " + url + "\n");
+  execFileSync("curl", ["-sSL", "-o", destPath, url], { stdio: "inherit" });
+}
+
+function extractTarball(tarballPath, destDir) {
+  fs.mkdirSync(destDir, { recursive: true });
+  execFileSync("tar", ["-xzf", tarballPath, "-C", destDir], {
+    stdio: "inherit",
+  });
+  // After extraction, destDir contains a single subdir like
+  // `actian-ds-knowledge-<sha>/`. Return its absolute path.
+  var entries = fs.readdirSync(destDir).filter(function (e) {
+    return fs.statSync(path.join(destDir, e)).isDirectory();
+  });
+  if (entries.length !== 1) {
+    throw new Error(
+      "[vendor] expected exactly one top-level dir in tarball, got " +
+        entries.length,
+    );
+  }
+  return path.join(destDir, entries[0]);
+}
+
+function copyDirectory(src, dest) {
+  fs.mkdirSync(dest, { recursive: true });
+  var entries = fs.readdirSync(src, { withFileTypes: true });
+  for (var i = 0; i < entries.length; i++) {
+    var entry = entries[i];
+    var srcPath = path.join(src, entry.name);
+    var destPath = path.join(dest, entry.name);
+    if (entry.isDirectory()) {
+      copyDirectory(srcPath, destPath);
+    } else {
+      fs.copyFileSync(srcPath, destPath);
+    }
+  }
+}
+
+// (Parameterized: vendorDir comes from config.)
+function clearVendorDir(vendorDir) {
+  if (!fs.existsSync(vendorDir)) return;
+  fs.rmSync(vendorDir, { recursive: true, force: true });
+}
+
+// Read the substrate's distributable-surface declaration from the extracted
+// tarball. Returns a Set of allowed top-level entry names, or null if the
+// declaration is absent/malformed (old pins pre vendor-include.json → caller
+// falls back to the legacy excludeSet behavior).
+function readVendorInclude(extractedRepoRoot) {
+  var p = path.join(extractedRepoRoot, "vendor-include.json");
+  if (!fs.existsSync(p)) return null;
+  try {
+    var decl = JSON.parse(fs.readFileSync(p, "utf8"));
+    if (decl && Array.isArray(decl.include)) return new Set(decl.include);
+  } catch (e) {
+    /* malformed → fall back */
+  }
+  return null;
+}
+
+// Decide which top-level entries to vendor. Inclusion-first: if the substrate
+// declared an include-set, copy ONLY those (tooling is structurally absent).
+// Otherwise fall back to the legacy exclude-set.
+function selectEntries(names, includeSet, excludeSet) {
+  return names.filter(function (name) {
+    // Inclusion-first. In the legacy exclude-fallback branch, tolerate an
+    // absent excludeSet (a consumer that omits config.excludeTopLevel) — treat
+    // it as "no exclusions" rather than throwing on excludeSet.has(...).
+    return includeSet
+      ? includeSet.has(name)
+      : !(excludeSet && excludeSet.has(name));
+  });
+}
+
+// (Parameterized: vendorDir + excludeSet come from config.)
+function vendorContent(extractedRepoRoot, vendorDir, excludeSet) {
+  fs.mkdirSync(vendorDir, { recursive: true });
+  var includeSet = readVendorInclude(extractedRepoRoot);
+  if (includeSet) {
+    process.stdout.write(
+      "[vendor] inclusion mode — copying " +
+        includeSet.size +
+        " declared entries (vendor-include.json)\n",
+    );
+  } else {
+    process.stdout.write(
+      "[vendor] exclusion mode (no vendor-include.json in snapshot — legacy pin)\n",
+    );
+  }
+  var allNames = fs
+    .readdirSync(extractedRepoRoot, { withFileTypes: true })
+    .map(function (e) {
+      return e.name;
+    });
+  var selected = selectEntries(allNames, includeSet, excludeSet);
+  var vendored = [];
+  for (var i = 0; i < selected.length; i++) {
+    var name = selected[i];
+    var srcPath = path.join(extractedRepoRoot, name);
+    var destPath = path.join(vendorDir, name);
+    if (fs.statSync(srcPath).isDirectory()) {
+      copyDirectory(srcPath, destPath);
+    } else {
+      fs.copyFileSync(srcPath, destPath);
+    }
+    vendored.push(name);
+  }
+  return vendored;
+}
+
+// Config-driven entry. config = { knowledgeRepo, vendorDir, vendoredJsonPath,
+// excludeTopLevel, postVendorHook }. argv defaults to process.argv.slice(2)
+// (passed explicitly in tests).
+//
+// Contract (the consumer's thin wrapper owns the CLI shell — see clients/README):
+//   - No require.main block + NO process.exit here. On a fatal condition
+//     (no in-range tag, no resolvable SHA) the library THROWS; the wrapper's
+//     try/catch prints "[vendor] FATAL: <msg>" and exits non-zero. (The plugin's
+//     original main() exit(1)'d these inline; relocating the exit to the wrapper
+//     is the design — non-zero abort is preserved, the message is unchanged.)
+//   - postVendorHook() runs after a successful vendor copy, before "[vendor] OK":
+//     throw from it to abort, or set process.exitCode inside it for the plugin's
+//     "warn + non-zero exit, don't roll back" renderer semantics (respected — the
+//     snapshot is already on disk).
+//   - Returns { resolvedVersion, resolvedRange, sha } so a consumer (e.g. docs'
+//     GITHUB_ENV append) can read the resolution without re-parsing vendored.json.
+function runSnapshot(config, argv) {
+  var args = parseArgs(argv || process.argv.slice(2));
+  var current = readVendoredJson(config.vendoredJsonPath, config.knowledgeRepo);
+
+  // Move A2: tag-range resolution. Precedence:
+  //   1. --sha <sha>     → use SHA directly (back-compat for manual override)
+  //   2. --range <range> → resolve via that range
+  //   3. vendored.json.knowledge_repo_version_range → resolve via stored range
+  //   4. vendored.json.knowledge_repo_sha → legacy fallback (deprecated)
+  var sha = args.sha;
+  var resolvedVersion = null;
+  var resolvedRange =
+    args.range || current.knowledge_repo_version_range || null;
+
+  if (!sha && resolvedRange) {
+    var tags = fetchTagsFromGitHub(config.knowledgeRepo);
+    var matchedTag = resolveTargetTag(tags, resolvedRange);
+    if (!matchedTag) {
+      throw new Error(
+        "[vendor] no tag matches range '" +
+          resolvedRange +
+          "'. Available: " +
+          tags.join(", "),
+      );
+    }
+    sha = resolveTagSha(config.knowledgeRepo, matchedTag);
+    resolvedVersion = matchedTag;
+    process.stdout.write(
+      "[vendor] resolved range '" +
+        resolvedRange +
+        "' → " +
+        matchedTag +
+        " (" +
+        sha.slice(0, 7) +
+        ")\n",
+    );
+    // Surface a workflow warning if a newer-tag exists outside the range.
+    // Lets designers see range staleness in the CI summary instead of
+    // discovering it via user-reported drift (today's failure mode).
+    notifyIfNewerAvailable(tags, resolvedRange, matchedTag);
+  }
+
+  if (!sha) {
+    sha = current.knowledge_repo_sha; // legacy fallback
+  }
+
+  if (!sha) {
+    throw new Error(
+      "[vendor] no SHA available — pass --sha, --range, or set knowledge_repo_version_range in vendored.json",
+    );
+  }
+
+  if (args.resolveOnly) {
+    process.stdout.write("range=" + (resolvedRange || "") + "\n");
+    process.stdout.write("version=" + (resolvedVersion || "") + "\n");
+    process.stdout.write("sha=" + sha + "\n");
+    return {
+      resolvedVersion: resolvedVersion,
+      resolvedRange: resolvedRange,
+      sha: sha,
+    };
+  }
+
+  // Fetch + extract into a tempdir so we don't pollute the consumer tree on
+  // failure.
+  var tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), "vendor-snapshot-"));
+  var tarballPath = path.join(tmpRoot, "snapshot.tar.gz");
+
+  try {
+    fetchTarball(config.knowledgeRepo, sha, tarballPath);
+    var extractedRoot = extractTarball(tarballPath, tmpRoot);
+    process.stdout.write("[vendor] extracted to " + extractedRoot + "\n");
+
+    clearVendorDir(config.vendorDir);
+    var vendored = vendorContent(
+      extractedRoot,
+      config.vendorDir,
+      config.excludeTopLevel,
+    );
+    process.stdout.write(
+      "[vendor] copied " + vendored.length + " top-level entries:\n",
+    );
+    vendored.forEach(function (e) {
+      process.stdout.write("  - " + e + "\n");
+    });
+
+    var manifest = {
+      knowledge_repo: config.knowledgeRepo,
+      knowledge_repo_version_range: resolvedRange || null,
+      knowledge_repo_resolved_version: resolvedVersion || null,
+      knowledge_repo_resolved_sha: sha,
+      vendored_at: new Date().toISOString(),
+      vendored_entries: vendored.sort(),
+      excluded_entries: Array.from(config.excludeTopLevel || []).sort(),
+      vendor_url: resolvedVersion
+        ? "https://github.com/" +
+          config.knowledgeRepo +
+          "/tree/" +
+          resolvedVersion
+        : "https://github.com/" + config.knowledgeRepo + "/tree/" + sha,
+    };
+    writeVendoredJson(config.vendoredJsonPath, manifest);
+    process.stdout.write("[vendor] wrote " + config.vendoredJsonPath + "\n");
+
+    // Consumer-specific post-vendor step (e.g. the plugin regenerates its
+    // component mirrors). Replaces the plugin's runComponentReferenceRenderer().
+    if (config.postVendorHook) config.postVendorHook();
+
+    process.stdout.write("[vendor] OK\n");
+    return {
+      resolvedVersion: resolvedVersion,
+      resolvedRange: resolvedRange,
+      sha: sha,
+    };
+  } finally {
+    fs.rmSync(tmpRoot, { recursive: true, force: true });
+  }
+}
+
+module.exports = {
+  runSnapshot: runSnapshot,
+  parseArgs: parseArgs,
+  matchesRange: matchesRange,
+  compareSemver: compareSemver,
+  resolveTargetTag: resolveTargetTag,
+  notifyIfNewerAvailable: notifyIfNewerAvailable,
+  selectEntries: selectEntries,
+  readVendorInclude: readVendorInclude,
+  readVendoredJson: readVendoredJson,
+};

--- a/plugins/actian-design-system/scripts/vendor/vendor-snapshot.js
+++ b/plugins/actian-design-system/scripts/vendor/vendor-snapshot.js
@@ -117,6 +117,12 @@ if (require.main === module) {
       postVendorHook: runComponentReferenceRenderer,
     });
   } catch (err) {
+    // exit 2 = any fatal vendor error. The core THROWS the unrecoverable
+    // conditions (no in-range tag / no resolvable SHA) that the pre-shared-client
+    // main() exit(1)'d inline; they now flow here, joining other thrown errors
+    // under one fatal code. (The renderer-warning path is separate: postVendorHook
+    // sets exitCode=1 without throwing — vendor stays on disk.) CI fails on any
+    // non-zero, so the 1→2 shift for those two conditions is immaterial there.
     process.stderr.write("[vendor] FATAL: " + err.message + "\n");
     process.exit(2);
   }

--- a/plugins/actian-design-system/scripts/vendor/vendor-snapshot.js
+++ b/plugins/actian-design-system/scripts/vendor/vendor-snapshot.js
@@ -2,35 +2,41 @@
 "use strict";
 
 // Federation Phase 1.4a — vendor a snapshot of the actian-ds-knowledge repo
-// into plugins/actian-design-system/vendor/. Reads the pinned SHA from
-// vendored.json, downloads the GitHub tarball at that SHA, extracts the
-// content (excluding the knowledge repo's own scripts/, .github/, package
-// manifests, and meta files), and copies it into vendor/.
+// into plugins/actian-design-system/vendor/.
+//
+// THIN ENTRY over the substrate's shared snapshot core. The generic mechanics
+// (range-resolve → fetch tarball → include-select → copy → write vendored.json)
+// live in the canonical vendor/clients/vendor-snapshot.js, COPIED here as
+// vendor-snapshot-core.js and byte-identity-guarded by
+// tests/vendor/vendor-snapshot-core-drift.test.js — a build tool must not
+// import the bundle it produces (bootstrap + safety). This entry owns only the
+// plugin-specific bits: the vendor target/dir, the legacy exclude-set, the
+// post-vendor component-mirror regeneration (postVendorHook), and the
+// require.main / FATAL CLI shell.
 //
 // Usage:
-//   node scripts/vendor/vendor-snapshot.js               (pulls SHA from vendored.json)
-//   node scripts/vendor/vendor-snapshot.js --sha <sha>   (override SHA, also rewrites vendored.json)
+//   node scripts/vendor/vendor-snapshot.js               (range from vendored.json)
+//   node scripts/vendor/vendor-snapshot.js --sha <sha>   (override SHA)
+//   node scripts/vendor/vendor-snapshot.js --range <r>   (override the range)
+//   node scripts/vendor/vendor-snapshot.js --resolve-only
 //
-// Phase 1.5 (shipped) rewrote all consumer paths to read from vendor/
-// — the plugin no longer maintains its own docs/ or tokens/ trees.
-// vendored.json#knowledge_repo_sha pins the snapshot; vendor-snapshot.yml
+// vendored.json#knowledge_repo_version_range pins the snapshot; vendor-snapshot.yml
 // refreshes it nightly and bumps plugin.json patch on diff.
 
 var fs = require("fs");
 var path = require("path");
-var os = require("os");
-var { execFileSync, spawnSync } = require("child_process");
+var { spawnSync } = require("child_process");
+var core = require("./vendor-snapshot-core.js");
 
 var PLUGIN_ROOT = path.resolve(__dirname, "..", "..");
 var VENDORED_JSON_PATH = path.join(PLUGIN_ROOT, "vendored.json");
 var VENDOR_DIR = path.join(PLUGIN_ROOT, "vendor");
 var KNOWLEDGE_REPO = "volivarii/actian-ds-knowledge";
 
-// Top-level entries in the knowledge repo NOT to vendor — knowledge-repo's
-// own infrastructure (CI scripts, workflows, package manifests, meta files)
-// + contributor-facing docs (CLAUDE.md, AGENTS.md, etc.) have no place
-// inside the plugin. Consumers reference logical names via
-// vendor/paths-manifest.json, which IS vendored.
+// Legacy exclude-set — top-level entries in the knowledge repo NOT to vendor.
+// Only consulted when a pinned snapshot predates vendor-include.json (the core
+// prefers the substrate's declared include-set). Still passed because it also
+// populates vendored.json#excluded_entries (the core stamps it verbatim).
 var EXCLUDE_TOP_LEVEL = new Set([
   ".git",
   ".github",
@@ -56,256 +62,13 @@ var EXCLUDE_TOP_LEVEL = new Set([
   "CODEOWNERS",
 ]);
 
-function parseArgs(argv) {
-  var out = {};
-  for (var i = 0; i < argv.length; i++) {
-    if (argv[i] === "--sha") out.sha = argv[++i];
-    // Move A2: resolve via semver range (e.g., "~0.1.0") instead of SHA.
-    // Range is read from vendored.json.knowledge_repo_version_range when
-    // --range is passed without a value (or omit --range entirely).
-    else if (argv[i] === "--range") out.range = argv[++i];
-    // Resolve-only mode: print the resolved tag + SHA and exit. Used by
-    // vendor-snapshot.yml to log which tag it's about to pull.
-    else if (argv[i] === "--resolve-only") out.resolveOnly = true;
-  }
-  return out;
-}
-
-// Pure semver range resolver. Supports tilde (~), caret (^), and exact
-// version strings. Pre-1.0 caret behaves like tilde (patches only) per
-// npm convention.
-function matchesRange(version, range) {
-  var parseV = function (v) {
-    return String(v).split(".").map(Number);
-  };
-  var trimmed = String(range).trim();
-  var reqMajor, reqMinor, reqPatch;
-  if (trimmed.charAt(0) === "~") {
-    var parts = parseV(trimmed.slice(1));
-    reqMajor = parts[0];
-    reqMinor = parts[1];
-    reqPatch = parts[2] || 0;
-    var v = parseV(version);
-    return v[0] === reqMajor && v[1] === reqMinor && v[2] >= reqPatch;
-  }
-  if (trimmed.charAt(0) === "^") {
-    var cparts = parseV(trimmed.slice(1));
-    reqMajor = cparts[0];
-    reqMinor = cparts[1];
-    reqPatch = cparts[2] || 0;
-    var cv = parseV(version);
-    if (reqMajor === 0) {
-      // Pre-1.0: caret = tilde (only patches)
-      return cv[0] === reqMajor && cv[1] === reqMinor && cv[2] >= reqPatch;
-    }
-    return (
-      cv[0] === reqMajor &&
-      (cv[1] > reqMinor || (cv[1] === reqMinor && cv[2] >= reqPatch))
-    );
-  }
-  // Less-than operators (<X.Y.Z, <=X.Y.Z). Lets consumers opt into
-  // "anything up to the next major" without per-minor re-pin (Design E in
-  // project_sync_pipeline_improvements_2026_05_13.md). Compound ranges
-  // (>=A.B.C <X.Y.Z) intentionally not supported — keep the parser small;
-  // floors are theoretical for forward-only knowledge tags.
-  var ltMatch = trimmed.match(/^<(=?)\s*(\d+\.\d+\.\d+)$/);
-  if (ltMatch) {
-    var inclusive = ltMatch[1] === "=";
-    var cmp = compareSemver(version, ltMatch[2]);
-    return inclusive ? cmp <= 0 : cmp < 0;
-  }
-  return version === trimmed;
-}
-
-// Compare two semver strings; returns -1, 0, or 1.
-function compareSemver(a, b) {
-  var pa = String(a).split(".").map(Number);
-  var pb = String(b).split(".").map(Number);
-  for (var i = 0; i < 3; i++) {
-    if (pa[i] !== pb[i]) return pa[i] - pb[i] < 0 ? -1 : 1;
-  }
-  return 0;
-}
-
-// Filter, validate, and select the highest tag matching a range.
-// Returns the tag name (with "v" prefix) or null.
-function resolveTargetTag(tags, range) {
-  var candidates = tags
-    .map(function (t) {
-      return String(t).replace(/^v/, "");
-    })
-    .filter(function (v) {
-      // Strict semver (X.Y.Z numeric), no pre-release suffix
-      return /^[0-9]+\.[0-9]+\.[0-9]+$/.test(v);
-    })
-    .filter(function (v) {
-      return matchesRange(v, range);
-    });
-  if (candidates.length === 0) return null;
-  candidates.sort(compareSemver);
-  return "v" + candidates[candidates.length - 1];
-}
-
-// Compare the resolved tag against the highest available tag across ALL
-// strict-semver tags (regardless of range). If a newer tag exists outside
-// the range, emit a GitHub Actions ::warning:: directive so the workflow
-// summary surfaces the gap. Designer can then decide whether to widen the
-// range in vendored.json. No side effects beyond stdout.
-//
-// Returns true when a warning was emitted; false otherwise (useful for tests).
-// Design E in project_sync_pipeline_improvements_2026_05_13.md +
-// project_vendor_stable_channel_architecture.md.
-function notifyIfNewerAvailable(tags, currentRange, resolvedTag) {
-  var allVersions = tags
-    .map(function (t) {
-      return String(t).replace(/^v/, "");
-    })
-    .filter(function (v) {
-      return /^[0-9]+\.[0-9]+\.[0-9]+$/.test(v);
-    });
-  if (allVersions.length === 0) return false;
-  allVersions.sort(compareSemver);
-  var highest = allVersions[allVersions.length - 1];
-  var resolved = String(resolvedTag).replace(/^v/, "");
-  if (highest === resolved) return false;
-  process.stdout.write(
-    "::warning::Newer knowledge release available: v" +
-      highest +
-      " (current range '" +
-      currentRange +
-      "' resolves to v" +
-      resolved +
-      "). Update vendored.json#knowledge_repo_version_range when ready to adopt.\n",
-  );
-  return true;
-}
-
-// Fetch all tags from a public GitHub repo via the API. No auth needed
-// for public repos; uses curl which is always available in CI runners.
-function fetchTagsFromGitHub(repo) {
-  var url = "https://api.github.com/repos/" + repo + "/tags?per_page=100";
-  var raw = execFileSync("curl", ["-sSL", url], { encoding: "utf8" });
-  var parsed = JSON.parse(raw);
-  if (!Array.isArray(parsed)) {
-    throw new Error(
-      "GitHub tags API returned non-array: " +
-        JSON.stringify(parsed).slice(0, 200),
-    );
-  }
-  return parsed.map(function (t) {
-    return t.name;
-  });
-}
-
-// Resolve a tag name → COMMIT SHA via GitHub API. Tag must exist.
-// Handles lightweight tags (object.type === "commit") AND annotated tags
-// (object.type === "tag", requires a second hop to dereference to commit).
-function resolveTagSha(repo, tag) {
-  var versionOnly = tag.replace(/^v/, "");
-  var refUrl =
-    "https://api.github.com/repos/" + repo + "/git/refs/tags/v" + versionOnly;
-  var rawRef = execFileSync("curl", ["-sSL", refUrl], { encoding: "utf8" });
-  var parsedRef = JSON.parse(rawRef);
-  if (!parsedRef || !parsedRef.object || !parsedRef.object.sha) {
-    throw new Error(
-      "Cannot resolve tag '" +
-        tag +
-        "' to SHA. Response: " +
-        rawRef.slice(0, 200),
-    );
-  }
-  // Lightweight tag — points directly at a commit.
-  if (parsedRef.object.type !== "tag") {
-    return parsedRef.object.sha;
-  }
-  // Annotated tag — dereference the tag object to get the commit SHA.
-  var tagUrl =
-    "https://api.github.com/repos/" +
-    repo +
-    "/git/tags/" +
-    parsedRef.object.sha;
-  var rawTag = execFileSync("curl", ["-sSL", tagUrl], { encoding: "utf8" });
-  var parsedTag = JSON.parse(rawTag);
-  if (!parsedTag || !parsedTag.object || !parsedTag.object.sha) {
-    throw new Error(
-      "Cannot dereference annotated tag '" +
-        tag +
-        "' to commit SHA. Response: " +
-        rawTag.slice(0, 200),
-    );
-  }
-  return parsedTag.object.sha;
-}
-
-function readVendoredJson() {
-  if (!fs.existsSync(VENDORED_JSON_PATH)) {
-    return {
-      knowledge_repo: KNOWLEDGE_REPO,
-      knowledge_repo_sha: null,
-    };
-  }
-  return JSON.parse(fs.readFileSync(VENDORED_JSON_PATH, "utf8"));
-}
-
-function writeVendoredJson(data) {
-  fs.writeFileSync(VENDORED_JSON_PATH, JSON.stringify(data, null, 2) + "\n");
-}
-
-function fetchTarball(sha, destPath) {
-  // GitHub returns a tarball at this URL for any SHA on a public repo. No auth
-  // needed. The .tar.gz contains a single top-level directory like
-  // `actian-ds-knowledge-<full-sha>/` with the repo content inside.
-  var url =
-    "https://github.com/" + KNOWLEDGE_REPO + "/archive/" + sha + ".tar.gz";
-  process.stdout.write("[vendor] fetching " + url + "\n");
-  execFileSync("curl", ["-sSL", "-o", destPath, url], { stdio: "inherit" });
-}
-
-function extractTarball(tarballPath, destDir) {
-  fs.mkdirSync(destDir, { recursive: true });
-  execFileSync("tar", ["-xzf", tarballPath, "-C", destDir], {
-    stdio: "inherit",
-  });
-  // After extraction, destDir contains a single subdir like
-  // `actian-ds-knowledge-<sha>/`. Return its absolute path.
-  var entries = fs.readdirSync(destDir).filter(function (e) {
-    return fs.statSync(path.join(destDir, e)).isDirectory();
-  });
-  if (entries.length !== 1) {
-    throw new Error(
-      "[vendor] expected exactly one top-level dir in tarball, got " +
-        entries.length,
-    );
-  }
-  return path.join(destDir, entries[0]);
-}
-
-function copyDirectory(src, dest) {
-  fs.mkdirSync(dest, { recursive: true });
-  var entries = fs.readdirSync(src, { withFileTypes: true });
-  for (var i = 0; i < entries.length; i++) {
-    var entry = entries[i];
-    var srcPath = path.join(src, entry.name);
-    var destPath = path.join(dest, entry.name);
-    if (entry.isDirectory()) {
-      copyDirectory(srcPath, destPath);
-    } else {
-      fs.copyFileSync(srcPath, destPath);
-    }
-  }
-}
-
-function clearVendorDir() {
-  if (!fs.existsSync(VENDOR_DIR)) return;
-  fs.rmSync(VENDOR_DIR, { recursive: true, force: true });
-}
-
-// CI parity: vendor-snapshot.yml runs render-component-reference.js as a
-// separate step AFTER the snapshot copy to regenerate the three plugin-side
+// CI parity (postVendorHook): vendor-snapshot.yml runs render-component-reference.js
+// as a separate step AFTER the snapshot copy to regenerate the three plugin-side
 // component mirrors (dskit-components.md, fm-components.md, meta-kit/
-// components.md). Local invocations of this script bypassed that step and
-// left fresh clones with missing mirrors, which broke path-validation
-// tests. Run the renderer here so CI and local behave identically.
+// components.md). Local invocations bypassed that step and left fresh clones with
+// missing mirrors, which broke path-validation tests. The core runs this hook at
+// the same point (after vendored.json is written, before "[vendor] OK") so CI and
+// local behave identically.
 //
 // If the renderer fails, the vendor tree on disk is still useful — we log a
 // warning and set a non-zero exitCode rather than rolling back.
@@ -344,187 +107,30 @@ function runComponentReferenceRenderer() {
   return true;
 }
 
-// Read the substrate's distributable-surface declaration from the extracted
-// tarball. Returns a Set of allowed top-level entry names, or null if the
-// declaration is absent/malformed (old pins pre vendor-include.json → caller
-// falls back to the legacy EXCLUDE_TOP_LEVEL behavior).
-function readVendorInclude(extractedRepoRoot) {
-  var p = path.join(extractedRepoRoot, "vendor-include.json");
-  if (!fs.existsSync(p)) return null;
-  try {
-    var decl = JSON.parse(fs.readFileSync(p, "utf8"));
-    if (decl && Array.isArray(decl.include)) return new Set(decl.include);
-  } catch (e) {
-    /* malformed → fall back */
-  }
-  return null;
-}
-
-// Decide which top-level entries to vendor. Inclusion-first: if the substrate
-// declared an include-set, copy ONLY those (tooling is structurally absent).
-// Otherwise fall back to the legacy exclude-set.
-function selectEntries(names, includeSet, excludeSet) {
-  return names.filter(function (name) {
-    return includeSet ? includeSet.has(name) : !excludeSet.has(name);
-  });
-}
-
-function vendorContent(extractedRepoRoot) {
-  fs.mkdirSync(VENDOR_DIR, { recursive: true });
-  var includeSet = readVendorInclude(extractedRepoRoot);
-  if (includeSet) {
-    process.stdout.write(
-      "[vendor] inclusion mode — copying " +
-        includeSet.size +
-        " declared entries (vendor-include.json)\n",
-    );
-  } else {
-    process.stdout.write(
-      "[vendor] exclusion mode (no vendor-include.json in snapshot — legacy pin)\n",
-    );
-  }
-  var allNames = fs
-    .readdirSync(extractedRepoRoot, { withFileTypes: true })
-    .map(function (e) {
-      return e.name;
-    });
-  var selected = selectEntries(allNames, includeSet, EXCLUDE_TOP_LEVEL);
-  var vendored = [];
-  for (var i = 0; i < selected.length; i++) {
-    var name = selected[i];
-    var srcPath = path.join(extractedRepoRoot, name);
-    var destPath = path.join(VENDOR_DIR, name);
-    if (fs.statSync(srcPath).isDirectory()) {
-      copyDirectory(srcPath, destPath);
-    } else {
-      fs.copyFileSync(srcPath, destPath);
-    }
-    vendored.push(name);
-  }
-  return vendored;
-}
-
-function main() {
-  var args = parseArgs(process.argv.slice(2));
-  var current = readVendoredJson();
-
-  // Move A2: tag-range resolution. Precedence:
-  //   1. --sha <sha>     → use SHA directly (back-compat for manual override)
-  //   2. --range <range> → resolve via that range
-  //   3. vendored.json.knowledge_repo_version_range → resolve via stored range
-  //   4. vendored.json.knowledge_repo_sha → legacy fallback (deprecated)
-  var sha = args.sha;
-  var resolvedVersion = null;
-  var resolvedRange =
-    args.range || current.knowledge_repo_version_range || null;
-
-  if (!sha && resolvedRange) {
-    var tags = fetchTagsFromGitHub(KNOWLEDGE_REPO);
-    var matchedTag = resolveTargetTag(tags, resolvedRange);
-    if (!matchedTag) {
-      process.stderr.write(
-        "[vendor] no tag matches range '" +
-          resolvedRange +
-          "'. Available: " +
-          tags.join(", ") +
-          "\n",
-      );
-      process.exit(1);
-    }
-    sha = resolveTagSha(KNOWLEDGE_REPO, matchedTag);
-    resolvedVersion = matchedTag;
-    process.stdout.write(
-      "[vendor] resolved range '" +
-        resolvedRange +
-        "' → " +
-        matchedTag +
-        " (" +
-        sha.slice(0, 7) +
-        ")\n",
-    );
-    // Surface a workflow warning if a newer-tag exists outside the range.
-    // Lets designers see range staleness in the CI summary instead of
-    // discovering it via user-reported drift (today's failure mode).
-    notifyIfNewerAvailable(tags, resolvedRange, matchedTag);
-  }
-
-  if (!sha) {
-    sha = current.knowledge_repo_sha; // legacy fallback
-  }
-
-  if (!sha) {
-    process.stderr.write(
-      "[vendor] no SHA available — pass --sha, --range, or set knowledge_repo_version_range in vendored.json\n",
-    );
-    process.exit(1);
-  }
-
-  if (args.resolveOnly) {
-    process.stdout.write("range=" + (resolvedRange || "") + "\n");
-    process.stdout.write("version=" + (resolvedVersion || "") + "\n");
-    process.stdout.write("sha=" + sha + "\n");
-    return;
-  }
-
-  // Fetch + extract into a tempdir so we don't pollute the plugin tree on
-  // failure.
-  var tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), "vendor-snapshot-"));
-  var tarballPath = path.join(tmpRoot, "snapshot.tar.gz");
-
-  try {
-    fetchTarball(sha, tarballPath);
-    var extractedRoot = extractTarball(tarballPath, tmpRoot);
-    process.stdout.write("[vendor] extracted to " + extractedRoot + "\n");
-
-    clearVendorDir();
-    var vendored = vendorContent(extractedRoot);
-    process.stdout.write(
-      "[vendor] copied " + vendored.length + " top-level entries:\n",
-    );
-    vendored.forEach(function (e) {
-      process.stdout.write("  - " + e + "\n");
-    });
-
-    var manifest = {
-      knowledge_repo: KNOWLEDGE_REPO,
-      knowledge_repo_version_range: resolvedRange || null,
-      knowledge_repo_resolved_version: resolvedVersion || null,
-      knowledge_repo_resolved_sha: sha,
-      vendored_at: new Date().toISOString(),
-      vendored_entries: vendored.sort(),
-      excluded_entries: Array.from(EXCLUDE_TOP_LEVEL).sort(),
-      vendor_url: resolvedVersion
-        ? "https://github.com/" + KNOWLEDGE_REPO + "/tree/" + resolvedVersion
-        : "https://github.com/" + KNOWLEDGE_REPO + "/tree/" + sha,
-    };
-    writeVendoredJson(manifest);
-    process.stdout.write("[vendor] wrote " + VENDORED_JSON_PATH + "\n");
-
-    // CI/local parity — regenerate the three plugin-side component mirrors
-    // that vendor-snapshot.yml regenerates in a separate step.
-    runComponentReferenceRenderer();
-
-    process.stdout.write("[vendor] OK\n");
-  } finally {
-    fs.rmSync(tmpRoot, { recursive: true, force: true });
-  }
-}
-
 if (require.main === module) {
   try {
-    main();
+    core.runSnapshot({
+      knowledgeRepo: KNOWLEDGE_REPO,
+      vendorDir: VENDOR_DIR,
+      vendoredJsonPath: VENDORED_JSON_PATH,
+      excludeTopLevel: EXCLUDE_TOP_LEVEL,
+      postVendorHook: runComponentReferenceRenderer,
+    });
   } catch (err) {
     process.stderr.write("[vendor] FATAL: " + err.message + "\n");
     process.exit(2);
   }
 }
 
+// Public API preserved for consumers/tests: the pure range-resolution + include-
+// selection helpers, re-exported from the copied core (single source).
 module.exports = {
-  main: main,
-  matchesRange: matchesRange,
-  compareSemver: compareSemver,
-  resolveTargetTag: resolveTargetTag,
-  notifyIfNewerAvailable: notifyIfNewerAvailable,
-  selectEntries: selectEntries,
-  readVendorInclude: readVendorInclude,
+  runSnapshot: core.runSnapshot,
+  matchesRange: core.matchesRange,
+  compareSemver: core.compareSemver,
+  resolveTargetTag: core.resolveTargetTag,
+  notifyIfNewerAvailable: core.notifyIfNewerAvailable,
+  selectEntries: core.selectEntries,
+  readVendorInclude: core.readVendorInclude,
+  runComponentReferenceRenderer: runComponentReferenceRenderer,
 };

--- a/plugins/actian-design-system/tests/integration/no-bare-vendor-paths.test.js
+++ b/plugins/actian-design-system/tests/integration/no-bare-vendor-paths.test.js
@@ -19,6 +19,11 @@ const ALLOWLIST = new Set([
   "scripts/lib/paths.js",
   "scripts/vendor/vendor-snapshot.js",
 ]);
+// NOTE: walk() below skips any dir named "vendor" (see name === "vendor"), so
+// scripts/vendor/ is not scanned at all — both the entry above and the copied
+// vendor-snapshot-core.js are effectively unscanned here. The core stays
+// path-clean by being a byte-identical copy of the substrate's parameterized
+// canonical (no bare vendor paths by design), enforced by the drift-guard test.
 
 // Patterns that indicate a "bare vendor path" — references that should
 // route through PATHS but don't.
@@ -30,11 +35,7 @@ const BARE_PATTERNS = [
 function walk(dir, results) {
   const entries = fs.readdirSync(dir);
   for (const name of entries) {
-    if (
-      name === "node_modules" ||
-      name === "vendor" ||
-      name.startsWith(".")
-    ) {
+    if (name === "node_modules" || name === "vendor" || name.startsWith(".")) {
       continue;
     }
     const full = path.join(dir, name);
@@ -61,7 +62,9 @@ test("no bare vendor paths in plugin scripts", () => {
       const match = content.match(pattern);
       if (match) {
         const lineNum = content.slice(0, match.index).split("\n").length;
-        violations.push(rel + ":" + lineNum + " — bare vendor path: " + match[0]);
+        violations.push(
+          rel + ":" + lineNum + " — bare vendor path: " + match[0],
+        );
       }
     }
   }

--- a/plugins/actian-design-system/tests/vendor/vendor-snapshot-core-drift.test.js
+++ b/plugins/actian-design-system/tests/vendor/vendor-snapshot-core-drift.test.js
@@ -1,0 +1,26 @@
+"use strict";
+
+// Drift-guard: the plugin's vendor-snapshot is a thin entry over a COPIED core
+// (scripts/vendor/vendor-snapshot-core.js). A build tool must not import the
+// bundle it produces (bootstrap + safety), so instead of importing the vendored
+// canonical we copy it and assert byte-identity here. If a vendor refresh
+// changes the canonical, this fails until the copy is re-synced:
+//   cp vendor/clients/vendor-snapshot.js scripts/vendor/vendor-snapshot-core.js
+// See vendor/clients/README.md (shared consumption client).
+
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const path = require("node:path");
+
+const PLUGIN_ROOT = path.join(__dirname, "..", "..");
+const COPIED = path.join(PLUGIN_ROOT, "scripts", "vendor", "vendor-snapshot-core.js");
+const CANONICAL = path.join(PLUGIN_ROOT, "vendor", "clients", "vendor-snapshot.js");
+
+test("vendor-snapshot-core.js is byte-identical to the vendored canonical", function () {
+  assert.equal(
+    fs.readFileSync(COPIED, "utf8"),
+    fs.readFileSync(CANONICAL, "utf8"),
+    "scripts/vendor/vendor-snapshot-core.js drifted from vendor/clients/vendor-snapshot.js — re-copy it.",
+  );
+});


### PR DESCRIPTION
## Shared Consumption Client — Phase 2 (plugin adoption)

Adopts the substrate's `clients/` reference reader (shipped in knowledge **v0.26.0**, vendored via #127) so the plugin stops maintaining its own copies of the generic consumption mechanics. **Behavior-preserving** — 871/871 tests green, no data/output change.

### Two adoptions (spec §3.2 / §3.3)

1. **Resolver — import (single source).** `scripts/lib/paths.js` collapses to a thin wrapper that imports the generic manifest→PATHS walker (`buildPathsFromManifest` + `SUPPORTED_SCHEMA_VERSION`) from the vendored `vendor/clients/resolve-paths.js` instead of defining its own (~130 lines removed). The plugin-specific layers stay in the wrapper: `verifyVendorIntegrity` (still runs between parse and build), `normalizeVersion`, and the overlays (`components.mirrors`, `registries.byKit`, `content.bySlug`, `pluginRoot`/`vendor`/`foundations.distDir`). Same `PATHS` shape, same error messages, same exports — `tests/lib/paths.test.js` green unchanged.

2. **Snapshot — copy + drift-guard.** `scripts/vendor/vendor-snapshot.js` becomes a thin entry (plugin config + the component-mirror `postVendorHook` + the `require.main`/FATAL CLI shell) over `scripts/vendor/vendor-snapshot-core.js` — a **byte-identical copy** of the canonical `vendor/clients/vendor-snapshot.js`. A build tool must not import the bundle it produces (bootstrap + safety), so we copy and guard: `tests/vendor/vendor-snapshot-core-drift.test.js` fails CI if the copy drifts from the vendored canonical. The entry re-exports the range/include helpers the existing vendor tests import.

### Why no behavior change

- Resolver: the vendored core is the byte-faithful factor of the plugin's own former code (knowledge #207); the walker, schema check, and `paths.js:`-prefixed error messages are identical.
- Snapshot: `runComponentReferenceRenderer` is preserved verbatim and wired as `postVendorHook` (runs at the same point — after `vendored.json` is written, before `[vendor] OK`; keeps `exitCode=1`-on-failure). The `config` (`knowledgeRepo`/`vendorDir`/`vendoredJsonPath`/`excludeTopLevel`) maps 1:1 to the old module constants, so `vendored.json` + the `vendor/` tree are produced identically. One immaterial shift: the unrecoverable no-tag / no-SHA conditions now `throw` (the core owns no CLI) and exit **2** via the entry's catch instead of inline **1** — CI fails on any non-zero, and it's now consistent with the other fatal errors the original already exited 2 for.

### Review

A code-reviewer pass (read-only git) returned **Ready to merge — yes**, no Critical/behavioral issues. Two doc-gap findings applied: a comment explaining the exit-code semantics, and an accurate note that `walk()` skips `scripts/vendor/` wholesale (so the copied core isn't scanned by `no-bare-vendor-paths` — verified empirically; it stays path-clean by being a byte-identical copy of the parameterized canonical).

### Scope

- MINOR bump → **1.93.0** (feature adoption). Re-vendor #127 already brought `vendor/clients/`.
- Eliminates the duplicated resolver + snapshot mechanics (drift source). A future mechanism change is made once in the substrate's `clients/` and picked up on re-vendor (resolver) / re-sync (snapshot, drift-guard-enforced).
- Unblocks **Phase 3 (docs)** adoption (same pattern; docs also gains include-mode via it).

Spec: `…/specs/2026-06-02-shared-consumption-client-design.md`.
