### PR TITLE
feat(knowledge): a11y linked-criteria slice — sourced WCAG criteria in brief + companion (v1.94.0)

### DIFF
--- a/plugins/actian-design-system/.claude-plugin/plugin.json
+++ b/plugins/actian-design-system/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "actian-design-system",
-  "description": "Actian Design System toolkit — generate wireframe flows with prototype wiring, create component briefs, audit designs, compare flows, and build presentations. 8 skills (with tiered generation: recognized / adapted / improvised), 8 agents, 155 tokens (3 themes, 8 collections), WCAG 2.1 AA. DS knowledge vendored from volivarii/actian-ds-knowledge.",
-  "version": "1.93.5",
+  "description": "Actian Design System toolkit — generate wireframe flows with prototype wiring, create component briefs, audit designs, compare flows, and build presentations. 8 skills (with tiered generation: recognized / adapted / improvised), 8 agents, 155 tokens (3 themes, 8 collections), WCAG 2.2 AA. DS knowledge vendored from volivarii/actian-ds-knowledge.",
+  "version": "1.94.0",
   "author": {
     "name": "Actian UX Team"
   },

--- a/plugins/actian-design-system/CLAUDE.md
+++ b/plugins/actian-design-system/CLAUDE.md
@@ -114,7 +114,7 @@ Every output includes a generation card (first element) with: skill name, prompt
 
 - **Tokens:** `vendor/tokens/tokens.json` (source of truth). For HTML: bind to vendored `--zen-*` vars (brand primary = `var(--zen-color-primary-500)` = canonical `#0F5FDC`; links = `var(--zen-color-text-link-default)`), never hardcoded hex. *(There is no `--zen-color-theme-primary` in vendored tokens.)*
 - **Content guidelines:** `vendor/content/dist/global.md` (cross-cutting voice/tone/word rules) + `vendor/content/dist/words-to-avoid.json` (structured avoid-word rules for tooling; `PATHS.content.wordsToAvoid`) + per-component `vendor/components/dist/guidelines/<slug>.json` `domains.content`
-- **Accessibility:** `vendor/accessibility/src/<slug>.md` (per-section) — WCAG 2.1 AA
+- **Accessibility:** `vendor/accessibility/src/<slug>.md` (per-section) — WCAG 2.2 AA
 - **Never hardcode:** colors, fonts, spacing, radius, shadows, icons. Use tokens. FM outputs use `--fm-*` variables only.
 - **Component instances:** set ALL properties (variants, text, booleans, nested). See `references/ds-rules/component-instance-rules.md`.
 - **Library gaps:** check catalog before custom frames. See `references/ds-rules/library-gap-detection.md`.

--- a/plugins/actian-design-system/docs/llms-overview.md
+++ b/plugins/actian-design-system/docs/llms-overview.md
@@ -28,7 +28,7 @@ in sync via the plugin's `vendor-snapshot.yml` workflow.
 | Component guidelines | `vendor/components/dist/guidelines/<slug>.json` (`domains.*` shape) | `components/dist/guidelines/` | JSON | Per-component multi-domain merged docs |
 | Foundations | `vendor/foundations/src/<slug>.md` (per-section, ordered via `_order.json`) + `vendor/foundations/dist/*.json` | `foundations/src/` | MD + JSON | Spacing, typography, color, motion (8 derived) |
 | Content guidelines | `vendor/content/dist/global.md` + per-component `vendor/components/dist/guidelines/<slug>.json` `domains.content` | `content/` + `components/` | MD + JSON | Voice, tone, copy patterns |
-| Accessibility | `vendor/accessibility/src/<slug>.md` (per-section, ordered via `_order.json`) | `accessibility/src/` | MD | WCAG 2.1 AA conformance rules |
+| Accessibility | `vendor/accessibility/src/<slug>.md` (per-section, ordered via `_order.json`) | `accessibility/src/` | MD | WCAG 2.2 AA conformance rules |
 | App context | `vendor/app-context/app-context.json` | `app-context/` | JSON | Apps, entities, terminology, patterns |
 | FM↔DS map | `references/convert-to-hifi/fm-to-ds-map.json` | (plugin only) | JSON | Wireframe-to-DS component mapping (plugin-owned; Track E eviction) |
 | Skill behavior | `plugins/actian-design-system/skills/*/SKILL.md` | (plugin only) | MD | Per-skill instructions and references |

--- a/plugins/actian-design-system/examples/brief-data-example.json
+++ b/plugins/actian-design-system/examples/brief-data-example.json
@@ -416,7 +416,7 @@
   },
   "card8_accessibility": {
     "cardTitle": "Accessibility",
-    "cardSubtitle": "WCAG 2.1 AA requirements, keyboard, ARIA, and contrast",
+    "cardSubtitle": "WCAG 2.2 AA requirements, keyboard, ARIA, and contrast",
     "requirements": [
       {
         "title": "Default state: underlined",

--- a/plugins/actian-design-system/references/component-brief/data-schema.md
+++ b/plugins/actian-design-system/references/component-brief/data-schema.md
@@ -222,7 +222,7 @@ Sentence case for both, per Figma content guideline (section/page headers are se
 ```json
 {
   "cardTitle": "Accessibility",
-  "cardSubtitle": "WCAG 2.1 AA requirements, keyboard, ARIA, and contrast",
+  "cardSubtitle": "WCAG 2.2 AA requirements, keyboard, ARIA, and contrast",
   "requirements": [
     {
       "title": "Role & semantics",

--- a/plugins/actian-design-system/scripts/lib/knowledge/README.md
+++ b/plugins/actian-design-system/scripts/lib/knowledge/README.md
@@ -1,0 +1,43 @@
+# `scripts/lib/knowledge/` — consumer-side knowledge layer
+
+Reusable, render-agnostic queries over the vendored substrate. Skills consume
+these instead of re-reading raw `vendor/…` files ad-hoc. First member: `a11y.js`.
+
+## Helper contract
+
+Every helper in this directory MUST:
+
+1. **Resolve via `PATHS`** (`scripts/lib/paths.js`) — never hardcode `vendor/…`
+   literals. (Guarded by `tests/integration/no-bare-vendor-paths.test.js`.)
+2. **Return render-agnostic plain data** — no HTML/Figma shapes. Consumers
+   (HTML renderer, Figma push, companion answer) decide presentation.
+3. **Fail gracefully** — never throw on missing/unknown input. Return empty
+   collections + a `resolved` boolean so callers can fall back.
+4. **Be pure + unit-tested** — no MCP, no network; logic is testable against
+   the vendor snapshot.
+5. **Ship a CLI entry** (`if (require.main === module)`) printing JSON, so
+   agent surfaces (companion) and humans can query directly.
+
+## Members
+
+### `a11y.js`
+- `resolveLinkedCriteria(guidelinesJson, categoryDefaults)` — pure core; union of
+  component `meta.a11y_refs` and category `a11y_refs.requirementRefs`, deduped
+  (component wins), grouped `{ component, inherited, resolved }`.
+- `linkedCriteriaForComponent(slug, opts?)` — load-by-slug (or `opts.{guidelinesJson,
+  categoryDefaults}` to reuse already-loaded data).
+- `linkedCriteriaForCategory(categorySlug)` — inherited (foundation) criteria only.
+- CLI: `node a11y.js <slug>` | `node a11y.js --category=<slug>`.
+- Criterion shape: `{ slug, title, wcag: string[], tier, note?, excerpt? }`.
+
+## Phase-2 backlog (the pattern grows into these — see the 2026-06-02 absolute-knowledge spec)
+
+Each follows the contract above:
+- **content/usage helper** — "how should we display hints on inputs?" (per-component
+  `domains.content`/`usage` + global content guidelines).
+- **tokens helper** — token/spacing/color lookups over `tokens.json` + foundations.
+- **app-context helper** — Studio/Explorer/Administration context queries.
+- **graph / inverse-edge queries** — "which components reference WCAG 2.1.1 / this
+  token?" (consume the dormant `graph.json`).
+- **companion multi-domain routing** — route a free-text question to the right helper.
+- **design-audit consumer** — check a design against a component's linked criteria.

--- a/plugins/actian-design-system/scripts/lib/knowledge/a11y.js
+++ b/plugins/actian-design-system/scripts/lib/knowledge/a11y.js
@@ -1,0 +1,90 @@
+"use strict";
+
+/**
+ * knowledge/a11y.js — first member of the plugin's consumer-side knowledge layer.
+ *
+ * Resolves a component's linked WCAG criteria: the union of its own
+ * meta.a11y_refs (component-pattern tier) and its category's foundation
+ * a11y_refs.requirementRefs, resolved against the substrate a11y-index,
+ * deduped, grouped by provenance ("This component" / "Inherited from category"),
+ * render-agnostic. Reuses the substrate resolver in
+ * transformers/category-defaults-loader.js. See ./README.md for the contract.
+ */
+
+var fs = require("fs");
+var PATHS = require("../paths");
+var catLoader = require("../../transformers/category-defaults-loader");
+
+// Map a resolved a11y-index entry -> a render-agnostic Criterion.
+function toCriterion(entry, note) {
+  if (!entry) return null;
+  var c = {
+    slug: entry.slug,
+    title: entry.title || entry.slug,
+    wcag: Array.isArray(entry.wcag) ? entry.wcag : [],
+    tier: entry.tier || null,
+  };
+  if (entry.body_excerpt) c.excerpt = entry.body_excerpt;
+  if (note) c.note = note;
+  return c;
+}
+
+// Normalize a raw [{ref, note?}] list, dropping malformed entries.
+function refList(raw) {
+  if (!Array.isArray(raw)) return [];
+  var out = [];
+  for (var i = 0; i < raw.length; i++) {
+    var r = raw[i];
+    if (r && typeof r.ref === "string" && r.ref) {
+      out.push({ ref: r.ref, note: typeof r.note === "string" ? r.note : null });
+    }
+  }
+  return out;
+}
+
+// Pure core: given an already-loaded guideline doc + category defaults, return
+// grouped/deduped/resolved criteria. Component group wins on dedupe.
+function resolveLinkedCriteria(guidelinesJson, categoryDefaults) {
+  var componentRefs = refList(
+    guidelinesJson && guidelinesJson.meta && guidelinesJson.meta.a11y_refs,
+  );
+  var categoryRefs = refList(
+    categoryDefaults &&
+      categoryDefaults.a11y_refs &&
+      categoryDefaults.a11y_refs.requirementRefs,
+  );
+
+  var seen = {};
+  var component = [];
+  for (var i = 0; i < componentRefs.length; i++) {
+    var s = componentRefs[i].ref;
+    if (seen[s]) continue;
+    var crit = toCriterion(catLoader.resolveAccessibilityRef(s), componentRefs[i].note);
+    if (crit) {
+      component.push(crit);
+      seen[s] = true;
+    }
+  }
+
+  var inherited = [];
+  for (var j = 0; j < categoryRefs.length; j++) {
+    var cs = categoryRefs[j].ref;
+    if (seen[cs]) continue; // component group wins
+    var ccrit = toCriterion(catLoader.resolveAccessibilityRef(cs), categoryRefs[j].note);
+    if (ccrit) {
+      inherited.push(ccrit);
+      seen[cs] = true;
+    }
+  }
+
+  return {
+    component: component,
+    inherited: inherited,
+    resolved: component.length > 0 || inherited.length > 0,
+  };
+}
+
+module.exports = {
+  toCriterion: toCriterion,
+  resolveLinkedCriteria: resolveLinkedCriteria,
+};

--- a/plugins/actian-design-system/scripts/lib/knowledge/a11y.js
+++ b/plugins/actian-design-system/scripts/lib/knowledge/a11y.js
@@ -36,7 +36,10 @@ function refList(raw) {
   for (var i = 0; i < raw.length; i++) {
     var r = raw[i];
     if (r && typeof r.ref === "string" && r.ref) {
-      out.push({ ref: r.ref, note: typeof r.note === "string" ? r.note : null });
+      out.push({
+        ref: r.ref,
+        note: typeof r.note === "string" ? r.note : null,
+      });
     }
   }
   return out;
@@ -59,7 +62,10 @@ function resolveLinkedCriteria(guidelinesJson, categoryDefaults) {
   for (var i = 0; i < componentRefs.length; i++) {
     var s = componentRefs[i].ref;
     if (seen[s]) continue;
-    var crit = toCriterion(catLoader.resolveAccessibilityRef(s), componentRefs[i].note);
+    var crit = toCriterion(
+      catLoader.resolveAccessibilityRef(s),
+      componentRefs[i].note,
+    );
     if (crit) {
       component.push(crit);
       seen[s] = true;
@@ -70,7 +76,10 @@ function resolveLinkedCriteria(guidelinesJson, categoryDefaults) {
   for (var j = 0; j < categoryRefs.length; j++) {
     var cs = categoryRefs[j].ref;
     if (seen[cs]) continue; // component group wins
-    var ccrit = toCriterion(catLoader.resolveAccessibilityRef(cs), categoryRefs[j].note);
+    var ccrit = toCriterion(
+      catLoader.resolveAccessibilityRef(cs),
+      categoryRefs[j].note,
+    );
     if (ccrit) {
       inherited.push(ccrit);
       seen[cs] = true;
@@ -84,7 +93,98 @@ function resolveLinkedCriteria(guidelinesJson, categoryDefaults) {
   };
 }
 
+// --- load-by-slug helpers (the standalone / CLI / companion path) ---
+
+function _loadComponentsMap(pathStr) {
+  if (!pathStr || !fs.existsSync(pathStr)) return {};
+  try {
+    return JSON.parse(fs.readFileSync(pathStr, "utf8")).components || {};
+  } catch (e) {
+    return {};
+  }
+}
+
+// Resolve a component slug -> categorySlug via the registries (dskit, then fm,
+// then meta). The registry is the canonical source of categorySlug (knowledge
+// #189) — do NOT slugify the label. null when the slug is in no registry.
+function _categorySlugForComponent(slug) {
+  var reg = PATHS.components && PATHS.components.registries;
+  if (!reg) return null;
+  var kits = [reg.dskit, reg.fmkit, reg.metakit];
+  for (var i = 0; i < kits.length; i++) {
+    var comps = _loadComponentsMap(kits[i]);
+    if (comps[slug] && typeof comps[slug].categorySlug === "string") {
+      return comps[slug].categorySlug;
+    }
+  }
+  return null;
+}
+
+function _loadGuidelineDoc(slug) {
+  var byKey =
+    PATHS.components &&
+    PATHS.components.guidelineDoc &&
+    PATHS.components.guidelineDoc.byKey;
+  var p = typeof byKey === "function" ? byKey(slug) : null;
+  if (!p || !fs.existsSync(p)) return null;
+  try {
+    return JSON.parse(fs.readFileSync(p, "utf8"));
+  } catch (e) {
+    return null;
+  }
+}
+
+// Resolve linked criteria for a component. opts.{guidelinesJson, categoryDefaults}
+// let a caller (e.g. component-brief) pass already-loaded data; otherwise load
+// by slug. Graceful throughout — unknown slug -> { ..., resolved: false }.
+function linkedCriteriaForComponent(slug, opts) {
+  opts = opts || {};
+  var guidelinesJson = Object.prototype.hasOwnProperty.call(
+    opts,
+    "guidelinesJson",
+  )
+    ? opts.guidelinesJson
+    : _loadGuidelineDoc(slug);
+  var categoryDefaults;
+  if (Object.prototype.hasOwnProperty.call(opts, "categoryDefaults")) {
+    categoryDefaults = opts.categoryDefaults;
+  } else {
+    var catSlug = _categorySlugForComponent(slug);
+    categoryDefaults = catSlug
+      ? catLoader.loadDefaultsForCategory(catSlug)
+      : null;
+  }
+  return resolveLinkedCriteria(guidelinesJson, categoryDefaults);
+}
+
+// Category-level query (the "behavior/category" question): inherited only.
+function linkedCriteriaForCategory(categorySlug) {
+  var defaults = categorySlug
+    ? catLoader.loadDefaultsForCategory(categorySlug)
+    : null;
+  var res = resolveLinkedCriteria(null, defaults);
+  return { inherited: res.inherited, resolved: res.inherited.length > 0 };
+}
+
 module.exports = {
   toCriterion: toCriterion,
   resolveLinkedCriteria: resolveLinkedCriteria,
+  linkedCriteriaForComponent: linkedCriteriaForComponent,
+  linkedCriteriaForCategory: linkedCriteriaForCategory,
 };
+
+// CLI: node a11y.js <componentSlug>  |  node a11y.js --category=<categorySlug>
+if (require.main === module) {
+  var arg = process.argv[2];
+  if (!arg) {
+    console.error(
+      "usage: node a11y.js <componentSlug> | --category=<categorySlug>",
+    );
+    process.exit(2);
+  }
+  var out =
+    arg.indexOf("--category=") === 0
+      ? linkedCriteriaForCategory(arg.slice("--category=".length))
+      : linkedCriteriaForComponent(arg);
+  console.log(JSON.stringify(out, null, 2));
+}

--- a/plugins/actian-design-system/scripts/renderers/html-renderers/brief-renderer.css
+++ b/plugins/actian-design-system/scripts/renderers/html-renderers/brief-renderer.css
@@ -802,6 +802,40 @@ td code {
 .a11y-req-list__body {
   color: #475467;
 }
+/* Linked WCAG criteria (knowledge/a11y.js) — sourced, grouped-by-provenance list
+   rendered above the requirements list in the Accessibility card. */
+.a11y-criteria-group__label {
+  font-size: 12px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: #667085;
+  margin: 12px 0 6px;
+}
+.a11y-criteria-group__label:first-child {
+  margin-top: 0;
+}
+.a11y-criteria-list {
+  margin: 0 0 4px;
+  padding-left: 20px;
+  font-size: 14px;
+  color: #2d3648;
+  line-height: 1.6;
+}
+.a11y-criteria-list li {
+  margin-bottom: 6px;
+}
+.a11y-criteria-list li:last-child {
+  margin-bottom: 0;
+}
+.a11y-criteria-list__title {
+  font-weight: 600;
+  color: #101828;
+}
+.a11y-criteria-list__note {
+  color: #475467;
+  font-style: italic;
+}
 .code-block {
   background: #1a202c;
   border-radius: 12px;

--- a/plugins/actian-design-system/scripts/renderers/html-renderers/brief-renderer.js
+++ b/plugins/actian-design-system/scripts/renderers/html-renderers/brief-renderer.js
@@ -1058,7 +1058,7 @@
     return cardShell(
       (a11y && a11y.cardTitle) || "Accessibility",
       (a11y && a11y.cardSubtitle) ||
-        "WCAG 2.1 AA requirements, keyboard navigation, ARIA patterns, and contrast ratios",
+        "WCAG 2.2 AA requirements, keyboard navigation, ARIA patterns, and contrast ratios",
       parts.join(""),
       null,
       a11y,

--- a/plugins/actian-design-system/scripts/renderers/html-renderers/brief-renderer.js
+++ b/plugins/actian-design-system/scripts/renderers/html-renderers/brief-renderer.js
@@ -926,6 +926,55 @@
     if (!a11y) return "";
     var parts = [];
 
+    // Linked WCAG criteria (knowledge/a11y.js) — authoritative, substrate-sourced,
+    // grouped by provenance. Rendered above the generated requirements. No raw slugs.
+    var lc = a11y.linkedCriteria;
+    if (
+      lc &&
+      ((lc.component && lc.component.length) ||
+        (lc.inherited && lc.inherited.length))
+    ) {
+      var critList = function (items) {
+        var out = '<ul class="a11y-criteria-list">';
+        items.forEach(function (c) {
+          var wcag =
+            Array.isArray(c.wcag) && c.wcag.length
+              ? " — WCAG " + esc(c.wcag.join(", "))
+              : "";
+          out +=
+            "<li>" +
+            '<span class="a11y-criteria-list__title">' +
+            esc(c.title) +
+            "</span>" +
+            wcag +
+            (c.note
+              ? ' <span class="a11y-criteria-list__note">' +
+                esc(c.note) +
+                "</span>"
+              : "") +
+            "</li>";
+        });
+        return out + "</ul>";
+      };
+      var lcHtml = "";
+      if (lc.component && lc.component.length) {
+        lcHtml +=
+          '<div class="a11y-criteria-group__label">This component</div>' +
+          critList(lc.component);
+      }
+      if (lc.inherited && lc.inherited.length) {
+        lcHtml +=
+          '<div class="a11y-criteria-group__label">Inherited from category</div>' +
+          critList(lc.inherited);
+      }
+      parts.push(
+        '<div class="section" data-name="Linked WCAG criteria">' +
+          sectionTitle("Linked WCAG criteria") +
+          lcHtml +
+          "</div>",
+      );
+    }
+
     // Requirements as a plain bulleted list (Brief Refresh v2 Phase 1: dropped
     // the dense 2x3 a11y-card grid in favor of plain text). The data still
     // carries `icon` + `code` for any future re-elevation, but the renderer

--- a/plugins/actian-design-system/skills/companion/SKILL.md
+++ b/plugins/actian-design-system/skills/companion/SKILL.md
@@ -113,7 +113,12 @@ All three operate on existing URLs. Pick by prose:
 
 - **Design ops:** List findings (current vs. correct value). Spot fixes (wrong token, spacing, auto-layout): fix via `use_figma`, report what changed. Ambiguous fixes: present options first.
 - **Content designer:** Read text from selection, check against `vendor/content/dist/global.md` (cross-cutting voice/tone) + per-component `vendor/components/dist/guidelines/<slug>.json` `domains.content` when the selection is inside a known component, suggest rewrites with reasoning.
-- **A11y specialist:** Check contrast (4.5:1 normal, 3:1 large), touch targets (44x44px min), focus order. For full audit, recommend `/design-audit`.
+- **A11y specialist:** For "what are the WCAG requirements for this component/behavior?" questions, resolve the component slug from the registries (`vendor/components/dist/registries/dskit.json`, `vendor/components/dist/registries/fmkit.json`, `vendor/components/dist/registries/metakit.json`), then run the knowledge helper for authoritative, substrate-sourced criteria:
+  ```bash
+  source "${CLAUDE_PLUGIN_ROOT}/scripts/lib/resolve-node.sh" \
+    && "$NODE_BIN" "${CLAUDE_PLUGIN_ROOT}/scripts/lib/knowledge/a11y.js" <slug>
+  ```
+  Present the result grouped — "This component" (`component`) and "Inherited from category" (`inherited`) — citing each criterion's title + WCAG number(s); never the raw slug. For a category-level question use `--category=<categorySlug>` (which returns only the `inherited` group). If `resolved` is false, say so and fall back to general guidance. For live contrast/touch-target/focus-order checks on a selection, check contrast (4.5:1 normal, 3:1 large), touch targets (44x44px min), and focus order directly; for a full audit, recommend `/design-audit`.
 - **UX researcher:** Load `references/context/ux-patterns.md`, search by flow type, optionally web search. Ground recommendations in Actian product context.
 - **System librarian:** Draft guideline in existing format, show draft, user approves before any file edit.
 - **Tier review** (signals: "review tier-3", "show improvised screens", "what got improvised", "show deviations" + Figma URL): Read `.last-push.json` for the URL's flow page; for each `pushedNodes` entry where `tier === "improvised"`, or where `tier === "adapted"` with `matchedRecipe` set and `composition` null, print `label`: `justification`. No skill routing — companion handles directly.

--- a/plugins/actian-design-system/skills/component-brief/SKILL.md
+++ b/plugins/actian-design-system/skills/component-brief/SKILL.md
@@ -151,6 +151,25 @@ directly (the substrate's canonical slug, = slugify(category); knowledge
 `ctx.motionRefResolver` to `category-defaults-loader.resolveMotionRef`
 so the Phase A motion fallback can resolve the slug.
 
+**Linked WCAG criteria (v1.94.0+).** When the Accessibility card (`accessibility`)
+is selected, attach the authoritative, substrate-sourced criteria to it. Run the
+knowledge helper with the component slug:
+
+```bash
+source "${CLAUDE_PLUGIN_ROOT}/scripts/lib/resolve-node.sh" \
+  && "$NODE_BIN" "${CLAUDE_PLUGIN_ROOT}/scripts/lib/knowledge/a11y.js" <slug>
+```
+
+Take the `component` and `inherited` arrays from the JSON output and set
+`accessibility.linkedCriteria = { component, inherited }` on the card object. This
+is deterministic and authoritative — do NOT let the Phase B generator invent it.
+If the helper returns `resolved: false` (undocumented component, no category refs),
+omit `linkedCriteria` entirely (the renderer then renders the card as before).
+The generated `requirements` / Contrast / ARIA tables still render as practical
+guidance below the linked criteria.
+
+`accessibility.linkedCriteria` (optional) — `{ component: [{slug,title,wcag[],tier,note?,excerpt?}], inherited: [...] }`, sourced from `scripts/lib/knowledge/a11y.js`; omitted when unresolved. (No schema change — `validateBriefData` ignores unknown card fields.)
+
 **Phase A — Transcription (sequential, inline).** For each Phase A card:
 - If `resolveSection` returned `{ source: "figma", content }`: call `formatForBrief(cardKey, result, ctx)` and write directly into `brief-data.json`. Card object includes `_source: "figma"`.
 - If `resolveSection` returned `{ source: null, fallback: true, fallbackReason }`: invoke yourself (the main agent) inline to generate the missing content using the recipe's `sections` + `qualityRules` as guidance. Stamp `_source: "generated"`, `_fallback: true`, `_fallbackReason`. Do NOT dispatch the card-generator agent for this — Phase A fallbacks are inline.
@@ -186,6 +205,7 @@ Write: `{project_working_directory}/components/[name]/[name]-brief-data.json`
 - All token names use `--zen-` prefix (DS Kit) or `--fm-` prefix (FM)
 - No hardcoded hex values in token fields
 - `accessibility.requirements` has exactly 6 items (if card 7 selected)
+- `accessibility.linkedCriteria` (if present): each item has a non-empty title; no raw slug strings leak into rendered text.
 - **Code values use ASCII operators only** — `=>` not `⇒` (U+21D2), `->` not `→`, `<=` not `≤`, `>=` not `≥`, `!==` not `≠`. Especially watch generated content.
 - **`meta.pluginVersion` matches the project's `plugin.json` `version`** — read the file, do not transcribe from any example. If the value differs from the actual `plugin.json`, fix it before push.
 
@@ -227,6 +247,12 @@ Read your `brief-data.json` and push directly to Figma using small `use_figma` c
    a. Create card shell (Pattern 1). Read `card.cardTitle` and `card.cardSubtitle` from the data model — pass them straight to `setProperties` as `Title#140:0` and `Subtitle#140:1`. Do NOT hardcode card titles. **Default-leak detection (post-v1.66.0):** the Meta Kit Card Header now defaults to the generic placeholders `"Card title"` / `"Subtitle text"`. If a pushed card displays either string verbatim, `setProperties` silently failed (wrong property ID, wrong nested instance, or unresolved Card Header lookup) — fix the push call rather than ignoring the leak.
    b. Populate content: translate data model fields to Plugin API calls using component-brief/push-patterns.md
    c. Accessibility card (`accessibility`): use the simplified Pattern 6 — render `requirements` as a vertical bulleted list with bold-title + plain-body rows (one row per requirement, no per-card frames, no embedded code blocks). This replaces the 2×3 a11y-card grid retired in v1.66.3. Then render the Contrast table and ARIA table after the requirements list. Use Contrast Badge `setProperties` and A11y Spec Row `setProperties` for the table rows.
+   Additionally, before the requirements list, render the **Linked WCAG criteria** block when
+   `accessibility.linkedCriteria` is present: a "Linked WCAG criteria" sub-heading,
+   then two labeled groups — "This component" (`linkedCriteria.component`) and
+   "Inherited from category" (`linkedCriteria.inherited`) — each a bulleted list of
+   `{title} — WCAG {wcag joined}` (+ `note` if present; title alone when `wcag` is
+   empty). Never render the raw `slug`. Omit the block (and either group) when empty.
 6. After all cards pushed, report to user with count
 
 **Rules:**

--- a/plugins/actian-design-system/skills/design-audit/SKILL.md
+++ b/plugins/actian-design-system/skills/design-audit/SKILL.md
@@ -35,7 +35,7 @@ Audit scope for <target>:
   all (default) — copy + tokens + a11y + heuristic
   copy          — content guidelines, banned terms, label patterns
   tokens        — color/spacing/radius binding, hardcoded values
-  a11y          — WCAG 2.1 AA, contrast, ARIA, keyboard
+  a11y          — WCAG 2.2 AA, contrast, ARIA, keyboard
   heuristic     — UX patterns, layout, intent
 
 Reply: scope name, comma-separated list, or enter for all.

--- a/plugins/actian-design-system/tests/lib/knowledge-a11y.test.js
+++ b/plugins/actian-design-system/tests/lib/knowledge-a11y.test.js
@@ -19,7 +19,9 @@ test("resolveLinkedCriteria groups component vs inherited", function () {
   assert.equal(r.component.length, 1);
   assert.equal(r.component[0].slug, KNOWN_A);
   assert.ok(Array.isArray(r.component[0].wcag));
-  assert.ok(typeof r.component[0].title === "string" && r.component[0].title.length > 0);
+  assert.ok(
+    typeof r.component[0].title === "string" && r.component[0].title.length > 0,
+  );
   assert.equal(r.inherited.length, 1);
   assert.equal(r.inherited[0].slug, KNOWN_B);
   assert.equal(r.inherited[0].note, "n");
@@ -27,12 +29,18 @@ test("resolveLinkedCriteria groups component vs inherited", function () {
 
 test("dedupe: a slug in both groups stays only in component", function () {
   var doc = { meta: { a11y_refs: [{ ref: KNOWN_A }] } };
-  var cat = { a11y_refs: { requirementRefs: [{ ref: KNOWN_A }, { ref: KNOWN_B }] } };
+  var cat = {
+    a11y_refs: { requirementRefs: [{ ref: KNOWN_A }, { ref: KNOWN_B }] },
+  };
   var r = a11y.resolveLinkedCriteria(doc, cat);
   assert.equal(r.component.length, 1);
   assert.equal(r.inherited.length, 1);
   assert.equal(r.inherited[0].slug, KNOWN_B);
-  assert.ok(!r.inherited.some(function (c) { return c.slug === KNOWN_A; }));
+  assert.ok(
+    !r.inherited.some(function (c) {
+      return c.slug === KNOWN_A;
+    }),
+  );
 });
 
 test("unresolved slugs are skipped", function () {
@@ -61,4 +69,38 @@ test("empty wcag still yields a criterion (title-only render is the renderer's j
   var r = a11y.resolveLinkedCriteria(doc, null);
   assert.equal(r.component.length, 1);
   assert.ok(Array.isArray(r.component[0].wcag));
+});
+
+test("linkedCriteriaForComponent opts override skips loading", function () {
+  var r = a11y.linkedCriteriaForComponent("whats-new-dropdown", {
+    guidelinesJson: { meta: { a11y_refs: [{ ref: KNOWN_A }] } },
+    categoryDefaults: null,
+  });
+  assert.equal(r.component.length, 1);
+  assert.equal(r.component[0].slug, KNOWN_A);
+  assert.equal(r.inherited.length, 0);
+});
+
+test("linkedCriteriaForComponent load-by-slug resolves a documented component", function () {
+  // 'whats-new-dropdown' carries meta.a11y_refs in the vendored guidelines.
+  var r = a11y.linkedCriteriaForComponent("whats-new-dropdown");
+  assert.equal(typeof r.resolved, "boolean");
+  assert.ok(Array.isArray(r.component));
+  assert.ok(Array.isArray(r.inherited));
+});
+
+test("linkedCriteriaForComponent unknown slug -> resolved:false", function () {
+  var r = a11y.linkedCriteriaForComponent("definitely-not-a-real-component");
+  assert.equal(r.resolved, false);
+  assert.equal(r.component.length, 0);
+  assert.equal(r.inherited.length, 0);
+});
+
+test("linkedCriteriaForCategory returns inherited only", function () {
+  // 'action' category-defaults carries requirementRefs in the vendor snapshot.
+  var r = a11y.linkedCriteriaForCategory("action");
+  assert.ok(Array.isArray(r.inherited));
+  assert.equal(typeof r.resolved, "boolean");
+  assert.equal(r.resolved, true);
+  assert.equal(r.component, undefined);
 });

--- a/plugins/actian-design-system/tests/lib/knowledge-a11y.test.js
+++ b/plugins/actian-design-system/tests/lib/knowledge-a11y.test.js
@@ -1,0 +1,64 @@
+"use strict";
+
+var test = require("node:test");
+var assert = require("node:assert/strict");
+var a11y = require("../../scripts/lib/knowledge/a11y.js");
+
+// Real foundation slugs present in the vendored a11y-index (stable WCAG sections).
+// (Confirmed in vendor/accessibility/dist/a11y-index.json#bySlug.)
+var KNOWN_A = "color-contrast";
+var KNOWN_B = "focus-keyboard";
+var KNOWN_C = "aria-labels";
+var UNKNOWN = "definitely-not-a-real-a11y-slug";
+
+test("resolveLinkedCriteria groups component vs inherited", function () {
+  var doc = { meta: { a11y_refs: [{ ref: KNOWN_A }] } };
+  var cat = { a11y_refs: { requirementRefs: [{ ref: KNOWN_B, note: "n" }] } };
+  var r = a11y.resolveLinkedCriteria(doc, cat);
+  assert.equal(r.resolved, true);
+  assert.equal(r.component.length, 1);
+  assert.equal(r.component[0].slug, KNOWN_A);
+  assert.ok(Array.isArray(r.component[0].wcag));
+  assert.ok(typeof r.component[0].title === "string" && r.component[0].title.length > 0);
+  assert.equal(r.inherited.length, 1);
+  assert.equal(r.inherited[0].slug, KNOWN_B);
+  assert.equal(r.inherited[0].note, "n");
+});
+
+test("dedupe: a slug in both groups stays only in component", function () {
+  var doc = { meta: { a11y_refs: [{ ref: KNOWN_A }] } };
+  var cat = { a11y_refs: { requirementRefs: [{ ref: KNOWN_A }, { ref: KNOWN_B }] } };
+  var r = a11y.resolveLinkedCriteria(doc, cat);
+  assert.equal(r.component.length, 1);
+  assert.equal(r.inherited.length, 1);
+  assert.equal(r.inherited[0].slug, KNOWN_B);
+  assert.ok(!r.inherited.some(function (c) { return c.slug === KNOWN_A; }));
+});
+
+test("unresolved slugs are skipped", function () {
+  var doc = { meta: { a11y_refs: [{ ref: UNKNOWN }, { ref: KNOWN_C }] } };
+  var r = a11y.resolveLinkedCriteria(doc, null);
+  assert.equal(r.component.length, 1);
+  assert.equal(r.component[0].slug, KNOWN_C);
+});
+
+test("stub doc (no meta.a11y_refs) -> inherited only", function () {
+  var cat = { a11y_refs: { requirementRefs: [{ ref: KNOWN_A }] } };
+  var r = a11y.resolveLinkedCriteria({ domains: {} }, cat);
+  assert.equal(r.component.length, 0);
+  assert.equal(r.inherited.length, 1);
+  assert.equal(r.resolved, true);
+});
+
+test("nothing resolvable -> resolved:false, empty", function () {
+  var r = a11y.resolveLinkedCriteria(null, null);
+  assert.deepEqual(r, { component: [], inherited: [], resolved: false });
+});
+
+test("empty wcag still yields a criterion (title-only render is the renderer's job)", function () {
+  // 'principles' is a header-tier entry that resolves with wcag: [].
+  var doc = { meta: { a11y_refs: [{ ref: "principles" }] } };
+  var r = a11y.resolveLinkedCriteria(doc, null);
+  assert.equal(r.component.length, 1);
+  assert.ok(Array.isArray(r.component[0].wcag));
+});

--- a/plugins/actian-design-system/tests/lib/knowledge-a11y.test.js
+++ b/plugins/actian-design-system/tests/lib/knowledge-a11y.test.js
@@ -82,10 +82,15 @@ test("linkedCriteriaForComponent opts override skips loading", function () {
 });
 
 test("linkedCriteriaForComponent load-by-slug resolves a documented component", function () {
-  // 'whats-new-dropdown' carries meta.a11y_refs in the vendored guidelines.
+  // 'whats-new-dropdown' carries meta.a11y_refs in the vendored guidelines —
+  // a documented component MUST resolve component-level criteria (guards against
+  // a future re-vendor silently dropping its refs).
   var r = a11y.linkedCriteriaForComponent("whats-new-dropdown");
-  assert.equal(typeof r.resolved, "boolean");
-  assert.ok(Array.isArray(r.component));
+  assert.equal(r.resolved, true);
+  assert.ok(
+    r.component.length > 0,
+    "whats-new-dropdown must have component-level criteria",
+  );
   assert.ok(Array.isArray(r.inherited));
 });
 

--- a/plugins/actian-design-system/tests/renderers/brief-renderer.test.js
+++ b/plugins/actian-design-system/tests/renderers/brief-renderer.test.js
@@ -19,12 +19,7 @@ function ph(name) {
 }
 
 test("renderSection1 returns one supercard with 4 sub-section headings", function () {
-  var html = renderer.renderSection1(
-    fix.variants,
-    fix.anatomy,
-    fix.tokens,
-    ph,
-  );
+  var html = renderer.renderSection1(fix.variants, fix.anatomy, fix.tokens, ph);
 
   // Single card frame
   var cardFrameMatches = html.match(/<div class="brief-card"/g) || [];
@@ -95,12 +90,7 @@ test("renderSection1 omits Specs sub-section when anatomy.specs absent", functio
 
 test("Draft badge appears for generated sub-sections without _authored flag", function () {
   // Button fixture is AI-generated (Phase B), no _authored flags.
-  var html = renderer.renderSection1(
-    fix.variants,
-    fix.anatomy,
-    fix.tokens,
-    ph,
-  );
+  var html = renderer.renderSection1(fix.variants, fix.anatomy, fix.tokens, ph);
   // Expect at least 3 Draft badges (one per sub-section heading where source is set)
   var matches = html.match(/class="subsection-draft-badge"/g) || [];
   assert.ok(
@@ -155,12 +145,7 @@ test("renderSection1 + sibling renders together produce 6-card sequence (DS mode
   // Simulate the DOM cards array assembly the way DOMContentLoaded does it.
   var cards = [
     renderer.renderCard1(fix.card_header),
-    renderer.renderSection1(
-      fix.variants,
-      fix.anatomy,
-      fix.tokens,
-      ph,
-    ),
+    renderer.renderSection1(fix.variants, fix.anatomy, fix.tokens, ph),
     renderer.renderCard6(fix.usage),
     renderer.renderCard7(fix.card_content),
     renderer.renderCardMotion(fix.motion),
@@ -193,4 +178,51 @@ test("renderSection1 + sibling renders together produce 6-card sequence (DS mode
   assert.equal(componentDataName.length, 0, "no separate Component card");
   assert.equal(anatomyDataName.length, 0, "no separate Anatomy card");
   assert.equal(tokensDataName.length, 0, "no separate Design tokens card");
+});
+
+test("renderCard8 renders grouped Linked WCAG criteria when present", function () {
+  var a11y = {
+    linkedCriteria: {
+      component: [{ slug: "x", title: "Keyboard operable", wcag: ["2.1.1"] }],
+      inherited: [
+        {
+          slug: "y",
+          title: "Contrast (minimum)",
+          wcag: ["1.4.3"],
+          note: "4.5:1",
+        },
+      ],
+    },
+    requirements: [{ title: "R1", body: "b" }],
+    _source: "generated",
+  };
+  var html = renderer.renderCard8(a11y);
+  assert.ok(html.indexOf("Linked WCAG criteria") !== -1);
+  assert.ok(html.indexOf("This component") !== -1);
+  assert.ok(html.indexOf("Inherited from category") !== -1);
+  assert.ok(html.indexOf("Keyboard operable") !== -1);
+  assert.ok(html.indexOf("WCAG 2.1.1") !== -1);
+  assert.ok(html.indexOf("4.5:1") !== -1); // note rendered
+  assert.ok(html.indexOf("Requirements") !== -1); // existing block still renders
+});
+
+test("renderCard8 omits the criteria block when absent", function () {
+  var html = renderer.renderCard8({
+    requirements: [{ title: "R1" }],
+    _source: "generated",
+  });
+  assert.ok(html.indexOf("Linked WCAG criteria") === -1);
+});
+
+test("renderCard8 criterion with empty wcag renders title without a dangling WCAG", function () {
+  var a11y = {
+    linkedCriteria: {
+      component: [{ slug: "p", title: "Principles", wcag: [] }],
+      inherited: [],
+    },
+    _source: "generated",
+  };
+  var html = renderer.renderCard8(a11y);
+  assert.ok(html.indexOf("Principles") !== -1);
+  assert.ok(html.indexOf("Principles — WCAG") === -1);
 });

--- a/plugins/actian-design-system/tests/renderers/brief-renderer.test.js
+++ b/plugins/actian-design-system/tests/renderers/brief-renderer.test.js
@@ -226,3 +226,17 @@ test("renderCard8 criterion with empty wcag renders title without a dangling WCA
   assert.ok(html.indexOf("Principles") !== -1);
   assert.ok(html.indexOf("Principles — WCAG") === -1);
 });
+
+test("renderCard8 renders only 'Inherited from category' when component is empty", function () {
+  // The common case for stub / undocumented-but-categorized components.
+  var html = renderer.renderCard8({
+    linkedCriteria: {
+      component: [],
+      inherited: [{ slug: "z", title: "Text spacing", wcag: ["1.4.12"] }],
+    },
+    _source: "generated",
+  });
+  assert.ok(html.indexOf("Inherited from category") !== -1);
+  assert.ok(html.indexOf("This component") === -1);
+  assert.ok(html.indexOf("Text spacing") !== -1);
+});


### PR DESCRIPTION
## Summary
First vertical slice of the plugin's consumer-side **knowledge layer** (`scripts/lib/knowledge/`). Gives the plugin an authoritative, reusable a11y query: a component's **linked WCAG criteria** — the union of its own `meta.a11y_refs` (component-pattern tier, *"This component"*) and its category's `a11y_refs.requirementRefs` (foundation tier, *"Inherited from category"*) — resolved against the vendored substrate a11y-index, deduped (component wins), grouped by provenance, render-agnostic.

- **`scripts/lib/knowledge/a11y.js`** — the helper. `resolveLinkedCriteria` (pure core) · `linkedCriteriaForComponent(slug, opts?)` · `linkedCriteriaForCategory(categorySlug)` · CLI (`node a11y.js <slug>` | `--category=<slug>`). Reuses the existing substrate resolver (`category-defaults-loader`) and `PATHS`; fails gracefully (unknown → `resolved:false`, never throws).
- **`component-brief`** consumes it — SKILL assembles `accessibility.linkedCriteria`; `renderCard8` renders a grouped block above the requirements (with CSS); Figma push mirrors it. Title + WCAG number(s) only, never the raw slug; empty-`wcag` renders title-only.
- **`companion`** answers *"what are the WCAG requirements for X?"* through the helper instead of improvising from raw files.
- **`scripts/lib/knowledge/README.md`** — the helper contract (PATHS-only, render-agnostic, graceful, pure, CLI) + named Phase-2 backlog (content/usage, tokens, app-context, graph/inverse, companion routing, design-audit).
- **WCAG 2.2 AA rebaseline** (substrate rebaselined in knowledge #196) swept across CLAUDE.md, skills, references, the renderer default subtitle, example fixture, and overview doc. Criterion-number citations untouched.
- **MINOR bump → 1.94.0.**

## Test Plan
- [x] `find tests -name '*.test.js' | xargs node --test` — 892 pass (the lone failure is the pre-existing `vendor-paths-resolve` guard hitting **untracked local** `docs/superpowers/{plans,specs}/*` files referencing the pre-restructure vendor layout — not on CI, not from this branch)
- [x] New unit tests: `tests/lib/knowledge-a11y.test.js` (10 — union, dedupe, fallback ladder, opts-passthrough, unknown-slug, empty-wcag) + `tests/renderers/brief-renderer.test.js` (4 new — grouped, absent-omit, empty-wcag title-only, inherited-only)
- [x] Code guard `no-bare-vendor-paths` passes (helper uses `PATHS` only)
- [x] `css-staleness` passes (the four new `a11y-criteria-*` classes are styled)
- [x] CLI smoke: documented component → grouped `resolved:true`; `--category=action` → inherited-only; unknown slug → `resolved:false`

## Review
Each task reviewed two-stage (spec compliance → code quality); whole branch given a final holistic review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)