### PR TITLE
feat(flow): generate-flow Tier A perceived-performance — preview-before-push + N/M progress + --refresh seam (v1.99.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,18 @@ they are not individually listed below unless they changed user-facing behavior.
 This file was seeded at v1.97.0 from the commit history; entries before that
 are summarized at the release level.
 
+## [1.99.0] — 2026-06-04
+
+### Added
+- **generate-flow visual feedback (Tier A).** The HTML preview now renders
+  **automatically and before** the Figma push (was opt-in and last), and the
+  build + push phases stream `N/M` progress to the chat — so the run is never a
+  silent wait and the visual lands before the slow push.
+- **`assemble-preview.js --refresh <seconds>`** — injects a self-contained
+  auto-reload (meta-refresh + JS fallback, no server) into the preview HTML.
+  Off by default; deterministic. Seam for the staged "watch it build"
+  follow-on + a Cowork auto-refresh spike.
+
 ## [1.98.2] — 2026-06-04
 
 ### Fixed

--- a/plugins/actian-design-system/.claude-plugin/plugin.json
+++ b/plugins/actian-design-system/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "actian-design-system",
   "description": "Actian Design System toolkit — generate wireframe flows with prototype wiring, create component briefs, audit designs, compare flows, and build presentations. 8 skills (with tiered generation: recognized / adapted / improvised), 9 agents, 155 tokens (3 themes, 8 collections), WCAG 2.2 AA. DS knowledge vendored from volivarii/actian-ds-knowledge.",
-  "version": "1.98.2",
+  "version": "1.99.0",
   "author": {
     "name": "Actian UX Team"
   },

--- a/plugins/actian-design-system/scripts/renderers/assemble-preview.js
+++ b/plugins/actian-design-system/scripts/renderers/assemble-preview.js
@@ -142,7 +142,13 @@ function escapeJsonForScript(jsonStr) {
 // ---------------------------------------------------------------------------
 
 function parseArgs(argv) {
-  var args = { input: null, type: null, output: null, annotations: true };
+  var args = {
+    input: null,
+    type: null,
+    output: null,
+    annotations: true,
+    refresh: 0,
+  };
   var positionals = [];
   var i = 2; // skip node + script
 
@@ -154,6 +160,8 @@ function parseArgs(argv) {
       args.output = argv[++i];
     } else if (arg === "--no-annotations") {
       args.annotations = false;
+    } else if (arg === "--refresh" && i + 1 < argv.length) {
+      args.refresh = parseFloat(argv[++i]);
     } else if (arg.charAt(0) !== "-") {
       positionals.push(arg);
     }
@@ -197,6 +205,12 @@ function main() {
               name: "--no-annotations",
               required: false,
               description: "Skip annotation layer (Alpine.js + UI)",
+            },
+            {
+              name: "--refresh",
+              required: false,
+              description:
+                "Inject a self-contained auto-reload (meta + JS) every N seconds; 0/absent = off",
             },
           ],
           types: Object.keys(TYPE_CONFIGS),
@@ -283,6 +297,20 @@ function main() {
   // No transform needed — all renderers read the same format as their *-to-figma.js counterparts
   var escapedJson = escapeJsonForScript(rawJson);
 
+  // Self-contained auto-reload (no server). Off unless --refresh <positive seconds>.
+  // meta-refresh covers static panels; the setTimeout is a JS fallback. Both are
+  // deterministic given the interval (no timestamps/randomness) so goldens are stable.
+  var refreshSecs =
+    typeof args.refresh === "number" && args.refresh > 0 ? args.refresh : 0;
+  var refreshHead = refreshSecs
+    ? '  <meta http-equiv="refresh" content="' + refreshSecs + '">\n'
+    : "";
+  var refreshBody = refreshSecs
+    ? "  <script>setTimeout(function(){location.reload();}, " +
+      Math.round(refreshSecs * 1000) +
+      ");</script>\n"
+    : "";
+
   // Assemble HTML
   var html =
     "<!DOCTYPE html>\n" +
@@ -290,6 +318,7 @@ function main() {
     "<head>\n" +
     '  <meta charset="UTF-8">\n' +
     '  <meta name="viewport" content="width=device-width, initial-scale=1.0">\n' +
+    refreshHead +
     "  <title>" +
     title +
     "</title>\n" +
@@ -322,6 +351,7 @@ function main() {
         annotationHtml +
         "\n"
       : "") +
+    refreshBody +
     "</body>\n" +
     "</html>\n";
 

--- a/plugins/actian-design-system/skills/generate-flow/SKILL.md
+++ b/plugins/actian-design-system/skills/generate-flow/SKILL.md
@@ -257,6 +257,7 @@ If any condition fails, fall back per the table below.
        --output {project_working_directory}/flows/flow-data.json
      ```
      Sequential mode (<6 screens): build flow-data.json directly — but FIRST classify each screen per the agent's Step 0 (above). When `meta.references[]` has fingerprints, the AI reads them inline from the in-memory flow-data when picking recipes.
+   - **Progress (chat):** this is the longest silent phase — keep the user informed. Print one line per screen as it lands (parallel batches: as each batch's partials merge; sequential: as each screen object is authored): `✓ <N>/<M> <screen name>`. Lead with `Building <feature> — <M> screens` before the first.
 6. **Validate flow data** — run the validation script before pushing:
    ```bash
    source "${CLAUDE_PLUGIN_ROOT}/scripts/lib/resolve-node.sh"
@@ -299,12 +300,20 @@ For warning-level findings (`default-true-boolean-unset`, `unresolved-token`, `t
 
 **`intent-mismatch` recovery (hifi tier only):** When the validator flags `intent-mismatch` findings on hifi-converted data, either change the variant to match the expected variant for the effective intent (e.g., `Type=Critical primary` for `destructive-action` on a DS button), OR change the `intent` field at the responsible node to reflect the actual screen role. For sibling-rule warnings ("destructive-action container ambiguous" or "missing Critical primary"), restructure the button group: exactly one Critical primary action button, with Tertiary or Secondary cancel/dismiss siblings.
 
-7. Push to Figma (see Push section below)
-7.5. **Post-push gate** (interactive — see Step 7.5 below) — runs the audit if `--audit` is set OR designer opts in via gate.
-8. Preview (opt-in):
+6.5. **Auto-render the HTML preview (always — before the push).** As soon as validation passes, render the preview from `flow-data.json` and surface it to the user. This is automatic (NOT opt-in) and happens BEFORE the slow Figma push, so the user sees the design fast:
    ```bash
    source "${CLAUDE_PLUGIN_ROOT}/scripts/lib/resolve-node.sh"
-   "$NODE_BIN" "${CLAUDE_PLUGIN_ROOT}/scripts/renderers/assemble-preview.js" flow-data.json --type flow -o {project_working_directory}/flows/[feature]-flow.html
+   "$NODE_BIN" "${CLAUDE_PLUGIN_ROOT}/scripts/renderers/assemble-preview.js" \
+     {project_working_directory}/flows/flow-data.json --type flow \
+     -o {project_working_directory}/flows/[feature]-flow.html
+   ```
+   Tell the user: `Preview ready → <path>`. **If the render fails, surface the error and CONTINUE to the push** — the preview is an aid, never a gate. (The render reads only `flow-data.json`; it has no dependency on the push.)
+7. Push to Figma (see Push section below)
+   - **Progress (chat):** print `Pushing <N>/<M> to Figma…` as each screen frame is pushed, so the push phase is never silent.
+7.5. **Post-push gate** (interactive — see Step 7.5 below) — runs the audit if `--audit` is set OR designer opts in via gate.
+8. Preview — already rendered automatically at Step 6.5 (before the push). If the user needs it re-served (local server), run `ensure-server.sh`:
+   ```bash
+   source "${CLAUDE_PLUGIN_ROOT}/scripts/lib/resolve-node.sh"
    BASE_URL=$(${CLAUDE_PLUGIN_ROOT}/scripts/renderers/ensure-server.sh "{project_working_directory}" 8765)
    ```
 9. Parity check (opt-in) → `references/figma/parity-check.md` + `references/ds-rules/quality-checklist.md`. Manifest includes `sourceHash` (of flow-data.json), `componentKeys` (from push), and `tokenHash` (of tokens file).
@@ -395,7 +404,7 @@ Does this work, or would you like to adjust?
 **Actions:**
 - **"approve"** — standard detail, build data model
 - **"approve draft"** or **"approve production"** — specify detail level
-- **"preview"** — generate HTML preview before pushing
+- **"preview"** — (now default) the HTML preview always renders automatically before the push; this action no longer changes behavior
 - **"push [Figma URL]"** — approve standard + push directly to Figma
 - **"push draft [URL]"** or **"push production [URL]"** — specify detail + push
 ```

--- a/plugins/actian-design-system/tests/integration/generate-flow-preview-ordering.test.js
+++ b/plugins/actian-design-system/tests/integration/generate-flow-preview-ordering.test.js
@@ -1,0 +1,24 @@
+"use strict";
+var { describe, it } = require("node:test");
+var assert = require("node:assert");
+var fs = require("node:fs");
+var path = require("node:path");
+
+var SKILL = path.resolve(__dirname, "../../skills/generate-flow/SKILL.md");
+
+describe("generate-flow pipeline ordering", function () {
+  var src = fs.readFileSync(SKILL, "utf8");
+
+  it("renders the preview before pushing to Figma", function () {
+    // The auto-render step (6.5) must appear before the push (Step 7) in the pipeline.
+    var renderIdx = src.indexOf("Auto-render the HTML preview");
+    var pushIdx = src.indexOf("7. Push to Figma");
+    assert.ok(renderIdx !== -1, "Step 6.5 auto-render block must exist");
+    assert.ok(pushIdx !== -1, "Step 7 push must exist");
+    assert.ok(renderIdx < pushIdx, "preview render (6.5) must precede the push (7)");
+  });
+
+  it("documents the preview render as automatic / before the push", function () {
+    assert.match(src, /before the push/i, "preview must be described as before the push");
+  });
+});

--- a/plugins/actian-design-system/tests/renderers/assemble-preview-refresh.test.js
+++ b/plugins/actian-design-system/tests/renderers/assemble-preview-refresh.test.js
@@ -1,0 +1,102 @@
+"use strict";
+var { describe, it } = require("node:test");
+var assert = require("node:assert");
+var fs = require("node:fs");
+var os = require("node:os");
+var path = require("node:path");
+var cp = require("node:child_process");
+
+var SCRIPT = path.resolve(
+  __dirname,
+  "../../scripts/renderers/assemble-preview.js",
+);
+var FIXTURE = path.join(__dirname, "fixtures", "refresh-probe.flow.json");
+
+function render(extraArgs) {
+  var out = path.join(
+    os.tmpdir(),
+    "csw-refresh-" +
+      process.pid +
+      "-" +
+      extraArgs.join("_").replace(/[^a-z0-9]/gi, "") +
+      ".html",
+  );
+  var args = [SCRIPT, FIXTURE, "--type", "flow", "-o", out].concat(extraArgs);
+  var r = cp.spawnSync(process.execPath, args, { encoding: "utf8" });
+  assert.equal(r.status, 0, r.stderr);
+  var html = fs.readFileSync(out, "utf8");
+  fs.unlinkSync(out);
+  return html;
+}
+
+describe("assemble-preview --refresh", function () {
+  it("injects a self-contained meta-refresh + JS reload at the given interval", function () {
+    var html = render(["--refresh", "2"]);
+    assert.match(
+      html,
+      /<meta http-equiv="refresh" content="2">/,
+      "meta-refresh present",
+    );
+    assert.match(
+      html,
+      /setTimeout\(function\(\)\{location\.reload\(\);\}, 2000\)/,
+      "JS reload fallback present at 2000ms",
+    );
+  });
+
+  it("injects nothing when the flag is absent (default)", function () {
+    // Use --no-annotations to isolate the refresh seam from annotation-layer.js
+    // (which contains its own location.reload() for mtime-based hot-reload).
+    var html = render(["--no-annotations"]);
+    assert.doesNotMatch(
+      html,
+      /http-equiv="refresh"/,
+      "no meta-refresh by default",
+    );
+    assert.doesNotMatch(
+      html,
+      /location\.reload\(\)/,
+      "no JS reload by default",
+    );
+  });
+
+  it("treats 0 / non-positive / non-numeric as off", function () {
+    ["0", "-1", "abc"].forEach(function (v) {
+      var html = render(["--refresh", v, "--no-annotations"]);
+      assert.doesNotMatch(
+        html,
+        /http-equiv="refresh"/,
+        "refresh=" + v + " injects no meta",
+      );
+      assert.doesNotMatch(
+        html,
+        /location\.reload\(\)/,
+        "refresh=" + v + " injects no JS",
+      );
+    });
+  });
+
+  it("changes ONLY the reload lines vs the no-flag render (deterministic seam)", function () {
+    var plain = render(["--no-annotations"]).split("\n");
+    var refreshed = render(["--refresh", "3", "--no-annotations"]).split("\n");
+    var added = refreshed.filter(function (line) {
+      return plain.indexOf(line) === -1;
+    });
+    // Only the two injected lines are new.
+    assert.equal(
+      added.length,
+      2,
+      "exactly two lines added, got: " + JSON.stringify(added),
+    );
+    assert.ok(
+      added.some(function (l) {
+        return /http-equiv="refresh"/.test(l);
+      }),
+    );
+    assert.ok(
+      added.some(function (l) {
+        return /location\.reload\(\)/.test(l);
+      }),
+    );
+  });
+});

--- a/plugins/actian-design-system/tests/renderers/fixtures/refresh-probe.flow.json
+++ b/plugins/actian-design-system/tests/renderers/fixtures/refresh-probe.flow.json
@@ -1,0 +1,12 @@
+{
+  "meta": { "feature": "Refresh probe", "app": "Studio" },
+  "screens": [
+    {
+      "name": "Probe",
+      "template": "admin",
+      "content": [
+        { "type": "TEXT", "content": "refresh counter: 1", "size": 48, "font": "Inter:Bold" }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Kills the "silent wait + preview-last" UX in `generate-flow`. After the screen-list gate the run is no longer a long silent window, and the visual lands **before** the slow Figma push instead of after it.

- **Auto-render the HTML preview before the push (un-gated).** New pipeline Step 6.5 renders the preview from `flow-data.json` as soon as validation passes and surfaces `Preview ready → <path>` — automatic, not opt-in. Fail-open: a render error surfaces but never blocks the push (the preview is an aid, not a gate). The old opt-in Step 8 / Gate-3 `"preview"` action are kept as now-redundant aliases, so no path the agent depends on is removed.
- **Stream `N/M` chat progress** during the build (Step 5, the longest silent phase: `✓ <N>/<M> <screen>`) and the push (Step 7: `Pushing <N>/<M> to Figma…`).
- **`assemble-preview.js --refresh <seconds>` seam.** Injects a self-contained auto-reload (meta-refresh + inline-JS `location.reload()` fallback, no server, no network) into the preview HTML. Off by default; deterministic (no timestamps/randomness). Backs a Cowork auto-refresh spike and the staged "watch it build" Tier B. Also helps `file://` / browser users today.
- **Structural ordering guard** (`generate-flow-preview-ordering.test.js`) locks the preview-render-before-push invariant so a future reorder fails CI loudly.
- **v1.98.2 → 1.99.0** (MINOR, backward-compatible) + CHANGELOG.

**Out of scope (Tier B, gated on the Cowork spike — separate spec):** skeleton-at-approval, per-screen live-populate streaming, Figma placeholder-shimmer.

## Test Plan

- [x] `--refresh` seam: 4 tests (inject / off-by-default / non-positive+non-numeric off / deterministic "exactly two lines added") — green
- [x] ordering guard: 2 tests — green
- [x] `doc-conventions` (no bare `node` in committed `.md`) — 9/9 green
- [x] full suite: 1022/1023 pass; the lone failure is `vendor-paths-resolve` resolving stale paths inside **uncommitted** `docs/superpowers/` plan files — absent in CI
- [ ] **Manual Cowork spike** (`/tmp/refresh-probe*.html`): does Cowork's static preview panel honor a self-contained auto-reload? Pass → greenlights Tier B.

## Review

Each task passed independent spec-compliance + code-quality review; a final holistic review confirmed the feature coheres, the `assemble-preview.js` interface matches Step 6.5's invocation, the seam is self-contained/deterministic/off-by-default, and the CHANGELOG does not overclaim (no Tier B / live-streaming shipped).

🤖 Generated with [Claude Code](https://claude.com/claude-code)