### PR TITLE
Wider-audience Phase 0: stop-the-bleeding hardening (v1.96.0)

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ DS knowledge (tokens, components, foundations, content + accessibility guideline
 
 The plugin is available in both **Cowork** and **Code** tabs after install. At this time, **Code** is recommended for best results.
 
-> **Figma integration:** The Figma MCP (`claude.ai Figma`) is built into Claude. On first use, you'll be prompted to authorize your Figma account — no additional setup required. Works with Figma files in the browser and Figma desktop.
+> **Figma integration:** The plugin's Figma read/write uses the `claude.ai Figma` connector. On **Claude Desktop / Cowork** it's built in — you'll be prompted to authorize your Figma account on first use (no separate install). On the **Claude Code CLI**, connect it via `/mcp` (or `claude plugin install figma@claude-plugins-official`). Works with Figma files in the browser and Figma desktop.
 
 ### Claude Code CLI
 
@@ -51,6 +51,15 @@ The plugin is available in both **Cowork** and **Code** tabs after install. At t
 claude plugin marketplace add volivarii/Actian-DS-Claude-plugin
 claude plugin install actian-design-system@actian-design-system
 ```
+
+### Prerequisites
+
+For the plugin to produce real DS output (not hex fallbacks), you need:
+
+- **Figma desktop running** — for canvas read/write.
+- **A Figma editor seat with the DS / FM / Meta libraries enabled.** Without it — or if a file isn't connected to the libraries — output falls back to raw hex values instead of bound design-system styles. That's a setup issue, not a plugin bug.
+- **The Figma MCP connected** — built in on Desktop / Cowork; on CLI connect via `/mcp` (see the Figma integration note above).
+- **Node.js available** — used by the local preview/validation scripts. The plugin auto-resolves nvm / Volta / asdf / fnm / Homebrew / system installs; if it can't find node, install it from [nodejs.org](https://nodejs.org) or set `NODE_BIN`.
 
 ### Auto-updates + permissions (optional)
 
@@ -89,6 +98,14 @@ Add to `~/.claude/settings.json`:
 1. Remove the marketplace: Customize > find marketplace > Remove
 2. Re-add the marketplace: `volivarii/Actian-DS-Claude-plugin`
 3. Install the plugin again
+
+Or, faster — clear the cached copy directly, then restart Claude:
+
+```bash
+rm -rf ~/.claude/plugins/cache/Actian-DS-Claude-plugin/actian-design-system/
+```
+
+(If the path differs, verify the `cache/<marketplace>/<plugin>/` folder names on your machine. During the testing window, the maintainer ships hot-fixes by version bump — clearing the cache is how you pull them.)
 
 **CLI:**
 

--- a/README.md
+++ b/README.md
@@ -61,9 +61,9 @@ For the plugin to produce real DS output (not hex fallbacks), you need:
 - **The Figma MCP connected** — built in on Desktop / Cowork; on CLI connect via `/mcp` (see the Figma integration note above).
 - **Node.js available** — used by the local preview/validation scripts. The plugin auto-resolves nvm / Volta / asdf / fnm / Homebrew / system installs; if it can't find node, install it from [nodejs.org](https://nodejs.org) or set `NODE_BIN`.
 
-### Auto-updates + permissions (optional)
+### Auto-updates + permissions (recommended for testers)
 
-Add to `~/.claude/settings.json`:
+Add to `~/.claude/settings.json` — `autoUpdate: true` makes hot-fixes land automatically at session start (this is the simplest way to stay current during the test window):
 
 ```json
 {
@@ -91,30 +91,26 @@ Add to `~/.claude/settings.json`:
 
 ### Updating the plugin
 
-**Desktop:**
+Plugin auto-update works in current Claude Code (v2.1.x, June 2026+). Because this is a **third-party** marketplace, auto-update is **opt-in** — turn it on once and updates arrive automatically at session start (you'll be prompted to run `/reload-plugins`).
 
-> **Known issue:** The built-in update mechanism for external marketplace plugins [does not reliably detect new versions](https://github.com/anthropics/claude-code/issues/38271). The cached version persists even after a new release is pushed.
+**Enable auto-update (recommended for testers):** either set `"autoUpdate": true` in the `extraKnownMarketplaces` block above, or run `/plugin` > **Marketplaces** tab > select Actian Design System > **Enable auto-update**.
 
-1. Remove the marketplace: Customize > find marketplace > Remove
-2. Re-add the marketplace: `volivarii/Actian-DS-Claude-plugin`
-3. Install the plugin again
-
-Or, faster — clear the cached copy directly, then restart Claude:
-
-```bash
-rm -rf ~/.claude/plugins/cache/Actian-DS-Claude-plugin/actian-design-system/
-```
-
-(If the path differs, verify the `cache/<marketplace>/<plugin>/` folder names on your machine. During the testing window, the maintainer ships hot-fixes by version bump — clearing the cache is how you pull them.)
-
-**CLI:**
+**CLI — manual pull** (if you didn't enable auto-update):
 
 ```bash
 claude plugin marketplace update actian-design-system
 claude plugin update actian-design-system@actian-design-system
 ```
 
-**Auto-update** (one-time): Run `/plugin` > **Marketplaces** tab > select Actian Design System > **Enable auto-update**. Updates are then applied at startup.
+**Cowork / Desktop:** an org owner can turn on **Organization settings > Plugins > Sync automatically** (the GitHub marketplace then re-syncs whenever a PR merges); otherwise use the manual **Update** button. Changes reach each member on their next session (up to ~30 min).
+
+**Fallback (rarely needed):** if an update still doesn't land, refresh the marketplace with `/plugin marketplace update` or, as a last resort, clear the cached copy and restart Claude:
+
+```bash
+rm -rf ~/.claude/plugins/cache/Actian-DS-Claude-plugin/actian-design-system/
+```
+
+(Verify the `cache/<marketplace>/<plugin>/` folder names if the path differs.)
 
 **Verify your version:** Ask the companion "what version are you running?"
 

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ The guidelines hold throughout — tokens, spacing, content rules, accessibility
 
 DS knowledge (tokens, components, foundations, content + accessibility guidelines) is vendored from [`volivarii/actian-ds-knowledge`](https://github.com/volivarii/actian-ds-knowledge) — the canonical source-of-truth repo synced directly from Figma. The plugin pulls a pinned snapshot nightly via `vendor-snapshot.yml`.
 
-**v1.79.1** · 8 skills (tiered generation: recognized / adapted / improvised) · 9 agents · 23 recipes · 155 design tokens across 8 collections · 3 themes · WCAG 2.1 AA · surgical refine engine · vision-grounded references · interactive gates · federated knowledge substrate · component briefs with Section 1 supercard (anatomy + variation + tokens + specs / usages / content / motion / accessibility) — Section 6 (real platform examples) deferred
+**v1.96.0** · 8 skills (tiered generation: recognized / adapted / improvised) · 9 agents · 23 recipes · 155 design tokens across 8 collections · 3 themes · WCAG 2.1 AA · surgical refine engine · vision-grounded references · interactive gates · federated knowledge substrate · component briefs with Section 1 supercard (anatomy + variation + tokens + specs / usages / content / motion / accessibility) — Section 6 (real platform examples) deferred
 
 ---
 
@@ -43,7 +43,7 @@ DS knowledge (tokens, components, foundations, content + accessibility guideline
 
 The plugin is available in both **Cowork** and **Code** tabs after install. At this time, **Code** is recommended for best results.
 
-> **Figma integration:** The plugin's Figma read/write uses the `claude.ai Figma` connector. On **Claude Desktop / Cowork** it's built in — you'll be prompted to authorize your Figma account on first use (no separate install). On the **Claude Code CLI**, connect it via `/mcp` (or `claude plugin install figma@claude-plugins-official`). Works with Figma files in the browser and Figma desktop.
+> **Figma integration:** The plugin's Figma read/write uses the `claude.ai Figma` connector. On **Claude Desktop / Cowork** it's built in — you'll be prompted to authorize your Figma account on first use (no separate install). On the **Claude Code CLI**, connect it via `/mcp` (it's a Claude-managed connector, surfaced under `/mcp`). Works with Figma files in the browser and Figma desktop.
 
 ### Claude Code CLI
 
@@ -107,10 +107,10 @@ claude plugin update actian-design-system@actian-design-system
 **Fallback (rarely needed):** if an update still doesn't land, refresh the marketplace with `/plugin marketplace update` or, as a last resort, clear the cached copy and restart Claude:
 
 ```bash
-rm -rf ~/.claude/plugins/cache/Actian-DS-Claude-plugin/actian-design-system/
+rm -rf ~/.claude/plugins/cache/actian-design-system/actian-design-system/
 ```
 
-(Verify the `cache/<marketplace>/<plugin>/` folder names if the path differs.)
+(The cache is keyed by `cache/<marketplace>/<plugin>/` — here both are `actian-design-system`; verify the folder names if your path differs.)
 
 **Verify your version:** Ask the companion "what version are you running?"
 

--- a/plugins/actian-design-system/.claude-plugin/plugin.json
+++ b/plugins/actian-design-system/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "actian-design-system",
   "description": "Actian Design System toolkit — generate wireframe flows with prototype wiring, create component briefs, audit designs, compare flows, and build presentations. 8 skills (with tiered generation: recognized / adapted / improvised), 8 agents, 155 tokens (3 themes, 8 collections), WCAG 2.2 AA. DS knowledge vendored from volivarii/actian-ds-knowledge.",
-  "version": "1.95.0",
+  "version": "1.96.0",
   "author": {
     "name": "Actian UX Team"
   },

--- a/plugins/actian-design-system/hooks/hooks.json
+++ b/plugins/actian-design-system/hooks/hooks.json
@@ -8,11 +8,6 @@
             "type": "command",
             "command": "bash \"${CLAUDE_PLUGIN_ROOT}/scripts/hooks/check-update.sh\"",
             "timeout": 5
-          },
-          {
-            "type": "command",
-            "command": "bash \"${CLAUDE_PLUGIN_ROOT}/scripts/sync/sync-check.sh\"",
-            "timeout": 15
           }
         ]
       }

--- a/plugins/actian-design-system/scripts/hooks/check-update.sh
+++ b/plugins/actian-design-system/scripts/hooks/check-update.sh
@@ -10,11 +10,18 @@ if [ ! -f "$PLUGIN_JSON" ]; then
   exit 0
 fi
 
+# Resolve node — on Desktop it's rarely in PATH, so bare `node` would silently
+# produce empty output and the check would no-op for the entire Desktop audience.
+source "$CLAUDE_PLUGIN_ROOT/scripts/lib/resolve-node.sh" 2>/dev/null || true
+if [ -z "$NODE_BIN" ]; then
+  exit 0
+fi
+
 # Get marketplace version
-MARKET_VERSION=$(node -e "console.log(require('$PLUGIN_JSON').version)" 2>/dev/null)
+MARKET_VERSION=$("$NODE_BIN" -e "console.log(require('$PLUGIN_JSON').version)" 2>/dev/null)
 
 # Get cached version
-CACHE_VERSION=$(node -e "console.log(require('${CLAUDE_PLUGIN_ROOT}/.claude-plugin/plugin.json').version)" 2>/dev/null)
+CACHE_VERSION=$("$NODE_BIN" -e "console.log(require('${CLAUDE_PLUGIN_ROOT}/.claude-plugin/plugin.json').version)" 2>/dev/null)
 
 # If versions match or couldn't read, skip silently
 if [ -z "$MARKET_VERSION" ] || [ -z "$CACHE_VERSION" ] || [ "$MARKET_VERSION" = "$CACHE_VERSION" ]; then
@@ -23,5 +30,5 @@ fi
 
 # Update available — notify via additionalContext
 cat <<EOF
-{"hookSpecificOutput":{"sessionStartContext":"DS Plugin update available (v${CACHE_VERSION} → v${MARKET_VERSION}). To apply: ! rm -rf ~/.claude/plugins/cache/actian-design-system/ && restart Claude."}}
+{"hookSpecificOutput":{"sessionStartContext":"DS Plugin update available (v${CACHE_VERSION} → v${MARKET_VERSION}). If auto-update is enabled it applies at session start (run /reload-plugins). Otherwise: /plugin marketplace update — or last resort ! rm -rf ~/.claude/plugins/cache/actian-design-system/actian-design-system/ && restart Claude."}}
 EOF

--- a/plugins/actian-design-system/scripts/lib/resolve-node.sh
+++ b/plugins/actian-design-system/scripts/lib/resolve-node.sh
@@ -6,12 +6,17 @@
 
 NODE_BIN="$(command -v node 2>/dev/null || echo "")"
 if [ -z "$NODE_BIN" ]; then
-  for _candidate in /usr/local/bin/node /opt/homebrew/bin/node; do
+  for _candidate in \
+    /usr/local/bin/node /opt/homebrew/bin/node \
+    "$HOME"/.volta/bin/node "$HOME"/.asdf/shims/node \
+    "$HOME"/.nvm/versions/node/*/bin/node \
+    "$HOME"/.fnm/aliases/default/bin/node \
+    "$HOME"/.local/share/fnm/aliases/default/bin/node; do
     if [ -x "$_candidate" ]; then NODE_BIN="$_candidate"; break; fi
   done
 fi
 if [ -z "$NODE_BIN" ]; then
-  echo "Error: node not found in PATH or standard locations" >&2
+  echo "Error: node not found. Install Node.js (https://nodejs.org) or export NODE_BIN=/path/to/node." >&2
   exit 1
 fi
 export NODE_BIN

--- a/plugins/actian-design-system/scripts/lib/resolve-node.sh
+++ b/plugins/actian-design-system/scripts/lib/resolve-node.sh
@@ -17,6 +17,9 @@ if [ -z "$NODE_BIN" ]; then
 fi
 if [ -z "$NODE_BIN" ]; then
   echo "Error: node not found. Install Node.js (https://nodejs.org) or export NODE_BIN=/path/to/node." >&2
-  exit 1
+  # This file is meant to be sourced. When sourced, `return` hands control back to
+  # the caller (so e.g. ensure-server.sh can run its own fallback); `exit` would kill
+  # the caller's shell. Only `exit` when executed directly.
+  if [ "${BASH_SOURCE[0]}" = "${0}" ]; then exit 1; else return 1; fi
 fi
 export NODE_BIN

--- a/plugins/actian-design-system/scripts/renderers/ensure-server.sh
+++ b/plugins/actian-design-system/scripts/renderers/ensure-server.sh
@@ -50,7 +50,13 @@ fi
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 SERVER_LOG="/tmp/preview-server-$PORT.log"
 # Resolve node binary — Desktop sandbox may not have it in PATH
-source "$SCRIPT_DIR/resolve-node.sh"
+source "$SCRIPT_DIR/../lib/resolve-node.sh"
+# Fallback: if resolve-node.sh was unavailable/didn't set NODE_BIN, try PATH directly.
+if [ -z "$NODE_BIN" ]; then NODE_BIN="$(command -v node 2>/dev/null || echo "")"; fi
+if [ -z "$NODE_BIN" ]; then
+  echo "Error: node not found (resolve-node.sh unavailable and node not in PATH). Install Node.js or set NODE_BIN." >&2
+  exit 1
+fi
 # Use nohup + disown to ensure the server survives after this script exits.
 # On Desktop (Cowork), background processes get killed when the parent bash exits.
 nohup "$NODE_BIN" "$SCRIPT_DIR/preview-server.js" "$PORT" "$DIR_ABS" > "$SERVER_LOG" 2>&1 &

--- a/plugins/actian-design-system/scripts/transformers/fm-tree-to-flow-data.js
+++ b/plugins/actian-design-system/scripts/transformers/fm-tree-to-flow-data.js
@@ -15,14 +15,13 @@
 var fs = require("fs");
 var path = require("path");
 
-var PLUGIN_ROOT = path.resolve(__dirname, "../..");
-var DOCS_DIR = path.join(PLUGIN_ROOT, "docs", "generated");
 var shared = require("../lib/shared-constants");
+var PATHS = require("../lib/paths.js");
 
 // Build reverse lookup: componentKey → FM ref name
 function buildKeyToRefMap() {
   var fmRegistry = JSON.parse(
-    fs.readFileSync(path.join(DOCS_DIR, "fmkit.json"), "utf8"),
+    fs.readFileSync(PATHS.components.registries.fmkit, "utf8"),
   );
 
   // Reverse FM_SLUGS: slug → ref name

--- a/plugins/actian-design-system/scripts/transformers/transform-to-hifi.js
+++ b/plugins/actian-design-system/scripts/transformers/transform-to-hifi.js
@@ -22,12 +22,12 @@ var fs = require("fs");
 var path = require("path");
 var resolver = require("../lib/intent-resolver.js");
 var shared = require("../lib/shared-constants.js");
+var PATHS = require("../lib/paths.js");
 
 // ---------------------------------------------------------------------------
 // Paths
 // ---------------------------------------------------------------------------
 
-var GENERATED_DIR = path.resolve(__dirname, "../..", "docs", "generated");
 // Plugin-owned FM→DS mapping table (evicted from the substrate in Track E —
 // it's a tool-specific alignment table, not agnostic DS knowledge).
 var MAP_PATH = path.resolve(
@@ -37,7 +37,8 @@ var MAP_PATH = path.resolve(
   "convert-to-hifi",
   "fm-to-ds-map.json",
 );
-var DS_REGISTRY_PATH = path.join(GENERATED_DIR, "dskit.json");
+// DS Kit registry — vendored from the substrate (PATHS.components.registries.dskit).
+var DS_REGISTRY_PATH = PATHS.components.registries.dskit;
 
 // ---------------------------------------------------------------------------
 // Variant helpers

--- a/plugins/actian-design-system/scripts/validation/component-property-rules.js
+++ b/plugins/actian-design-system/scripts/validation/component-property-rules.js
@@ -153,7 +153,7 @@ module.exports = {
 
 if (require.main === module) {
   var fs = require("fs");
-  var path = require("path");
+  var PATHS = require("../lib/paths.js");
   var args = process.argv.slice(2);
 
   var slugs = null;
@@ -188,21 +188,15 @@ if (require.main === module) {
     process.exit(1);
   }
 
-  var PLUGIN_ROOT = path.resolve(__dirname, "..");
-  function loadKit(file) {
+  function loadKit(registryPath) {
     try {
-      return JSON.parse(
-        fs.readFileSync(
-          path.join(PLUGIN_ROOT, "docs", "generated", file),
-          "utf8",
-        ),
-      );
+      return JSON.parse(fs.readFileSync(registryPath, "utf8"));
     } catch (e) {
       return { components: {} };
     }
   }
-  var fm = loadKit("fmkit.json").components || {};
-  var ds = loadKit("dskit.json").components || {};
+  var fm = loadKit(PATHS.components.registries.fmkit).components || {};
+  var ds = loadKit(PATHS.components.registries.dskit).components || {};
 
   function indexBoth(kit) {
     var index = {};

--- a/plugins/actian-design-system/skills/companion/SKILL.md
+++ b/plugins/actian-design-system/skills/companion/SKILL.md
@@ -21,6 +21,8 @@ Designers learn three input shapes; the companion does the rest:
 
 1. Read `../../references/context/companion-context.md` — always-loaded DS summary
 2. If Figma URL(s) shared: extract fileKey + nodeId, classify node via `use_figma` (see `../../references/figma/figma-output.md`), then `get_design_context` + `get_screenshot`
+   - **If the Figma MCP is unavailable or unauthorized** (the `use_figma` / `get_design_context` calls error or the tool isn't found): say so and guide the user — on Claude Desktop / Cowork the `claude.ai Figma` connector is built in (authorize it on first use); on Claude Code CLI, connect it via `/mcp` (or `claude plugin install figma@claude-plugins-official`). Stop and tell the user rather than failing cryptically mid-task.
+   - **If a Figma file renders hex colors instead of bound DS styles**, the file isn't connected to the DS libraries — or you lack a Figma editor seat. Flag this as a setup issue, not a plugin bug.
 3. Note app context (Studio/Explorer/Administration)
 
 ## Step 2 — Classify intent

--- a/plugins/actian-design-system/skills/companion/SKILL.md
+++ b/plugins/actian-design-system/skills/companion/SKILL.md
@@ -21,7 +21,7 @@ Designers learn three input shapes; the companion does the rest:
 
 1. Read `../../references/context/companion-context.md` — always-loaded DS summary
 2. If Figma URL(s) shared: extract fileKey + nodeId, classify node via `use_figma` (see `../../references/figma/figma-output.md`), then `get_design_context` + `get_screenshot`
-   - **If the Figma MCP is unavailable or unauthorized** (the `use_figma` / `get_design_context` calls error or the tool isn't found): say so and guide the user — on Claude Desktop / Cowork the `claude.ai Figma` connector is built in (authorize it on first use); on Claude Code CLI, connect it via `/mcp` (or `claude plugin install figma@claude-plugins-official`). Stop and tell the user rather than failing cryptically mid-task.
+   - **If the Figma MCP is unavailable or unauthorized** (the `use_figma` / `get_design_context` calls error or the tool isn't found): say so and guide the user — on Claude Desktop / Cowork the `claude.ai Figma` connector is built in (authorize it on first use); on Claude Code CLI, connect it via `/mcp` (it's a Claude-managed connector, not the `figma@claude-plugins-official` Dev Mode plugin). Stop and tell the user rather than failing cryptically mid-task.
    - **If a Figma file renders hex colors instead of bound DS styles**, the file isn't connected to the DS libraries — or you lack a Figma editor seat. Flag this as a setup issue, not a plugin bug.
 3. Note app context (Studio/Explorer/Administration)
 

--- a/plugins/actian-design-system/tests/fixtures/fm-tree-minimal.json
+++ b/plugins/actian-design-system/tests/fixtures/fm-tree-minimal.json
@@ -1,0 +1,30 @@
+{
+  "root": "Minimal FM Screen",
+  "nodes": [
+    {
+      "t": "F",
+      "n": "Content",
+      "p": "Content",
+      "lm": "VERTICAL",
+      "w": 360,
+      "h": 200
+    },
+    {
+      "t": "I",
+      "n": "Primary Button",
+      "k": "368b62312ca941c80ea8eeed84a57d33bb470b09",
+      "v": { "Type": "Primary", "Size": "md" },
+      "pr": { "label": "Save" },
+      "p": "Content/Primary Button",
+      "w": 120,
+      "h": 40
+    },
+    {
+      "t": "T",
+      "n": "Helper text",
+      "c": "Choose an option below",
+      "s": 14,
+      "p": "Content/Helper text"
+    }
+  ]
+}

--- a/plugins/actian-design-system/tests/integration/ensure-server-smoke.test.js
+++ b/plugins/actian-design-system/tests/integration/ensure-server-smoke.test.js
@@ -1,0 +1,80 @@
+#!/usr/bin/env node
+"use strict";
+
+/**
+ * ensure-server-smoke.test.js — Cold-shell smoke test for ensure-server.sh.
+ *
+ * Reproduces the cold-caller scenario: a fresh tester (or the skill's own
+ * documented command) invokes ensure-server.sh WITHOUT pre-exporting NODE_BIN.
+ * The author's machine masks the bug because NODE_BIN is already exported in
+ * their interactive shell; here we DELETE NODE_BIN from the child env so the
+ * script must resolve node itself (sourcing resolve-node.sh from the right
+ * place + the self-healing fallback).
+ *
+ * Asserts: exit 0 (no throw) and stdout contains the served base URL.
+ * Always tears down: kills whatever is listening on the port and removes the
+ * temp dir, leaving no server running and no temp dir behind.
+ */
+
+var { test } = require("node:test");
+var assert = require("node:assert");
+var fs = require("fs");
+var os = require("os");
+var path = require("path");
+var { execFileSync, execSync } = require("child_process");
+
+var SCRIPT_PATH = path.resolve(
+  __dirname,
+  "..",
+  "..",
+  "scripts",
+  "renderers",
+  "ensure-server.sh",
+);
+
+var PORT = 8791;
+
+test(
+  "ensure-server.sh starts cold (NODE_BIN scrubbed) and prints the URL",
+  { timeout: 20000 },
+  function () {
+    var tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "ens-"));
+
+    // Scrubbed env: a COPY of process.env with NODE_BIN DELETED (PATH kept).
+    // This reproduces the cold caller — the author's exported NODE_BIN is what
+    // masks the broken `source` path.
+    var scrubbedEnv = Object.assign({}, process.env);
+    delete scrubbedEnv.NODE_BIN;
+
+    try {
+      var stdout = execFileSync(
+        "bash",
+        [SCRIPT_PATH, tempDir, String(PORT)],
+        { env: scrubbedEnv, encoding: "utf8" },
+      );
+
+      assert.ok(
+        stdout.indexOf("http://localhost:" + PORT) !== -1,
+        "expected stdout to contain http://localhost:" +
+          PORT +
+          " — got: " +
+          stdout,
+      );
+    } finally {
+      // Always tear down: kill anything still listening on the port, then
+      // remove the temp dir. Ignore errors (nothing to kill / already gone).
+      try {
+        execSync("lsof -ti :" + PORT + " | xargs kill", {
+          stdio: "ignore",
+        });
+      } catch (e) {
+        // no listener / kill failed — fine
+      }
+      try {
+        fs.rmSync(tempDir, { recursive: true, force: true });
+      } catch (e) {
+        // already gone — fine
+      }
+    }
+  },
+);

--- a/plugins/actian-design-system/tests/transformers/transformers-cli-smoke.test.js
+++ b/plugins/actian-design-system/tests/transformers/transformers-cli-smoke.test.js
@@ -1,0 +1,94 @@
+#!/usr/bin/env node
+"use strict";
+
+/**
+ * transformers-cli-smoke.test.js — End-to-end CLI smoke tests for the hifi
+ * conversion pipeline.
+ *
+ * These exercise the transformer scripts AS CLIs (via execFileSync), which is
+ * exactly how the convert-to-hifi skill invokes them. The existing
+ * transform-to-hifi.test.js suite injects the registry via the module API and
+ * never spawns the CLI, so it never touched the on-disk registry path — which
+ * is why a stale `docs/generated/` reference shipped silently and crashed the
+ * pipeline with ENOENT. This file closes that blind spot.
+ *
+ * Run with: node --test plugins/actian-design-system/tests/transformers/transformers-cli-smoke.test.js
+ */
+
+var { describe, it, after } = require("node:test");
+var assert = require("node:assert");
+var path = require("path");
+var fs = require("fs");
+var os = require("os");
+var { execFileSync } = require("child_process");
+
+var TRANSFORMERS_DIR = path.resolve(__dirname, "..", "..", "scripts", "transformers");
+var EXAMPLES_DIR = path.resolve(__dirname, "..", "..", "examples");
+var FIXTURES_DIR = path.resolve(__dirname, "..", "fixtures");
+
+var FM_TREE_TO_FLOW = path.join(TRANSFORMERS_DIR, "fm-tree-to-flow-data.js");
+var TRANSFORM_TO_HIFI = path.join(TRANSFORMERS_DIR, "transform-to-hifi.js");
+
+// Track temp outputs for cleanup.
+var tempOutputs = [];
+function tempOut(name) {
+  var p = path.join(
+    os.tmpdir(),
+    "transformers-cli-smoke-" + process.pid + "-" + Date.now() + "-" + name,
+  );
+  tempOutputs.push(p);
+  return p;
+}
+
+function runCli(scriptPath, inputPath, outPath) {
+  // execFileSync throws on non-zero exit; capturing stderr keeps failures
+  // readable. We don't assert on stderr (the scripts emit progress there).
+  execFileSync(process.execPath, [scriptPath, inputPath, "-o", outPath], {
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+}
+
+after(function () {
+  for (var i = 0; i < tempOutputs.length; i++) {
+    try {
+      if (fs.existsSync(tempOutputs[i])) fs.unlinkSync(tempOutputs[i]);
+    } catch (e) {
+      /* best-effort cleanup */
+    }
+  }
+});
+
+describe("transformers CLI smoke", function () {
+  it("transform-to-hifi.js CLI runs end-to-end and writes valid JSON", function () {
+    var input = path.join(EXAMPLES_DIR, "flow-data-example.json");
+    assert.ok(fs.existsSync(input), "fixture flow-data-example.json must exist");
+
+    var out = tempOut("hifi-data.json");
+    runCli(TRANSFORM_TO_HIFI, input, out);
+
+    assert.ok(fs.existsSync(out), "transform-to-hifi must write its output file");
+    var parsed = JSON.parse(fs.readFileSync(out, "utf8"));
+    assert.ok(parsed && typeof parsed === "object", "output must parse as a JSON object");
+    assert.ok(
+      Array.isArray(parsed.screens) && parsed.screens.length > 0,
+      "output must have a non-empty screens array",
+    );
+    assert.strictEqual(parsed.meta.mode, "hifi", "transform must mark meta.mode === 'hifi'");
+  });
+
+  it("fm-tree-to-flow-data.js CLI runs end-to-end and writes valid flow-data", function () {
+    var input = path.join(FIXTURES_DIR, "fm-tree-minimal.json");
+    assert.ok(fs.existsSync(input), "fixture fm-tree-minimal.json must exist");
+
+    var out = tempOut("flow-data.json");
+    runCli(FM_TREE_TO_FLOW, input, out);
+
+    assert.ok(fs.existsSync(out), "fm-tree-to-flow-data must write its output file");
+    var parsed = JSON.parse(fs.readFileSync(out, "utf8"));
+    assert.ok(parsed && typeof parsed === "object", "output must parse as a JSON object");
+    assert.ok(
+      Array.isArray(parsed.screens) && parsed.screens.length > 0,
+      "output must have a non-empty screens array",
+    );
+  });
+});

--- a/plugins/actian-design-system/tests/transformers/transformers-cli-smoke.test.js
+++ b/plugins/actian-design-system/tests/transformers/transformers-cli-smoke.test.js
@@ -22,7 +22,13 @@ var fs = require("fs");
 var os = require("os");
 var { execFileSync } = require("child_process");
 
-var TRANSFORMERS_DIR = path.resolve(__dirname, "..", "..", "scripts", "transformers");
+var TRANSFORMERS_DIR = path.resolve(
+  __dirname,
+  "..",
+  "..",
+  "scripts",
+  "transformers",
+);
 var EXAMPLES_DIR = path.resolve(__dirname, "..", "..", "examples");
 var FIXTURES_DIR = path.resolve(__dirname, "..", "fixtures");
 
@@ -61,19 +67,38 @@ after(function () {
 describe("transformers CLI smoke", function () {
   it("transform-to-hifi.js CLI runs end-to-end and writes valid JSON", function () {
     var input = path.join(EXAMPLES_DIR, "flow-data-example.json");
-    assert.ok(fs.existsSync(input), "fixture flow-data-example.json must exist");
+    assert.ok(
+      fs.existsSync(input),
+      "fixture flow-data-example.json must exist",
+    );
 
     var out = tempOut("hifi-data.json");
     runCli(TRANSFORM_TO_HIFI, input, out);
 
-    assert.ok(fs.existsSync(out), "transform-to-hifi must write its output file");
+    assert.ok(
+      fs.existsSync(out),
+      "transform-to-hifi must write its output file",
+    );
     var parsed = JSON.parse(fs.readFileSync(out, "utf8"));
-    assert.ok(parsed && typeof parsed === "object", "output must parse as a JSON object");
+    assert.ok(
+      parsed && typeof parsed === "object",
+      "output must parse as a JSON object",
+    );
     assert.ok(
       Array.isArray(parsed.screens) && parsed.screens.length > 0,
       "output must have a non-empty screens array",
     );
-    assert.strictEqual(parsed.meta.mode, "hifi", "transform must mark meta.mode === 'hifi'");
+    assert.strictEqual(
+      parsed.meta.mode,
+      "hifi",
+      "transform must mark meta.mode === 'hifi'",
+    );
+    // Guard the registry path itself: a broken dskit.json resolution would still
+    // emit screens but mark every instance unmapped. Require real mappings.
+    assert.ok(
+      parsed.meta.transformStats && parsed.meta.transformStats.mapped > 0,
+      "transform must map at least one instance (0 mapped ⇒ registry path is broken again)",
+    );
   });
 
   it("fm-tree-to-flow-data.js CLI runs end-to-end and writes valid flow-data", function () {
@@ -83,12 +108,31 @@ describe("transformers CLI smoke", function () {
     var out = tempOut("flow-data.json");
     runCli(FM_TREE_TO_FLOW, input, out);
 
-    assert.ok(fs.existsSync(out), "fm-tree-to-flow-data must write its output file");
+    assert.ok(
+      fs.existsSync(out),
+      "fm-tree-to-flow-data must write its output file",
+    );
     var parsed = JSON.parse(fs.readFileSync(out, "utf8"));
-    assert.ok(parsed && typeof parsed === "object", "output must parse as a JSON object");
+    assert.ok(
+      parsed && typeof parsed === "object",
+      "output must parse as a JSON object",
+    );
     assert.ok(
       Array.isArray(parsed.screens) && parsed.screens.length > 0,
       "output must have a non-empty screens array",
+    );
+    // Guard the key→ref map: the fixture's fmkit key must resolve to the real ref
+    // (fmButton), not fall through to an "unknown_*"/unmapped placeholder. A broken
+    // registry path would still emit a screen, just with an unresolved instance.
+    var serialized = JSON.stringify(parsed);
+    assert.ok(
+      serialized.indexOf('"ref":"fmButton"') !== -1,
+      "fixture INSTANCE must resolve to ref 'fmButton' (key→ref map must be intact)",
+    );
+    assert.ok(
+      serialized.indexOf('"unmapped":true') === -1 &&
+        serialized.indexOf('"unknown_') === -1,
+      "no instance should be left unmapped/unknown",
     );
   });
 });


### PR DESCRIPTION
## Summary

Phase 0 of the **wider-audience hardening** program — stop-the-bleeding fixes so a fresh-machine first run succeeds before the plugin opens to wider internal testing this week. A 4-lens readiness assessment found confirmed runtime bugs that only worked on the author's box (classic bus-factor). This branch fixes the showstoppers + first-run friction, each with net-new test coverage where the existing tests were blind.

**Bumps `1.95.0 → 1.96.0`** (MINOR — robustness capability + tester guidance the cohort needs).

### Fixes

1. **Hifi pipeline repointed off non-existent `docs/generated/`** → vendored registries via `PATHS.components.registries.{fmkit,dskit}`. Three readers were broken (`fm-tree-to-flow-data.js`, `transform-to-hifi.js`, `component-property-rules.js`); the green tests bypassed the bug via module injection. Added **CLI smoke tests** (real subprocess) — the proof the existing suite couldn't give.
2. **Preview server starts cold.** `ensure-server.sh` sourced `resolve-node.sh` from the wrong dir → empty `$NODE_BIN` unless the caller pre-exported it. Fixed the source path + added a self-healing `command -v node` fallback. Broadened `resolve-node.sh` to cover nvm / Volta / asdf / fnm (was /usr/local + Homebrew only) with an actionable not-found error. Net-new cold-shell smoke test.
3. **Removed the dead SessionStart hook** — `hooks.json` ran `sync-check.sh`, deleted back in v1.79.0, every session start.
4. **Figma MCP point-of-use detect-and-guide** in the companion skill: if the connector is unavailable/unauthorized, tell the user how to connect it (built in on Desktop/Cowork; `/mcp` on CLI) instead of failing cryptically. Notes that hex-instead-of-DS-styles = a library/seat setup issue, not a plugin bug.
5. **Onboarding docs** — env-precise Figma prereqs (editor seat + DS/FM/Meta libraries, `/mcp` on CLI), a `### Prerequisites` block, and **corrected auto-update guidance**: it works in current Claude Code (v2.1.x), opt-in for this third-party marketplace — lead testers with "enable auto-update", `rm -rf` cache-bust demoted to a fallback.

## ⚠️ Operational reminder — re-enable the vendor cron after the test window

The nightly vendor-snapshot cron is **frozen** (`disabled_manually`) for the duration of the test window so an unreviewed knowledge snapshot can't auto-propagate to the whole cohort mid-test. **Re-enable it when testing closes:**

```bash
gh workflow enable "Vendor knowledge-repo snapshot"
```

(PR-checks workflow stays active; only the scheduled snapshot is paused.)

## Test Plan

- [x] Full suite: 939 pass / 1 known-noise fail (`vendor-paths-resolve` trips only on an untracked local `docs/superpowers/*` plan referencing pre-federation paths — not on CI).
- [x] New CLI smoke tests for both transformers (real subprocess, exit 0 + valid output).
- [x] New cold-shell `ensure-server` smoke test (scrubbed `NODE_BIN` → still prints URL + exits 0).
- [x] `hooks.json` parses; PreToolUse groups untouched.
- [x] Final holistic read-only review of the whole branch = SHIP.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
