### PR TITLE
fix(renderers): flow HTML chrome contract drift (v1.104.3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,26 @@ they are not individually listed below unless they changed user-facing behavior.
 This file was seeded at v1.97.0 from the commit history; entries before that
 are summarized at the release level.
 
+## [1.104.3] — 2026-06-08
+
+### Fixed
+- Flow HTML chrome contract drift — the screen-generator now emits richer,
+  Figma-shaped data than the FM renderer consumed, producing broken output
+  (surfaced by a `generate-flow` hi-fi test):
+  - **Empty sidebar:** `navItems` (an array of `{label,state}`) was passed
+    where `sidebar()` expected a numeric count, so the placeholder loop never
+    ran and the nav rail rendered empty. It now renders real nav labels with
+    the active item highlighted (On-state or `activeNavItem` match), keeping
+    the legacy numeric-count shape working.
+  - **`[object Object]` page-header button:** `pageHeader.actions` (now
+    `[{label,variant}]`) was stringified whole; the renderer now reads
+    `.label` (still accepts bare strings).
+  - **`background:[object Object]` on frames/rects/ellipses:** Figma-shaped
+    fills `[{type,color}]` are normalized to a CSS color string via a new
+    `fillToCss` helper in `render-node.js` (string fills unchanged).
+- These affect the lo-fi deliverable; the same chrome/fills path also feeds
+  the planned DS-native hi-fi render, so the fixes are a prerequisite for it.
+
 ## [1.104.1] — 2026-06-08
 
 ### Added

--- a/plugins/actian-design-system/.claude-plugin/plugin.json
+++ b/plugins/actian-design-system/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "actian-design-system",
   "description": "Actian Design System toolkit — generate wireframe flows with prototype wiring, create component briefs, audit designs, compare flows, and build presentations. 8 skills (with tiered generation: recognized / adapted / improvised), 9 agents, 155 tokens (3 themes, 8 collections), WCAG 2.2 AA. DS knowledge vendored from volivarii/actian-ds-knowledge.",
-  "version": "1.104.2",
+  "version": "1.104.3",
   "author": {
     "name": "Actian UX Team"
   },

--- a/plugins/actian-design-system/scripts/renderers/html-renderers/flow-renderer.js
+++ b/plugins/actian-design-system/scripts/renderers/html-renderers/flow-renderer.js
@@ -96,21 +96,52 @@
     );
   }
 
+  function navItemHtml(label, active) {
+    // Keep each class attribute a complete string literal (never split a
+    // class list across a ternary/concatenation) so the css-staleness
+    // extractor doesn't capture stray expression tokens.
+    var open = active
+      ? '<div class="fm-nav-item fm-nav-item--active" data-name="'
+      : '<div class="fm-nav-item" data-name="';
+    return (
+      open +
+      esc(label) +
+      '">' +
+      '<div class="fm-nav-item__icon"></div>' +
+      '<div class="fm-nav-item__label">' +
+      esc(label) +
+      "</div>" +
+      "</div>"
+    );
+  }
+
   function sidebar(config) {
     if (!config) return "";
     var items = "";
+    // Rich shape: config.items is an array of nav entries (string or
+    // { label, state }). Render real labels — active = On-state or a label
+    // matching config.activeItem (the generator passes a slug/id, so compare
+    // case-insensitively). Falls back to the legacy count shape below.
+    if (Array.isArray(config.items)) {
+      for (var j = 0; j < config.items.length; j++) {
+        var entry = config.items[j] || {};
+        var label = typeof entry === "string" ? entry : entry.label || "";
+        var onState =
+          entry && entry.state && String(entry.state).toLowerCase() === "on";
+        var matchesActive =
+          config.activeItem &&
+          label &&
+          String(label).toLowerCase() ===
+            String(config.activeItem).toLowerCase();
+        items += navItemHtml(label, !!(onState || matchesActive));
+      }
+      return '<div class="fm-sidebar" data-name="Sidebar">' + items + "</div>";
+    }
+    // Legacy shape: numeric placeholder count + one labeled active item.
     var total = config.items || 6;
     for (var i = 0; i < total; i++) {
       if (i === 0 && config.activeItem) {
-        items +=
-          '<div class="fm-nav-item fm-nav-item--active" data-name="' +
-          esc(config.activeItem) +
-          '">' +
-          '<div class="fm-nav-item__icon"></div>' +
-          '<div class="fm-nav-item__label">' +
-          esc(config.activeItem) +
-          "</div>" +
-          "</div>";
+        items += navItemHtml(config.activeItem, true);
       } else {
         items +=
           '<div class="fm-nav-item fm-nav-item--placeholder">' +
@@ -137,8 +168,10 @@
     if (config.actions && config.actions.length) {
       html += '<div class="fm-page-header__actions">';
       config.actions.forEach(function (a) {
+        // Actions arrive as a bare label string or a { label, variant } object.
+        var label = typeof a === "string" ? a : (a && a.label) || "";
         html +=
-          '<div class="fm-button fm-button--primary">' + esc(a) + "</div>";
+          '<div class="fm-button fm-button--primary">' + esc(label) + "</div>";
       });
       html += "</div>";
     }

--- a/plugins/actian-design-system/scripts/renderers/html-renderers/render-node.js
+++ b/plugins/actian-design-system/scripts/renderers/html-renderers/render-node.js
@@ -61,6 +61,18 @@
     "Extra Bold": "800",
   };
 
+  // Normalize one fill entry to a CSS color string. Fills arrive either as a
+  // bare CSS string (a hex value or token reference) or a Figma-shaped object
+  // { type:"SOLID", color:"…" } when a screen-generator emits richer data.
+  // Returning "" for anything unrecognized keeps a bad fill from leaking
+  // "[object Object]" into the style attribute.
+  function fillToCss(fill) {
+    if (fill == null) return "";
+    if (typeof fill === "string") return fill;
+    if (typeof fill === "object" && fill.color != null) return fill.color;
+    return "";
+  }
+
   function buildFrameStyle(node) {
     var parts = [];
     var layout = node.layout || {};
@@ -153,7 +165,8 @@
 
     // Fills
     if (node.fills && node.fills.length > 0) {
-      parts.push("background:" + node.fills[0]);
+      var bgFill = fillToCss(node.fills[0]);
+      if (bgFill) parts.push("background:" + bgFill);
     }
 
     // Corner radius
@@ -339,7 +352,7 @@
       }
 
       case "ELLIPSE": {
-        var bg = (node.fills && node.fills[0]) || "#CBD2E0";
+        var bg = (node.fills && fillToCss(node.fills[0])) || "#CBD2E0";
         var ellipseStyle =
           "width:" +
           (node.width || 16) +
@@ -364,8 +377,8 @@
           "px;height:" +
           (node.height || 32) +
           "px;min-width:1px;min-height:1px;";
-        if (node.fills && node.fills[0])
-          rectStyle += "background:" + node.fills[0] + ";";
+        if (node.fills && fillToCss(node.fills[0]))
+          rectStyle += "background:" + fillToCss(node.fills[0]) + ";";
         if (node.cornerRadius)
           rectStyle +=
             "border-radius:" +

--- a/plugins/actian-design-system/tests/renderers/flow-renderer.test.js
+++ b/plugins/actian-design-system/tests/renderers/flow-renderer.test.js
@@ -651,6 +651,96 @@ const screenNoTier = screen({
 assertNotContains(screenNoTier, "tier-badge", "no badge when tier missing");
 
 // ---------------------------------------------------------------------------
+// Contract drift regressions — screen-generator emits richer Figma-shaped data
+// than the FM renderer historically consumed (sidebar count, string actions,
+// string fills). These guard the three bugs found in the connection-setup-
+// wizard hi-fi test (2026-06-08).
+// ---------------------------------------------------------------------------
+
+section("B3 — FRAME fills as Figma object shape {type,color}");
+
+const frameFillObj = renderContentNode({
+  type: "FRAME",
+  name: "Toolbar",
+  fills: [{ type: "SOLID", color: "var(--zen-color-bg-muted)" }],
+});
+assertContains(
+  frameFillObj,
+  "background:var(--zen-color-bg-muted)",
+  "fills object → color string",
+);
+assertNotContains(
+  frameFillObj,
+  "[object Object]",
+  "no [object Object] from fills object",
+);
+// String fills still work (backward compat).
+assertContains(
+  renderContentNode({ type: "FRAME", name: "Plain", fills: ["#FFFFFF"] }),
+  "background:#FFFFFF",
+  "string fill still works",
+);
+
+section("B1 — sidebar renders real navItems labels");
+
+const navScreen = screen({
+  name: "Connections list",
+  template: "admin",
+  activeNavItem: "connections",
+  navItems: [
+    { label: "Catalogs", state: "Off" },
+    { label: "Connections", state: "On" },
+    { label: "Scanners", state: "Off" },
+  ],
+  content: [],
+});
+assertContains(navScreen, "Catalogs", "nav label Catalogs rendered");
+assertContains(navScreen, "Scanners", "nav label Scanners rendered");
+assertNotContains(
+  navScreen,
+  '<div class="fm-sidebar" data-name="Sidebar"></div>',
+  "sidebar is not empty when navItems present",
+);
+assertContains(
+  navScreen,
+  'fm-nav-item--active" data-name="Connections"',
+  "active nav item is the on-state / activeNavItem match",
+);
+
+section("B2 — pageHeader action objects {label,variant}");
+
+const actionScreen = screen({
+  name: "Connections",
+  template: "admin",
+  pageHeader: {
+    title: "Connections",
+    actions: [{ label: "Create connection", variant: "Primary" }],
+  },
+  content: [],
+});
+assertContains(
+  actionScreen,
+  "Create connection",
+  "action object label rendered",
+);
+assertNotContains(
+  actionScreen,
+  "[object Object]",
+  "no [object Object] from action object",
+);
+// String actions still work (backward compat).
+assertContains(
+  screen({
+    name: "Legacy actions",
+    template: "admin",
+    pageHeader: { title: "X", actions: ["Save"] },
+    content: [],
+  }),
+  ">Save<",
+  "string action still works",
+);
+
+// ---------------------------------------------------------------------------
 // Summary
 // ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Why

A `generate-flow` **hi-fi** test produced broken HTML — empty sidebar, an `[object Object]` button, `background:[object Object]` on frames. Root cause: the screen-generator now emits **richer, Figma-shaped data** than the FM HTML renderer was written to consume (contract drift). These break the lo-fi deliverable today, and the same chrome/fills path feeds the planned DS-native hi-fi render, so fixing them is a prerequisite for the capstone.

> Note: this PR does **not** address the larger gap that `generate-flow` hi-fi never authors `library:"ds"` nodes (the DS-native engine is still unbuilt). That's tracked separately as the hi-fi capstone. This is the contract-drift fix only.

## Fixes

- **Empty sidebar** — `navItems` (array of `{label,state}`) was passed where `sidebar()` expected a numeric count, so `for (i=0; i<array; i++)` never ran → empty rail. Now renders real nav labels with the active item highlighted (On-state or `activeNavItem` match, case-insensitive). Legacy numeric-count shape preserved.
- **`[object Object]` page-header button** — `pageHeader.actions` (`[{label,variant}]`) was stringified whole; now reads `.label` (bare strings still accepted).
- **`background:[object Object]`** — Figma-shaped fills `[{type,color}]` normalized to a CSS color string via new `fillToCss()` in `render-node.js` (FRAME/RECT/ELLIPSE). String fills unchanged; unrecognized → no background (instead of leaking `[object Object]`).

## Testing

- **TDD:** 8 RED-first cases added to `flow-renderer.test.js` (one per symptom + backward-compat for string fills/actions).
- Full suite green at CI parity (**1325/1325**; the lone local-only `vendor-paths-resolve` fail is gitignored `docs/superpowers/` leftovers, absent on CI).
- **Verified on the reported data:** re-rendered the offending `flow-data.json` → 0 `[object Object]`, 0 empty sidebars, real nav labels render.

## Notes

- Two source-scan gates (`css-staleness`, `token-resolution`) caught comment/ternary artifacts during the fix (the documented P1a footgun) — reworded so class attributes stay complete literals and comments carry no `var(--…)` / `class="…"` tokens.
- Deferred (conscious): the screen-generator emitting `--zen-` tokens into FM nodes (vocabulary leak) — belongs with the DS-native work, not this drift patch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)