### PR TITLE
Wider-audience Phase 1: doc-drift sweep + count-guard (v1.97.0)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,7 +1,7 @@
 {
   "name": "actian-design-system",
   "metadata": {
-    "description": "Actian Design System 2026 toolkit — sync tokens from Figma, generate wireframe flows with prototype wiring (with tiered generation: recognized / adapted / improvised), create component briefs, audit designs, compare flows, and build presentations. 9 skills, 8 agents, 155 tokens (3 themes, 8 collections), WCAG 2.1 AA."
+    "description": "Actian Design System 2026 toolkit — generate wireframe flows with prototype wiring (with tiered generation: recognized / adapted / improvised), create component briefs, audit designs, compare flows, and build presentations. 8 skills, 9 agents, 155 tokens (3 themes, 8 collections), WCAG 2.2 AA."
   },
   "owner": {
     "name": "Actian UX Team"
@@ -10,7 +10,7 @@
     {
       "name": "actian-design-system",
       "source": "./plugins/actian-design-system",
-      "description": "Actian Design System 2026 toolkit — 9 skills + 8 agents. Skills: companion, sync-design-system, design-audit, generate-flow, component-brief, create-component, compare-flows, convert-to-hifi, generate-presentation. Agents: flow-researcher, brief-data-validator, wiring-analyzer, flow-consistency, parity-analyzer, screen-generator, card-generator, slide-generator. Direct Figma MCP extraction, 25 recipes, 3-tier fallback ladder for novel patterns, 155 tokens (3 themes, 8 collections), WCAG 2.1 AA."
+      "description": "Actian Design System 2026 toolkit — 8 skills + 9 agents. Skills: companion, design-audit, generate-flow, component-brief, create-component, compare-flows, convert-to-hifi, generate-presentation. Agents: flow-researcher, brief-researcher, brief-data-validator, wiring-analyzer, flow-consistency, parity-analyzer, screen-generator, card-generator, slide-generator. Direct Figma MCP extraction, 24 recipes, 3-tier fallback ladder for novel patterns, 155 tokens (3 themes, 8 collections), WCAG 2.2 AA."
     }
   ]
 }

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -1,10 +1,11 @@
 name: PR checks
 
 # Tier 1 PR gates for the Actian Design System plugin.
-# Three parallel jobs:
+# Four parallel jobs:
 #   1. test            — runs the plugin's full test suite
 #   2. json-syntax     — validates that all checked-in JSON files parse
 #   3. version-bump    — ensures plugin.json is bumped when source changes
+#   4. plugin-validate — `claude plugin validate` on the manifests (offline)
 #
 # Runs on EVERY PR (no paths: filter). Avoids the path-filtered-required-
 # check dead-PR gotcha: required status checks with paths: filters create a
@@ -62,3 +63,27 @@ jobs:
           BASE_SHA: ${{ github.event.pull_request.base.sha }}
           HEAD_SHA: ${{ github.event.pull_request.head.sha }}
         run: node .github/workflows/scripts/check-version-bump.js
+
+  plugin-validate:
+    name: Manifest validation
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - uses: actions/setup-node@v5
+        with:
+          node-version: '22'
+      - name: Install Claude Code CLI
+        # Pinned to the 2.x major (mirrors the @v5 action pins above) so an
+        # upstream major bump can't silently change `validate --strict` behavior
+        # and break this gate mid-test-window.
+        run: npm install -g @anthropic-ai/claude-code@2
+      - name: Validate marketplace manifest (strict)
+        # `claude plugin validate` is a fully offline manifest linter (no auth,
+        # no network — verified). --strict treats warnings as errors.
+        run: claude plugin validate --strict .claude-plugin/marketplace.json
+      - name: Validate plugin manifest
+        # Non-strict: the plugin ships a root CLAUDE.md, which the validator
+        # flags as a warning ("not loaded as project context"). That file is
+        # intentional (local --plugin-dir dev + the plugin's own rules), so we
+        # don't fail on it. Re-add --strict here if/when CLAUDE.md is migrated.
+        run: claude plugin validate plugins/actian-design-system

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,100 @@
+# Changelog
+
+All notable changes to the Actian Design System plugin are documented here.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
+in `plugins/actian-design-system/.claude-plugin/plugin.json`:
+**MAJOR** = breaking, **MINOR** = features, **PATCH** = fixes.
+
+Routine `vendor(knowledge): refresh to vX.Y.Z` commits are automated nightly
+patch bumps that propagate a pinned snapshot from
+[`volivarii/actian-ds-knowledge`](https://github.com/volivarii/actian-ds-knowledge);
+they are not individually listed below unless they changed user-facing behavior.
+
+This file was seeded at v1.97.0 from the commit history; entries before that
+are summarized at the release level.
+
+## [1.97.0] — 2026-06-04
+
+### Fixed
+- **Wider-audience Phase 1 — doc-drift sweep.** Reconciled every advertised
+  inventory count against ground truth (filesystem + vendored registries):
+  - Skills **9 → 8**, agents **8 → 9** across `marketplace.json` and
+    `plugin.json` (and added the missing `brief-researcher` to the marketplace
+    agent list).
+  - Recipes **23 / 25 → 24** (README banner / marketplace).
+  - **WCAG 2.1 → 2.2 AA** across README, `marketplace.json`, `USAGE.md`,
+    `llms.txt` (the substrate moved to 2.2 some releases ago).
+  - Component counts corrected to the vendored registries: **DS Kit 318 / 80
+    sets** (was 322 / 82 / 107), FM Kit 287 / 33, Meta Kit 28 / 11 — in README,
+    `companion-context.md`, `llms.txt`, `figma-push-patterns.md`.
+  - Guideline counts reframed from the obsolete "85 docs / 41 stubs" to the
+    vendored reality: **44 per-component guideline docs** (36 components + 8
+    registry-key aliases), all content-bearing in the current snapshot.
+- Purged the live `sync-design-system` references that survived its v1.79.0
+  decommission (marketplace skill list, `llms-overview.md`); kept the
+  intentional historical tombstones.
+- Rewrote README's stale project-structure tree (it described a pre-federation
+  `docs/foundations.md` / `docs/generated/` layout that no longer exists; the
+  DS substrate now lives under `vendor/`).
+
+### Added
+- **Count-guard regression test** (`tests/integration/doc-counts.test.js`):
+  derives the canonical skills / agents / recipes / component / guideline
+  counts from the source of truth and asserts every managed doc matches —
+  inventory counts can no longer drift silently.
+- **`claude plugin validate` CI gate** in `pr-checks.yml` (`--strict` for the
+  marketplace manifest; non-strict for the plugin manifest).
+- This `CHANGELOG.md`.
+
+## [1.96.0] — 2026-06-03
+
+### Fixed
+- **Wider-audience Phase 0 — stop-the-bleeding hardening** for first-run
+  robustness on fresh machines: repointed the hifi transformers off the
+  non-existent `docs/generated/` onto the vendored registries; fixed
+  `ensure-server.sh` cold-start node resolution; removed a dead `SessionStart`
+  hook; broadened node resolution (nvm / Volta / asdf / fnm / Homebrew /
+  system); env-precise README + point-of-use Figma-MCP guidance; corrected
+  tester auto-update / cache-bust instructions.
+
+## [1.95.0] — 2026-06-03
+
+### Added
+- Fat Marker HTML precision pass + tier-agnostic component-node seam, with
+  three new quality gates (coverage, token-resolution, golden-snapshot).
+
+## [1.94.0] — 2026-06-03
+
+### Added
+- Accessibility linked-criteria slice: sourced WCAG criteria surfaced in the
+  component brief and companion.
+
+## 1.93.x — 2026-06-02
+
+### Changed
+- Drift-proof vendored-path references (`vendor-paths-resolve` CI guard).
+- Adopted the shared knowledge consumption client (resolver import + snapshot
+  copy + drift guard).
+- Track E evictions: plugin now owns `presentation-guide.md` and
+  `fm-to-ds-map.json` under `references/`.
+- Inclusion-based vendoring — dropped upstream tooling from `vendor/`.
+
+## 1.90.0 – 1.91.0 — 2026-05-31
+
+### Changed
+- Consume the substrate directly: `bySlug` O(1) lookup + verbatim
+  `categorySlug`; structured `words-to-avoid.json` with an avoid-word
+  soft-check in flow validation.
+
+## 1.89.0 — earlier
+
+### Changed
+- Refreshed knowledge to slug-only foundations/accessibility filenames with
+  `_order.json`; symmetric `a11y_refs` / `motion_refs` consumer rename.
+
+[1.97.0]: https://github.com/volivarii/Actian-DS-Claude-plugin/releases/tag/v1.97.0
+[1.96.0]: https://github.com/volivarii/Actian-DS-Claude-plugin/releases/tag/v1.96.0
+[1.95.0]: https://github.com/volivarii/Actian-DS-Claude-plugin/releases/tag/v1.95.0
+[1.94.0]: https://github.com/volivarii/Actian-DS-Claude-plugin/releases/tag/v1.94.0

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ The guidelines hold throughout — tokens, spacing, content rules, accessibility
 
 DS knowledge (tokens, components, foundations, content + accessibility guidelines) is vendored from [`volivarii/actian-ds-knowledge`](https://github.com/volivarii/actian-ds-knowledge) — the canonical source-of-truth repo synced directly from Figma. The plugin pulls a pinned snapshot nightly via `vendor-snapshot.yml`.
 
-**v1.96.0** · 8 skills (tiered generation: recognized / adapted / improvised) · 9 agents · 23 recipes · 155 design tokens across 8 collections · 3 themes · WCAG 2.1 AA · surgical refine engine · vision-grounded references · interactive gates · federated knowledge substrate · component briefs with Section 1 supercard (anatomy + variation + tokens + specs / usages / content / motion / accessibility) — Section 6 (real platform examples) deferred
+**v1.97.0** · 8 skills (tiered generation: recognized / adapted / improvised) · 9 agents · 24 recipes · 155 design tokens across 8 collections · 3 themes · WCAG 2.2 AA · surgical refine engine · vision-grounded references · interactive gates · federated knowledge substrate · component briefs with Section 1 supercard (anatomy + variation + tokens + specs / usages / content / motion / accessibility) — Section 6 (real platform examples) deferred
 
 ---
 
@@ -165,7 +165,7 @@ Find every empty state we use across DS Kit
 Brief the Button component from https://figma.com/design/FILEKEY/DS?node-id=123-456
 ```
 
-The companion knows canonical layout patterns (dashboard, detail, browse, creation form, table view, explorer homepage, overlays), the registries (322 DS Kit + 287 FM Kit + 28 Meta Kit components — 82 / 33 / 11 component sets), and the content guidelines. Naming a pattern in your prompt gets you the right skeleton on the first try.
+The companion knows canonical layout patterns (dashboard, detail, browse, creation form, table view, explorer homepage, overlays), the registries (318 DS Kit + 287 FM Kit + 28 Meta Kit components — 80 / 33 / 11 component sets), and the content guidelines. Naming a pattern in your prompt gets you the right skeleton on the first try.
 
 ---
 
@@ -226,8 +226,8 @@ The companion has always-loaded knowledge of:
 - **Foundations** — `foundations.md` is the source of truth (v1.60.0+): a CI workflow regenerates 8 derived JSONs (color roles, spacing scale, type ramp, etc.) on every change, with PR comments confirming the regen
 - **Content rules** — sentence case, action verbs, error message patterns, empty state CTAs
 - **App context** — Studio (integration/catalog), Explorer (discovery), Administration (settings/users) — structured as queryable JSON with entities, terminology rules, and UI patterns
-- **Component inventory** — 322 DS Kit + 287 FM Kit + 28 Meta Kit components (82 / 33 / 11 sets) — dynamically derived from synced registries
-- **Component guidelines** — 85 per-component guideline JSONs (44 fully curated, 41 auto-stubs for set components awaiting authoring)
+- **Component inventory** — 318 DS Kit + 287 FM Kit + 28 Meta Kit components (80 / 33 / 11 sets) — dynamically derived from synced registries
+- **Component guidelines** — 44 per-component guideline docs (36 components + 8 registry-key aliases), all curated in the current snapshot; components without a doc fall back to per-category structural defaults
 
 It loads detailed references on demand: per-component guidelines, accessibility standards, UX patterns, foundation docs.
 
@@ -261,8 +261,8 @@ Figma libraries (DS Kit + FM Kit + Meta Kit) + foundations.md (UX-authored)
 volivarii/actian-ds-knowledge CI (sync-from-figma + foundations-derive)
     |
 plugin's vendor/ snapshot (refreshed nightly via vendor-snapshot.yml)
-    ├─ vendor/components/registries/  -- DS Kit + FM Kit + Meta Kit registries
-    ├─ vendor/components/guidelines/  -- per-component guidelines (44 curated + 41 auto-stubs)
+    ├─ vendor/components/dist/registries/  -- DS Kit + FM Kit + Meta Kit registries
+    ├─ vendor/components/dist/guidelines/  -- 44 per-component guideline docs (36 components + 8 aliases)
     ├─ vendor/foundations/            -- foundations.md + 8 derived JSONs
     ├─ vendor/tokens/                 -- DTCG + CSS custom properties
     ├─ vendor/{content,accessibility,presentation,app-context,fm-to-ds-map}/
@@ -275,7 +275,7 @@ Companion + skills read at runtime
 | Layer | Font | Components | Used for |
 |-------|------|-----------|----------|
 | **Fat Marker (lo-fi)** | Inter | 287 FM Kit components (33 sets) | Wireframe flows |
-| **DS Kit (hi-fi)** | Roboto | 322 DS Kit components (82 sets) | Component briefs, audits, hifi conversion |
+| **DS Kit (hi-fi)** | Roboto | 318 DS Kit components (80 sets) | Component briefs, audits, hifi conversion |
 | **Meta Kit** | Inter | 28 Meta Kit components (11 sets) | All output skills (cards, headers, badges) |
 
 3 themes: **Actian**, **Studio**, **Explorer** — tokens switch via `[data-theme]` CSS or Figma variable modes.
@@ -326,13 +326,16 @@ actian-design-system-plugin/
 │   │   ├── design-audit/                  # skill-specific
 │   │   ├── generate-flow/                 # skill-specific
 │   │   └── generate-presentation/         # skill-specific
-│   ├── tokens/                            # W3C DTCG + CSS custom properties
-│   └── docs/
-│       ├── foundations.md                 # editable source of truth
-│       ├── content-guidelines.md
-│       ├── accessibility-guidelines.md
-│       ├── component-guidelines/          # 85 per-component JSONs (45 full, 40 auto-stub)
-│       └── generated/                     # registries (dskit/fmkit/metakit), app-context, fm-to-ds-map, foundations JSONs
+│   ├── schemas/                           # JSON schemas (brief-data, flow-data, slide-data)
+│   ├── templates/                         # HTML wrappers (flow, fm, component-playground, annotation-layer)
+│   ├── vendor/                            # pinned knowledge-repo snapshot — the DS substrate
+│   │   ├── components/                    # registries (dskit/fmkit/metakit) + 44 guideline docs + bundles
+│   │   ├── foundations/                   # foundations.md (source of truth) + 8 derived JSONs
+│   │   ├── tokens/                        # W3C DTCG JSON + CSS custom properties
+│   │   ├── accessibility/                 # per-section WCAG 2.2 AA docs
+│   │   ├── content/                       # global.md + words-to-avoid.json
+│   │   └── app-context/                   # app-context.json
+│   └── docs/                              # llms-overview.md (AI orientation) + superpowers/ (specs, plans, audits)
 └── USAGE.md                               # detailed usage guide
 ```
 

--- a/USAGE.md
+++ b/USAGE.md
@@ -326,7 +326,7 @@ Write an error message for a failed connection — timeout after 30s
 What should the empty state say when there are no data products?
 ```
 
-### Accessibility — WCAG 2.1 AA checks
+### Accessibility — WCAG 2.2 AA checks
 
 ```
 https://figma.com/design/FILEKEY/File?node-id=123-456

--- a/llms.txt
+++ b/llms.txt
@@ -1,6 +1,6 @@
 # Actian Design System
 
-> Actian's design system, packaged as a Claude Code plugin. 9 skills for authoring and auditing Figma designs against the Actian DS via the official Figma MCP server. 155 tokens (3 themes, 8 collections), 107 DS Kit components, 33 FM Kit wireframe components, 25 Meta Kit + 3 templates.
+> Actian's design system, packaged as a Claude Code plugin. 8 skills for authoring and auditing Figma designs against the Actian DS via the official Figma MCP server. 155 tokens (3 themes, 8 collections), 318 DS Kit components, 287 FM Kit wireframe components, 28 Meta Kit components.
 
 The Actian DS is in a federated configuration (2026-05-09): the **knowledge layer** lives in [`volivarii/actian-ds-knowledge`](https://github.com/volivarii/actian-ds-knowledge); this plugin vendors a pinned snapshot at release time. The URLs below point AI agents at the canonical knowledge repo. The plugin's own AI orientation, push patterns, and skill code are linked at the bottom under "Plugin meta-docs".
 
@@ -8,7 +8,7 @@ The Actian DS is in a federated configuration (2026-05-09): the **knowledge laye
 
 - [AI agent orientation](https://raw.githubusercontent.com/volivarii/Actian-DS-Claude-plugin/main/plugins/actian-design-system/docs/llms-overview.md): start here — explains how DS knowledge is organized across tokens, registries, guidelines, and skills
 - [Plugin README](https://raw.githubusercontent.com/volivarii/Actian-DS-Claude-plugin/main/README.md): repo-level overview
-- [Plugin usage guide](https://raw.githubusercontent.com/volivarii/Actian-DS-Claude-plugin/main/USAGE.md): how to invoke the 9 skills
+- [Plugin usage guide](https://raw.githubusercontent.com/volivarii/Actian-DS-Claude-plugin/main/USAGE.md): how to invoke the 8 skills
 
 ## Knowledge — Foundations
 
@@ -20,13 +20,13 @@ The Actian DS is in a federated configuration (2026-05-09): the **knowledge laye
 ## Knowledge — Content & Accessibility
 
 - [Content guidelines](https://raw.githubusercontent.com/volivarii/actian-ds-knowledge/main/content/content.md): voice, tone, copy patterns
-- [Accessibility guidelines](https://raw.githubusercontent.com/volivarii/actian-ds-knowledge/main/accessibility/accessibility.md): WCAG 2.1 AA conformance
+- [Accessibility guidelines](https://raw.githubusercontent.com/volivarii/actian-ds-knowledge/main/accessibility/accessibility.md): WCAG 2.2 AA conformance
 
 ## Knowledge — Components
 
-- [DS Kit registry](https://raw.githubusercontent.com/volivarii/actian-ds-knowledge/main/components/registries/dskit.json): 107 design system components with keys, variants, and properties
-- [FM Kit registry](https://raw.githubusercontent.com/volivarii/actian-ds-knowledge/main/components/registries/fmkit.json): 33 wireframe components
-- [Meta Kit registry](https://raw.githubusercontent.com/volivarii/actian-ds-knowledge/main/components/registries/metakit.json): 25 components + 3 templates
+- [DS Kit registry](https://raw.githubusercontent.com/volivarii/actian-ds-knowledge/main/components/registries/dskit.json): 318 design system components with keys, variants, and properties
+- [FM Kit registry](https://raw.githubusercontent.com/volivarii/actian-ds-knowledge/main/components/registries/fmkit.json): 287 wireframe components
+- [Meta Kit registry](https://raw.githubusercontent.com/volivarii/actian-ds-knowledge/main/components/registries/metakit.json): 28 components
 - [App context](https://raw.githubusercontent.com/volivarii/actian-ds-knowledge/main/app-context/app-context.json): apps, entities, terminology, patterns
 - [FM↔DS map](https://raw.githubusercontent.com/volivarii/actian-ds-knowledge/main/fm-to-ds-map/fm-to-ds-map.json): wireframe-to-DS component mapping
 
@@ -42,6 +42,6 @@ The Actian DS is in a federated configuration (2026-05-09): the **knowledge laye
 - [CLAUDE.md (always-loaded plugin context)](https://raw.githubusercontent.com/volivarii/Actian-DS-Claude-plugin/main/plugins/actian-design-system/CLAUDE.md)
 - [Plugin architecture map](https://raw.githubusercontent.com/volivarii/Actian-DS-Claude-plugin/main/plugins/actian-design-system/ARCHITECTURE.md)
 - [Knowledge repo README](https://raw.githubusercontent.com/volivarii/actian-ds-knowledge/main/README.md): federation status, repo layout, CI workflows
-- [Component guidelines (85 JSON files, 44 curated)](https://github.com/volivarii/actian-ds-knowledge/tree/main/components/guidelines): per-component guideline JSONs
+- [Component guidelines (44 JSON files, all curated)](https://github.com/volivarii/actian-ds-knowledge/tree/main/components/guidelines): per-component guideline JSONs
 - [Foundations subtree (8 JSON files)](https://github.com/volivarii/actian-ds-knowledge/tree/main/foundations): per-foundation JSON files derived from foundations.md
 - [Presentation guide](https://raw.githubusercontent.com/volivarii/actian-ds-knowledge/main/presentation/presentation-guide.md): generate-presentation skill content patterns

--- a/plugins/actian-design-system/.claude-plugin/plugin.json
+++ b/plugins/actian-design-system/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "actian-design-system",
-  "description": "Actian Design System toolkit — generate wireframe flows with prototype wiring, create component briefs, audit designs, compare flows, and build presentations. 8 skills (with tiered generation: recognized / adapted / improvised), 8 agents, 155 tokens (3 themes, 8 collections), WCAG 2.2 AA. DS knowledge vendored from volivarii/actian-ds-knowledge.",
-  "version": "1.96.0",
+  "description": "Actian Design System toolkit — generate wireframe flows with prototype wiring, create component briefs, audit designs, compare flows, and build presentations. 8 skills (with tiered generation: recognized / adapted / improvised), 9 agents, 155 tokens (3 themes, 8 collections), WCAG 2.2 AA. DS knowledge vendored from volivarii/actian-ds-knowledge.",
+  "version": "1.97.0",
   "author": {
     "name": "Actian UX Team"
   },

--- a/plugins/actian-design-system/docs/llms-overview.md
+++ b/plugins/actian-design-system/docs/llms-overview.md
@@ -7,9 +7,9 @@ repo root.
 ## What this plugin is
 
 Actian's federated DS substrate, packaged as a Claude Code plugin. Provides
-9 skills (component-brief, generate-flow, generate-presentation,
-create-component, convert-to-hifi, design-audit, compare-flows, companion,
-sync-design-system) that author and audit Figma designs against the
+8 skills (component-brief, generate-flow, generate-presentation,
+create-component, convert-to-hifi, design-audit, compare-flows, companion)
+that author and audit Figma designs against the
 Actian DS via the official Figma MCP server.
 
 ## How knowledge is structured

--- a/plugins/actian-design-system/references/context/companion-context.md
+++ b/plugins/actian-design-system/references/context/companion-context.md
@@ -104,9 +104,9 @@ Full context: `references/context/app-context.md`
 
 | Library | Count | Font | Use |
 |---------|-------|------|-----|
-| DS Kit | 107 sets | Roboto | Full design system, all tokens, 3 themes |
-| FM Kit | 44 components | Inter | Lo-fi wireframes, FM palette |
-| Meta Kit | 25 components + 3 templates | Inter | Generation output, annotation markers |
+| DS Kit | 318 components (80 sets) | Roboto | Full design system, all tokens, 3 themes |
+| FM Kit | 287 components (33 sets) | Inter | Lo-fi wireframes, FM palette |
+| Meta Kit | 28 components (11 sets) | Inter | Generation output, annotation markers |
 
 Before building custom frames, check: `vendor/components/dist/dskit-components.md`, `vendor/components/dist/fm-components.md`, `vendor/components/dist/guidelines/{slug}.json`
 
@@ -162,9 +162,11 @@ The knowledge repo ships per-category structural defaults at
 category: action, form-input-selection, navigation, data-display,
 feedback, overlays) plus a `categories.bundle.json` roll-up. Each file
 declares the anatomy/variants/motion-refs/a11y-refs that apply across
-every component in the category. Stub components (those with auto-stub
-guidelines, ~41 of 85) lift these defaults into the brief grounding
-payload via `scripts/transformers/category-defaults-loader.js`.
+every component in the category. Components without curated guideline
+content — a stub guideline, or no per-component doc at all (most of the
+catalog; 44 guideline docs cover 36 components + 8 registry-key aliases) —
+lift these defaults into the brief grounding payload via
+`scripts/transformers/category-defaults-loader.js`.
 
 **Authoring workflow** lives in the knowledge repo at
 `components/src/categories/<slug>.md` (YAML frontmatter — the data —

--- a/plugins/actian-design-system/references/figma/figma-push-patterns.md
+++ b/plugins/actian-design-system/references/figma/figma-push-patterns.md
@@ -13,9 +13,9 @@ Direct Figma Plugin API patterns for pushing content to Figma. Each pattern is a
 
 | Registry | File | Contents |
 |----------|------|----------|
-| FM Kit | `vendor/components/dist/registries/fmkit.json` | 33 wireframe components with keys, variants, and properties |
-| Meta Kit | `vendor/components/dist/registries/metakit.json` | 25 components + 3 templates |
-| DS Kit | `vendor/components/dist/registries/dskit.json` | 107 design system components with keys, variants, and properties |
+| FM Kit | `vendor/components/dist/registries/fmkit.json` | 287 wireframe components with keys, variants, and properties |
+| Meta Kit | `vendor/components/dist/registries/metakit.json` | 28 components with keys, variants, and properties |
+| DS Kit | `vendor/components/dist/registries/dskit.json` | 318 design system components with keys, variants, and properties |
 
 Each registry entry contains: `key`, `importMethod` ("set" for `importComponentSetByKeyAsync`, "single" for `importComponentByKeyAsync`), `variants`, and `properties` (with exact hash-suffixed names for `setProperties()`).
 

--- a/plugins/actian-design-system/tests/integration/doc-counts.test.js
+++ b/plugins/actian-design-system/tests/integration/doc-counts.test.js
@@ -1,0 +1,308 @@
+#!/usr/bin/env node
+"use strict";
+
+/**
+ * doc-counts.test.js — Guard the human-facing inventory counts against the
+ * actual ground truth (filesystem + vendored registries).
+ *
+ * WHY THIS EXISTS
+ * ---------------
+ * The plugin advertises counts in prose across many surfaces: README banner,
+ * marketplace.json (two descriptions), plugin.json, llms.txt, companion-context,
+ * figma-push-patterns. Nothing kept them in sync, so they drifted badly
+ * (v1.97.0 sweep found: skills 9 vs 8, agents 8 vs 9, recipes 23/25 vs 24,
+ * WCAG 2.1 vs 2.2, DS Kit 322/107 vs 318, "85 guidelines / 41 stubs" when the
+ * vendored snapshot ships 44 docs and 0 stubs).
+ *
+ * This test DERIVES the canonical counts from the source of truth and asserts
+ * each managed doc states them correctly. When the registries re-vendor or a
+ * skill/agent/recipe is added, this test fails loudly and tells you exactly
+ * which doc string to update — drift can no longer ship silently.
+ *
+ * Ground truth:
+ *   - skills   = skills/<name>/ dirs containing a SKILL.md
+ *   - agents   = agents/*.md files
+ *   - recipes  = recipes/<kind>/*.json files excluding _index.json
+ *   - DS/FM/Meta components + sets = vendor/components/dist/registries/*.json
+ *   - guideline docs = vendor/components/dist/guidelines/*.json (minus the bundle)
+ *
+ * Zero dependencies — Node.js built-ins only.
+ * Run with: node tests/integration/doc-counts.test.js
+ * (from the plugins/actian-design-system directory)
+ */
+
+var { describe, it } = require("node:test");
+var assert = require("node:assert");
+var fs = require("fs");
+var path = require("path");
+
+var PLUGIN_ROOT = path.resolve(__dirname, "..", "..");
+var REPO_ROOT = path.resolve(PLUGIN_ROOT, "..", "..");
+
+// ---------------------------------------------------------------------------
+// Derive canonical counts from ground truth
+// ---------------------------------------------------------------------------
+
+function listDirs(p) {
+  if (!fs.existsSync(p)) return [];
+  return fs.readdirSync(p).filter(function (e) {
+    return fs.statSync(path.join(p, e)).isDirectory();
+  });
+}
+
+function deriveSkills() {
+  return listDirs(path.join(PLUGIN_ROOT, "skills")).filter(function (d) {
+    return fs.existsSync(path.join(PLUGIN_ROOT, "skills", d, "SKILL.md"));
+  }).length;
+}
+
+function deriveAgents() {
+  var dir = path.join(PLUGIN_ROOT, "agents");
+  if (!fs.existsSync(dir)) return 0;
+  return fs.readdirSync(dir).filter(function (f) {
+    return f.endsWith(".md");
+  }).length;
+}
+
+function deriveRecipes() {
+  var root = path.join(PLUGIN_ROOT, "recipes");
+  var total = 0;
+  listDirs(root).forEach(function (kind) {
+    fs.readdirSync(path.join(root, kind)).forEach(function (f) {
+      if (f.endsWith(".json") && f !== "_index.json") total++;
+    });
+  });
+  return total;
+}
+
+function deriveRegistry(lib) {
+  var p = path.join(
+    PLUGIN_ROOT,
+    "vendor",
+    "components",
+    "dist",
+    "registries",
+    lib + ".json",
+  );
+  var reg = JSON.parse(fs.readFileSync(p, "utf8"));
+  var keys = Object.keys(reg.components || {});
+  var sets = keys.filter(function (k) {
+    return reg.components[k].importMethod === "set";
+  }).length;
+  // Prefer the declared componentCount; fall back to key count.
+  var count =
+    typeof reg.componentCount === "number" ? reg.componentCount : keys.length;
+  return { count: count, sets: sets, keyCount: keys.length };
+}
+
+function deriveGuidelines() {
+  var dir = path.join(
+    PLUGIN_ROOT,
+    "vendor",
+    "components",
+    "dist",
+    "guidelines",
+  );
+  var files = fs.readdirSync(dir).filter(function (f) {
+    return f.endsWith(".json") && f !== "guidelines.bundle.json";
+  });
+  var aliases = files.filter(function (f) {
+    var j = JSON.parse(fs.readFileSync(path.join(dir, f), "utf8"));
+    return Object.prototype.hasOwnProperty.call(j, "_alias_of");
+  }).length;
+  return {
+    total: files.length,
+    canonical: files.length - aliases,
+    aliases: aliases,
+  };
+}
+
+var SKILLS = deriveSkills();
+var AGENTS = deriveAgents();
+var RECIPES = deriveRecipes();
+var DS = deriveRegistry("dskit");
+var FM = deriveRegistry("fmkit");
+var META = deriveRegistry("metakit");
+var GUIDE = deriveGuidelines();
+
+// ---------------------------------------------------------------------------
+// Managed doc surfaces + the strings each must contain / must not contain.
+// `mustContain` strings are built FROM the derived counts, so they track the
+// ground truth automatically. `mustNotContain` are regression guards for the
+// specific stale values this guard was created to kill.
+// ---------------------------------------------------------------------------
+
+function f(rel) {
+  return path.join(REPO_ROOT, rel);
+}
+
+var CHECKS = [
+  {
+    file: f("README.md"),
+    mustContain: [
+      SKILLS + " skills",
+      AGENTS + " agents",
+      RECIPES + " recipes",
+      "WCAG 2.2 AA",
+      DS.count +
+        " DS Kit + " +
+        FM.count +
+        " FM Kit + " +
+        META.count +
+        " Meta Kit",
+      DS.count + " DS Kit components (" + DS.sets + " sets)",
+      GUIDE.total + " per-component guideline docs",
+    ],
+    mustNotContain: [
+      "WCAG 2.1 AA",
+      "322 DS Kit",
+      "82 / 33 / 11",
+      "82 sets",
+      "85 per-component",
+      "41 auto-stub",
+      "44 fully curated",
+    ],
+  },
+  {
+    file: f(".claude-plugin/marketplace.json"),
+    mustContain: [
+      SKILLS + " skills, " + AGENTS + " agents",
+      SKILLS + " skills + " + AGENTS + " agents",
+      RECIPES + " recipes",
+      "WCAG 2.2 AA",
+      "brief-researcher",
+    ],
+    mustNotContain: ["WCAG 2.1 AA", "sync-design-system", "25 recipes"],
+  },
+  {
+    file: f("plugins/actian-design-system/.claude-plugin/plugin.json"),
+    mustContain: [SKILLS + " skills", AGENTS + " agents", "WCAG 2.2 AA"],
+    mustNotContain: ["WCAG 2.1 AA"],
+  },
+  {
+    file: f("llms.txt"),
+    mustContain: [
+      SKILLS + " skills",
+      DS.count + " DS Kit components",
+      FM.count + " FM Kit wireframe components",
+      META.count + " Meta Kit components",
+      "WCAG 2.2 AA",
+      GUIDE.total + " JSON files",
+    ],
+    mustNotContain: [
+      "WCAG 2.1 AA",
+      "107 DS Kit",
+      "107 design system",
+      "85 JSON files",
+    ],
+  },
+  {
+    file: f("USAGE.md"),
+    mustContain: ["WCAG 2.2 AA"],
+    mustNotContain: ["WCAG 2.1 AA"],
+  },
+  {
+    file: f(
+      "plugins/actian-design-system/references/context/companion-context.md",
+    ),
+    mustContain: [
+      DS.count + " components (" + DS.sets + " sets)",
+      FM.count + " components (" + FM.sets + " sets)",
+      META.count + " components (" + META.sets + " sets)",
+      GUIDE.total + " guideline docs",
+    ],
+    mustNotContain: ["107 sets", "44 components |", "~41 of 85"],
+  },
+  {
+    file: f(
+      "plugins/actian-design-system/references/figma/figma-push-patterns.md",
+    ),
+    mustContain: [
+      DS.count + " design system components",
+      FM.count + " wireframe components",
+    ],
+    mustNotContain: ["107 design system components", "33 wireframe components"],
+  },
+];
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("Doc inventory counts match ground truth", function () {
+  it("derives sane counts from the filesystem + registries", function () {
+    assert.ok(SKILLS >= 1, "skills count should be >= 1");
+    assert.ok(AGENTS >= 1, "agents count should be >= 1");
+    assert.ok(RECIPES >= 1, "recipes count should be >= 1");
+    assert.ok(DS.count > 0 && FM.count > 0 && META.count > 0);
+    assert.ok(GUIDE.total > 0);
+    // The declared componentCount must equal the actual component-key count.
+    ["dskit", "fmkit", "metakit"].forEach(function (lib) {
+      var r = deriveRegistry(lib);
+      assert.equal(
+        r.count,
+        r.keyCount,
+        lib +
+          ".json: componentCount (" +
+          r.count +
+          ") != #components keys (" +
+          r.keyCount +
+          ")",
+      );
+    });
+  });
+
+  CHECKS.forEach(function (check) {
+    var rel = path.relative(REPO_ROOT, check.file);
+    describe(rel, function () {
+      var content = fs.existsSync(check.file)
+        ? fs.readFileSync(check.file, "utf8")
+        : null;
+
+      it("exists", function () {
+        assert.ok(content !== null, "managed doc not found: " + rel);
+      });
+
+      (check.mustContain || []).forEach(function (needle) {
+        it('states "' + needle + '"', function () {
+          assert.ok(
+            content && content.indexOf(needle) !== -1,
+            rel +
+              ' is missing expected count string "' +
+              needle +
+              '".\nGround truth: ' +
+              SKILLS +
+              " skills / " +
+              AGENTS +
+              " agents / " +
+              RECIPES +
+              " recipes / DS " +
+              DS.count +
+              "(" +
+              DS.sets +
+              " sets) / FM " +
+              FM.count +
+              "(" +
+              FM.sets +
+              " sets) / Meta " +
+              META.count +
+              "(" +
+              META.sets +
+              " sets) / " +
+              GUIDE.total +
+              " guideline docs.\nUpdate the doc to match.",
+          );
+        });
+      });
+
+      (check.mustNotContain || []).forEach(function (needle) {
+        it('does not contain stale "' + needle + '"', function () {
+          assert.ok(
+            content && content.indexOf(needle) === -1,
+            rel + ' still contains stale string "' + needle + '" — remove it.',
+          );
+        });
+      });
+    });
+  });
+});


### PR DESCRIPTION
## Wider-audience hardening — Phase 1 (doc-drift sweep)

Second slice of the wider-audience hardening program (Phase 0 = #137). The plugin is being promoted to a wider internal testing audience this week; the advertised inventory counts had drifted badly across surfaces, and nothing kept them in sync. This reconciles every count against **ground truth** (filesystem + vendored registries) and adds a derive-driven guard so they can't silently re-drift.

### Drift found & fixed

| Fact | Was (drifted) | Now (ground truth) |
|---|---|---|
| Skills | 9 (+ dead `sync-design-system`) | **8** |
| Agents | 8 (missing `brief-researcher`) | **9** |
| Recipes | 23 / 25 | **24** |
| WCAG | 2.1 AA | **2.2 AA** |
| DS Kit | 322 / 82 sets / 107 | **318 / 80 sets** |
| FM / Meta | "44 comp" / "25+3" | **287/33 · 28/11** |
| Guidelines | "85 docs, 41 stubs" | **44 docs (36 + 8 aliases), 0 stubs** |

**Surfaces reconciled:** `marketplace.json` (both descriptions; dropped `sync-design-system`, added `brief-researcher`), `plugin.json` (9 agents, v1.97.0), `README.md` (banner, ×3 component counts, guideline reframe, **rewrote the stale project-structure tree** that described a non-existent `docs/generated/`), `USAGE.md`, `llms.txt`, `llms-overview.md`, `companion-context.md`, `figma-push-patterns.md`. Live `sync-design-system` refs purged; historical tombstones kept.

### Added (root-cause fixes, not just patches)

- **`tests/integration/doc-counts.test.js`** — derive-driven count-guard (57 assertions). Reads the registries/filesystem and asserts each managed doc matches; fails loudly on future drift. Runs in the existing `test` CI job.
- **`plugin-validate` CI job** in `pr-checks.yml` — `claude plugin validate` (`--strict` on the marketplace manifest, non-strict on the plugin manifest; runs fully offline, CLI pinned to `@2`).
- **`CHANGELOG.md`** — seeded from git history.

### Verification

- Count-guard **57/57** · full suite green (the lone local `vendor-paths-resolve` failure is gitignored/untracked `docs/superpowers/plans/*`, absent in CI)
- `claude plugin validate` passes both manifests · YAML valid
- **Independent 3-reviewer pass** (accuracy & completeness / test & CI robustness / tester-facing quality) — all **PASS**; every number re-derived from scratch; findings addressed (guard now *asserts* guideline counts; README tree parentheticals corrected; CLI pinned).

### Follow-ups logged for Phase 2 (not in this PR)

- `claude plugin validate --strict` on the **plugin** manifest fails on a `CLAUDE.md` "not loaded as project context" warning — worth confirming whether the plugin-root rules actually load for marketplace-install testers (real wider-audience robustness question).
- Empty untracked cruft dir `plugins/actian-design-system/plugins/` (harmless; confuses `validate` path resolution).

> Note: the vendor knowledge-snapshot cron was re-enabled (`active`) per maintainer instruction (it had been frozen during Phase 0 for content control).

🤖 Generated with [Claude Code](https://claude.com/claude-code)