### PR TITLE
feat(vendor): self-healing doc-count sync (v1.105.0)

### DIFF
--- a/.github/workflows/vendor-snapshot.yml
+++ b/.github/workflows/vendor-snapshot.yml
@@ -109,6 +109,20 @@ jobs:
             --kit all \
             --output vendor/components/dist
 
+      - name: Sync doc inventory counts
+        # A re-vendor can change a registry component count. The doc-counts
+        # guard (tests/integration/doc-counts.test.js) then fails on the now
+        # stale prose, leaving this auto-merge PR stuck with no self-healing
+        # path (observed on the v0.30.5 refresh: DS Kit 318→319). This rewrites
+        # the managed docs (README, llms.txt, marketplace.json, plugin.json,
+        # companion-context, figma-push-patterns) from the registries so the
+        # guard passes. Idempotent no-op when no count changed. Shares its
+        # source of truth (scripts/lib/doc-counts.js) with the guard, so the
+        # two can't disagree.
+        working-directory: plugins/actian-design-system
+        run: |
+          node scripts/vendor/sync-doc-counts.js
+
       - name: Detect changes
         id: diff
         run: |
@@ -158,6 +172,12 @@ jobs:
             plugins/actian-design-system/vendor/**
             plugins/actian-design-system/vendored.json
             plugins/actian-design-system/.claude-plugin/plugin.json
+            README.md
+            llms.txt
+            USAGE.md
+            .claude-plugin/marketplace.json
+            plugins/actian-design-system/references/context/companion-context.md
+            plugins/actian-design-system/references/figma/figma-push-patterns.md
 
       - name: Enable auto-merge
         if: steps.diff.outputs.changed == 'true' && steps.cpr.outputs.pull-request-number

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,26 @@ they are not individually listed below unless they changed user-facing behavior.
 This file was seeded at v1.97.0 from the commit history; entries before that
 are summarized at the release level.
 
+## [1.105.0] — 2026-06-10
+
+### Added
+- **Self-healing doc-count sync in the vendor pipeline** — a knowledge re-vendor
+  that changes a registry component count (e.g. DS Kit 318→319 in v0.30.5) used
+  to leave the human-facing inventory counts (README, llms.txt, marketplace.json,
+  plugin.json, companion-context, figma-push-patterns) stale, failing the
+  `doc-counts` guard and leaving the auto-merge vendor PR **stuck** with no
+  self-healing path. The vendor-snapshot workflow now runs
+  `scripts/vendor/sync-doc-counts.js` after each pull to rewrite those counts
+  from the registries, and commits the result (the managed docs were added to
+  the PR's `add-paths`), so count-changing refreshes merge cleanly.
+  - The guard (`tests/integration/doc-counts.test.js`) and the fixer now share
+    one source of truth — `scripts/lib/doc-counts.js` (`deriveCounts` +
+    `buildChecks` + `fixContent` + `syncDocCounts`) — so they can never
+    disagree. Vendor reads route through `PATHS`; fixer regexes are anchored and
+    idempotent (a real-doc idempotency test guards against over-greedy
+    rewrites). Run `node scripts/vendor/sync-doc-counts.js --check` to report
+    drift, or without `--check` to fix it.
+
 ## [1.104.5] — 2026-06-10
 
 ### Added

--- a/plugins/actian-design-system/.claude-plugin/plugin.json
+++ b/plugins/actian-design-system/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "actian-design-system",
   "description": "Actian Design System toolkit — generate wireframe flows with prototype wiring, create component briefs, audit designs, compare flows, and build presentations. 8 skills (with tiered generation: recognized / adapted / improvised), 9 agents, 155 tokens (3 themes, 8 collections), WCAG 2.2 AA. DS knowledge vendored from volivarii/actian-ds-knowledge.",
-  "version": "1.104.6",
+  "version": "1.105.0",
   "author": {
     "name": "Actian UX Team"
   },

--- a/plugins/actian-design-system/scripts/lib/doc-counts.js
+++ b/plugins/actian-design-system/scripts/lib/doc-counts.js
@@ -1,0 +1,361 @@
+"use strict";
+
+/**
+ * doc-counts.js — single source of truth for the plugin's human-facing
+ * inventory counts and which managed docs must state them.
+ *
+ * Consumed by BOTH:
+ *   - tests/integration/doc-counts.test.js  (GUARD — asserts each doc states
+ *     the derived counts; fails loudly on drift)
+ *   - scripts/vendor/sync-doc-counts.js     (FIXER — rewrites the doc strings
+ *     to match the derived counts; run in the vendor-snapshot workflow so a
+ *     count-changing refresh self-heals instead of failing CI)
+ *
+ * Because both sides read the same `buildChecks()`, the guard and the fixer
+ * can never disagree.
+ *
+ * Each `contains` entry is { str, fixRx? }:
+ *   - `str`   is the canonical phrase the guard asserts is present AND the
+ *             string the fixer writes.
+ *   - `fixRx` (optional, MUST be /g) matches the same phrase with the numbers
+ *             wildcarded, anchored tightly enough that replacing it with `str`
+ *             is unambiguous and idempotent. Literal phrases (e.g. "WCAG 2.2
+ *             AA") have no fixRx — the guard checks them, the fixer ignores
+ *             them. `str` is written as a literal (no $-pattern expansion).
+ *
+ * Zero dependencies — Node.js built-ins only.
+ */
+
+var fs = require("fs");
+var path = require("path");
+// Vendor reads route through PATHS (the indirection layer), never bare
+// vendor-path string literals — guarded by no-bare-vendor-paths.test.js.
+var PATHS = require("./paths.js");
+
+var PLUGIN_ROOT = path.resolve(__dirname, "..", "..");
+
+// ---------------------------------------------------------------------------
+// Derive canonical counts from ground truth (filesystem + vendored registries)
+// ---------------------------------------------------------------------------
+
+function listDirs(p) {
+  if (!fs.existsSync(p)) return [];
+  return fs.readdirSync(p).filter(function (e) {
+    return fs.statSync(path.join(p, e)).isDirectory();
+  });
+}
+
+function deriveSkills() {
+  return listDirs(path.join(PLUGIN_ROOT, "skills")).filter(function (d) {
+    return fs.existsSync(path.join(PLUGIN_ROOT, "skills", d, "SKILL.md"));
+  }).length;
+}
+
+function deriveAgents() {
+  var dir = path.join(PLUGIN_ROOT, "agents");
+  if (!fs.existsSync(dir)) return 0;
+  return fs.readdirSync(dir).filter(function (f) {
+    return f.endsWith(".md");
+  }).length;
+}
+
+function deriveRecipes() {
+  var root = path.join(PLUGIN_ROOT, "recipes");
+  var total = 0;
+  listDirs(root).forEach(function (kind) {
+    fs.readdirSync(path.join(root, kind)).forEach(function (f) {
+      if (f.endsWith(".json") && f !== "_index.json") total++;
+    });
+  });
+  return total;
+}
+
+function deriveRegistry(lib) {
+  // lib is "dskit" | "fmkit" | "metakit" — keyed directly in PATHS.
+  var p = PATHS.components.registries[lib];
+  var reg = JSON.parse(fs.readFileSync(p, "utf8"));
+  var keys = Object.keys(reg.components || {});
+  var sets = keys.filter(function (k) {
+    return reg.components[k].importMethod === "set";
+  }).length;
+  var count =
+    typeof reg.componentCount === "number" ? reg.componentCount : keys.length;
+  return { count: count, sets: sets, keyCount: keys.length };
+}
+
+function deriveGuidelines() {
+  // Derive the guidelines dir from a PATHS-resolved guideline-doc path
+  // (rather than a hardcoded vendor-path literal) so the indirection layer
+  // stays the single source of vendor locations.
+  var docs = PATHS.components.guidelineDoc;
+  // guidelineDoc maps slug -> path but also carries a byKey() helper; pick the
+  // first string-valued entry so we never path.dirname() a function if the
+  // manifest key order ever changes.
+  var firstPath = Object.keys(docs)
+    .map(function (k) {
+      return docs[k];
+    })
+    .find(function (v) {
+      return typeof v === "string";
+    });
+  var dir = path.dirname(firstPath);
+  var files = fs.readdirSync(dir).filter(function (f) {
+    return f.endsWith(".json") && f !== "guidelines.bundle.json";
+  });
+  var aliases = files.filter(function (f) {
+    var j = JSON.parse(fs.readFileSync(path.join(dir, f), "utf8"));
+    return Object.prototype.hasOwnProperty.call(j, "_alias_of");
+  }).length;
+  return {
+    total: files.length,
+    canonical: files.length - aliases,
+    aliases: aliases,
+  };
+}
+
+function deriveCounts() {
+  return {
+    SKILLS: deriveSkills(),
+    AGENTS: deriveAgents(),
+    RECIPES: deriveRecipes(),
+    DS: deriveRegistry("dskit"),
+    FM: deriveRegistry("fmkit"),
+    META: deriveRegistry("metakit"),
+    GUIDE: deriveGuidelines(),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Managed doc surfaces (repo-root-relative paths) + the strings each must
+// contain / must not contain, built FROM the derived counts.
+// ---------------------------------------------------------------------------
+
+function buildChecks(c) {
+  return [
+    {
+      file: "README.md",
+      contains: [
+        { str: c.SKILLS + " skills", fixRx: /\d+ skills/g },
+        { str: c.AGENTS + " agents", fixRx: /\d+ agents/g },
+        { str: c.RECIPES + " recipes", fixRx: /\d+ recipes/g },
+        { str: "WCAG 2.2 AA" },
+        {
+          str:
+            c.DS.count +
+            " DS Kit + " +
+            c.FM.count +
+            " FM Kit + " +
+            c.META.count +
+            " Meta Kit",
+          fixRx: /\d+ DS Kit \+ \d+ FM Kit \+ \d+ Meta Kit/g,
+        },
+        {
+          str: c.DS.count + " DS Kit components (" + c.DS.sets + " sets)",
+          fixRx: /\d+ DS Kit components \(\d+ sets\)/g,
+        },
+        // Per-kit SET breakdown, both phrasings ("… component sets" and
+        // "(… sets)"). A vendor refresh that grows a kit can move these.
+        {
+          str:
+            c.DS.sets +
+            " / " +
+            c.FM.sets +
+            " / " +
+            c.META.sets +
+            " component sets",
+          fixRx: /\d+ \/ \d+ \/ \d+ component sets/g,
+        },
+        {
+          str: c.DS.sets + " / " + c.FM.sets + " / " + c.META.sets + " sets",
+          fixRx: /\d+ \/ \d+ \/ \d+ sets/g,
+        },
+        {
+          str: c.GUIDE.total + " per-component guideline docs",
+          fixRx: /\d+ per-component guideline docs/g,
+        },
+        // Guideline canonical/alias split. fixRx matches only the "<n>
+        // components + <n>" prefix so the trailing "(registry-key) aliases"
+        // wording is preserved regardless of which phrasing the doc uses.
+        {
+          str: c.GUIDE.canonical + " components + " + c.GUIDE.aliases,
+          fixRx: /\d+ components \+ \d+/g,
+        },
+      ],
+      notContains: [
+        "WCAG 2.1 AA",
+        "322 DS Kit",
+        "82 / 33 / 11",
+        "82 sets",
+        "85 per-component",
+        "41 auto-stub",
+        "44 fully curated",
+      ],
+    },
+    {
+      file: ".claude-plugin/marketplace.json",
+      contains: [
+        {
+          str: c.SKILLS + " skills, " + c.AGENTS + " agents",
+          fixRx: /\d+ skills, \d+ agents/g,
+        },
+        {
+          str: c.SKILLS + " skills + " + c.AGENTS + " agents",
+          fixRx: /\d+ skills \+ \d+ agents/g,
+        },
+        { str: c.RECIPES + " recipes", fixRx: /\d+ recipes/g },
+        { str: "WCAG 2.2 AA" },
+        { str: "brief-researcher" },
+      ],
+      notContains: ["WCAG 2.1 AA", "sync-design-system", "25 recipes"],
+    },
+    {
+      file: "plugins/actian-design-system/.claude-plugin/plugin.json",
+      contains: [
+        { str: c.SKILLS + " skills", fixRx: /\d+ skills/g },
+        { str: c.AGENTS + " agents", fixRx: /\d+ agents/g },
+        { str: "WCAG 2.2 AA" },
+      ],
+      notContains: ["WCAG 2.1 AA"],
+    },
+    {
+      file: "llms.txt",
+      contains: [
+        { str: c.SKILLS + " skills", fixRx: /\d+ skills/g },
+        {
+          str: c.DS.count + " DS Kit components",
+          fixRx: /\d+ DS Kit components/g,
+        },
+        {
+          str: c.FM.count + " FM Kit wireframe components",
+          fixRx: /\d+ FM Kit wireframe components/g,
+        },
+        {
+          str: c.META.count + " Meta Kit components",
+          fixRx: /\d+ Meta Kit components/g,
+        },
+        { str: "WCAG 2.2 AA" },
+        // Anchored on ", all curated" so it never clobbers the sibling
+        // "Foundations subtree (8 JSON files)" line.
+        {
+          str: c.GUIDE.total + " JSON files, all curated",
+          fixRx: /\d+ JSON files, all curated/g,
+        },
+      ],
+      notContains: [
+        "WCAG 2.1 AA",
+        "107 DS Kit",
+        "107 design system",
+        "85 JSON files",
+      ],
+    },
+    {
+      file: "USAGE.md",
+      contains: [{ str: "WCAG 2.2 AA" }],
+      notContains: ["WCAG 2.1 AA"],
+    },
+    {
+      file: "plugins/actian-design-system/references/context/companion-context.md",
+      // Each row is anchored on its library label so the three identically
+      // shaped "N components (M sets)" cells map to the right registry.
+      contains: [
+        {
+          str:
+            "DS Kit | " + c.DS.count + " components (" + c.DS.sets + " sets)",
+          fixRx: /DS Kit \| \d+ components \(\d+ sets\)/g,
+        },
+        {
+          str:
+            "FM Kit | " + c.FM.count + " components (" + c.FM.sets + " sets)",
+          fixRx: /FM Kit \| \d+ components \(\d+ sets\)/g,
+        },
+        {
+          str:
+            "Meta Kit | " +
+            c.META.count +
+            " components (" +
+            c.META.sets +
+            " sets)",
+          fixRx: /Meta Kit \| \d+ components \(\d+ sets\)/g,
+        },
+        {
+          str: c.GUIDE.total + " guideline docs",
+          fixRx: /\d+ guideline docs/g,
+        },
+        {
+          str: c.GUIDE.canonical + " components + " + c.GUIDE.aliases,
+          fixRx: /\d+ components \+ \d+/g,
+        },
+      ],
+      notContains: ["107 sets", "44 components |", "~41 of 85"],
+    },
+    {
+      file: "plugins/actian-design-system/references/figma/figma-push-patterns.md",
+      contains: [
+        {
+          str: c.DS.count + " design system components",
+          fixRx: /\d+ design system components/g,
+        },
+        {
+          str: c.FM.count + " wireframe components",
+          fixRx: /\d+ wireframe components/g,
+        },
+      ],
+      notContains: ["107 design system components", "33 wireframe components"],
+    },
+  ];
+}
+
+// ---------------------------------------------------------------------------
+// Fixer core — pure string transform so it's trivially testable.
+// ---------------------------------------------------------------------------
+
+/**
+ * Rewrite every fixable phrase in `content` to its canonical `str`.
+ * Literal items (no fixRx) are left alone. The replacement is a literal
+ * (a function is used so `$` sequences in `str` are not interpreted).
+ */
+function fixContent(content, containsItems) {
+  var out = content;
+  (containsItems || []).forEach(function (item) {
+    if (!item.fixRx) return;
+    out = out.replace(item.fixRx, function () {
+      return item.str;
+    });
+  });
+  return out;
+}
+
+/**
+ * Walk every managed doc, rewrite its count phrases to the derived values, and
+ * (when opts.write) persist the change. Returns { counts, changed[] } where
+ * `changed` is the repo-relative paths whose content the fixer altered.
+ *
+ * @param {string} repoRoot - absolute path to the repository root
+ * @param {{ write?: boolean }} [opts] - write:true persists; otherwise dry-run
+ */
+function syncDocCounts(repoRoot, opts) {
+  opts = opts || {};
+  var counts = deriveCounts();
+  var checks = buildChecks(counts);
+  var changed = [];
+  checks.forEach(function (check) {
+    var abs = path.join(repoRoot, check.file);
+    if (!fs.existsSync(abs)) return;
+    var content = fs.readFileSync(abs, "utf8");
+    var fixed = fixContent(content, check.contains);
+    if (fixed !== content) {
+      changed.push(check.file);
+      if (opts.write) fs.writeFileSync(abs, fixed, "utf8");
+    }
+  });
+  return { counts: counts, changed: changed };
+}
+
+module.exports = {
+  deriveCounts: deriveCounts,
+  buildChecks: buildChecks,
+  fixContent: fixContent,
+  syncDocCounts: syncDocCounts,
+  // Exposed for any consumer that wants a single registry's numbers.
+  deriveRegistry: deriveRegistry,
+};

--- a/plugins/actian-design-system/scripts/vendor/sync-doc-counts.js
+++ b/plugins/actian-design-system/scripts/vendor/sync-doc-counts.js
@@ -1,0 +1,87 @@
+#!/usr/bin/env node
+"use strict";
+
+/**
+ * sync-doc-counts.js — rewrite the plugin's human-facing inventory counts
+ * (README, marketplace.json, plugin.json, llms.txt, companion-context,
+ * figma-push-patterns) to match the derived ground truth.
+ *
+ * Run by .github/workflows/vendor-snapshot.yml after a knowledge re-vendor:
+ * when a refresh changes a registry component count, the doc-counts guard
+ * (tests/integration/doc-counts.test.js) would otherwise fail and leave the
+ * auto-merge vendor PR stuck. This step rewrites the prose so the guard passes
+ * and the PR merges — the same fix a human would otherwise do by hand.
+ *
+ * Logic + the managed-doc list live in scripts/lib/doc-counts.js, SHARED with
+ * the guard, so they can never disagree.
+ *
+ * Usage (from plugins/actian-design-system/):
+ *   node scripts/vendor/sync-doc-counts.js          # rewrite docs in place
+ *   node scripts/vendor/sync-doc-counts.js --check  # report only; exit 1 if stale
+ */
+
+var path = require("path");
+var { syncDocCounts } = require("../lib/doc-counts.js");
+
+// scripts/vendor → plugins/actian-design-system → <repo root>
+var REPO_ROOT = path.resolve(__dirname, "..", "..", "..", "..");
+
+function main(argv) {
+  var check = argv.indexOf("--check") !== -1;
+  var res = syncDocCounts(REPO_ROOT, { write: !check });
+  var c = res.counts;
+
+  process.stdout.write(
+    "[sync-doc-counts] ground truth: " +
+      c.SKILLS +
+      " skills / " +
+      c.AGENTS +
+      " agents / " +
+      c.RECIPES +
+      " recipes / DS " +
+      c.DS.count +
+      "(" +
+      c.DS.sets +
+      " sets) / FM " +
+      c.FM.count +
+      "(" +
+      c.FM.sets +
+      " sets) / Meta " +
+      c.META.count +
+      "(" +
+      c.META.sets +
+      " sets) / " +
+      c.GUIDE.total +
+      " guideline docs\n",
+  );
+
+  if (res.changed.length === 0) {
+    process.stdout.write("[sync-doc-counts] all managed docs already in sync\n");
+    return 0;
+  }
+
+  if (check) {
+    process.stderr.write(
+      "[sync-doc-counts] STALE — these docs do not match ground truth:\n",
+    );
+    res.changed.forEach(function (f) {
+      process.stderr.write("  " + f + "\n");
+    });
+    process.stderr.write(
+      "  Run `node scripts/vendor/sync-doc-counts.js` to fix.\n",
+    );
+    return 1;
+  }
+
+  process.stdout.write("[sync-doc-counts] rewrote:\n");
+  res.changed.forEach(function (f) {
+    process.stdout.write("  " + f + "\n");
+  });
+  return 0;
+}
+
+if (require.main === module) {
+  process.exit(main(process.argv.slice(2)));
+}
+
+module.exports = { main: main };

--- a/plugins/actian-design-system/tests/integration/doc-counts.test.js
+++ b/plugins/actian-design-system/tests/integration/doc-counts.test.js
@@ -14,12 +14,14 @@
  * WCAG 2.1 vs 2.2, DS Kit 322/107 vs 318, "85 guidelines / 41 stubs" when the
  * vendored snapshot ships 44 docs and 0 stubs).
  *
- * This test DERIVES the canonical counts from the source of truth and asserts
- * each managed doc states them correctly. When the registries re-vendor or a
- * skill/agent/recipe is added, this test fails loudly and tells you exactly
- * which doc string to update — drift can no longer ship silently.
+ * The canonical counts + the managed-doc check list now live in
+ * scripts/lib/doc-counts.js, SHARED with scripts/vendor/sync-doc-counts.js
+ * (the fixer that rewrites the doc strings during a vendor refresh). This test
+ * is the GUARD side: it asserts each managed doc states the derived counts and
+ * contains no stale regression strings. Because both sides read the same
+ * buildChecks(), the guard and the fixer can never disagree.
  *
- * Ground truth:
+ * Ground truth (see scripts/lib/doc-counts.js):
  *   - skills   = skills/<name>/ dirs containing a SKILL.md
  *   - agents   = agents/*.md files
  *   - recipes  = recipes/<kind>/*.json files excluding _index.json
@@ -36,194 +38,17 @@ var assert = require("node:assert");
 var fs = require("fs");
 var path = require("path");
 
+var {
+  deriveCounts,
+  buildChecks,
+  deriveRegistry,
+} = require("../../scripts/lib/doc-counts.js");
+
 var PLUGIN_ROOT = path.resolve(__dirname, "..", "..");
 var REPO_ROOT = path.resolve(PLUGIN_ROOT, "..", "..");
 
-// ---------------------------------------------------------------------------
-// Derive canonical counts from ground truth
-// ---------------------------------------------------------------------------
-
-function listDirs(p) {
-  if (!fs.existsSync(p)) return [];
-  return fs.readdirSync(p).filter(function (e) {
-    return fs.statSync(path.join(p, e)).isDirectory();
-  });
-}
-
-function deriveSkills() {
-  return listDirs(path.join(PLUGIN_ROOT, "skills")).filter(function (d) {
-    return fs.existsSync(path.join(PLUGIN_ROOT, "skills", d, "SKILL.md"));
-  }).length;
-}
-
-function deriveAgents() {
-  var dir = path.join(PLUGIN_ROOT, "agents");
-  if (!fs.existsSync(dir)) return 0;
-  return fs.readdirSync(dir).filter(function (f) {
-    return f.endsWith(".md");
-  }).length;
-}
-
-function deriveRecipes() {
-  var root = path.join(PLUGIN_ROOT, "recipes");
-  var total = 0;
-  listDirs(root).forEach(function (kind) {
-    fs.readdirSync(path.join(root, kind)).forEach(function (f) {
-      if (f.endsWith(".json") && f !== "_index.json") total++;
-    });
-  });
-  return total;
-}
-
-function deriveRegistry(lib) {
-  var p = path.join(
-    PLUGIN_ROOT,
-    "vendor",
-    "components",
-    "dist",
-    "registries",
-    lib + ".json",
-  );
-  var reg = JSON.parse(fs.readFileSync(p, "utf8"));
-  var keys = Object.keys(reg.components || {});
-  var sets = keys.filter(function (k) {
-    return reg.components[k].importMethod === "set";
-  }).length;
-  // Prefer the declared componentCount; fall back to key count.
-  var count =
-    typeof reg.componentCount === "number" ? reg.componentCount : keys.length;
-  return { count: count, sets: sets, keyCount: keys.length };
-}
-
-function deriveGuidelines() {
-  var dir = path.join(
-    PLUGIN_ROOT,
-    "vendor",
-    "components",
-    "dist",
-    "guidelines",
-  );
-  var files = fs.readdirSync(dir).filter(function (f) {
-    return f.endsWith(".json") && f !== "guidelines.bundle.json";
-  });
-  var aliases = files.filter(function (f) {
-    var j = JSON.parse(fs.readFileSync(path.join(dir, f), "utf8"));
-    return Object.prototype.hasOwnProperty.call(j, "_alias_of");
-  }).length;
-  return {
-    total: files.length,
-    canonical: files.length - aliases,
-    aliases: aliases,
-  };
-}
-
-var SKILLS = deriveSkills();
-var AGENTS = deriveAgents();
-var RECIPES = deriveRecipes();
-var DS = deriveRegistry("dskit");
-var FM = deriveRegistry("fmkit");
-var META = deriveRegistry("metakit");
-var GUIDE = deriveGuidelines();
-
-// ---------------------------------------------------------------------------
-// Managed doc surfaces + the strings each must contain / must not contain.
-// `mustContain` strings are built FROM the derived counts, so they track the
-// ground truth automatically. `mustNotContain` are regression guards for the
-// specific stale values this guard was created to kill.
-// ---------------------------------------------------------------------------
-
-function f(rel) {
-  return path.join(REPO_ROOT, rel);
-}
-
-var CHECKS = [
-  {
-    file: f("README.md"),
-    mustContain: [
-      SKILLS + " skills",
-      AGENTS + " agents",
-      RECIPES + " recipes",
-      "WCAG 2.2 AA",
-      DS.count +
-        " DS Kit + " +
-        FM.count +
-        " FM Kit + " +
-        META.count +
-        " Meta Kit",
-      DS.count + " DS Kit components (" + DS.sets + " sets)",
-      GUIDE.total + " per-component guideline docs",
-    ],
-    mustNotContain: [
-      "WCAG 2.1 AA",
-      "322 DS Kit",
-      "82 / 33 / 11",
-      "82 sets",
-      "85 per-component",
-      "41 auto-stub",
-      "44 fully curated",
-    ],
-  },
-  {
-    file: f(".claude-plugin/marketplace.json"),
-    mustContain: [
-      SKILLS + " skills, " + AGENTS + " agents",
-      SKILLS + " skills + " + AGENTS + " agents",
-      RECIPES + " recipes",
-      "WCAG 2.2 AA",
-      "brief-researcher",
-    ],
-    mustNotContain: ["WCAG 2.1 AA", "sync-design-system", "25 recipes"],
-  },
-  {
-    file: f("plugins/actian-design-system/.claude-plugin/plugin.json"),
-    mustContain: [SKILLS + " skills", AGENTS + " agents", "WCAG 2.2 AA"],
-    mustNotContain: ["WCAG 2.1 AA"],
-  },
-  {
-    file: f("llms.txt"),
-    mustContain: [
-      SKILLS + " skills",
-      DS.count + " DS Kit components",
-      FM.count + " FM Kit wireframe components",
-      META.count + " Meta Kit components",
-      "WCAG 2.2 AA",
-      GUIDE.total + " JSON files",
-    ],
-    mustNotContain: [
-      "WCAG 2.1 AA",
-      "107 DS Kit",
-      "107 design system",
-      "85 JSON files",
-    ],
-  },
-  {
-    file: f("USAGE.md"),
-    mustContain: ["WCAG 2.2 AA"],
-    mustNotContain: ["WCAG 2.1 AA"],
-  },
-  {
-    file: f(
-      "plugins/actian-design-system/references/context/companion-context.md",
-    ),
-    mustContain: [
-      DS.count + " components (" + DS.sets + " sets)",
-      FM.count + " components (" + FM.sets + " sets)",
-      META.count + " components (" + META.sets + " sets)",
-      GUIDE.total + " guideline docs",
-    ],
-    mustNotContain: ["107 sets", "44 components |", "~41 of 85"],
-  },
-  {
-    file: f(
-      "plugins/actian-design-system/references/figma/figma-push-patterns.md",
-    ),
-    mustContain: [
-      DS.count + " design system components",
-      FM.count + " wireframe components",
-    ],
-    mustNotContain: ["107 design system components", "33 wireframe components"],
-  },
-];
+var COUNTS = deriveCounts();
+var CHECKS = buildChecks(COUNTS);
 
 // ---------------------------------------------------------------------------
 // Tests
@@ -231,11 +56,13 @@ var CHECKS = [
 
 describe("Doc inventory counts match ground truth", function () {
   it("derives sane counts from the filesystem + registries", function () {
-    assert.ok(SKILLS >= 1, "skills count should be >= 1");
-    assert.ok(AGENTS >= 1, "agents count should be >= 1");
-    assert.ok(RECIPES >= 1, "recipes count should be >= 1");
-    assert.ok(DS.count > 0 && FM.count > 0 && META.count > 0);
-    assert.ok(GUIDE.total > 0);
+    assert.ok(COUNTS.SKILLS >= 1, "skills count should be >= 1");
+    assert.ok(COUNTS.AGENTS >= 1, "agents count should be >= 1");
+    assert.ok(COUNTS.RECIPES >= 1, "recipes count should be >= 1");
+    assert.ok(
+      COUNTS.DS.count > 0 && COUNTS.FM.count > 0 && COUNTS.META.count > 0,
+    );
+    assert.ok(COUNTS.GUIDE.total > 0);
     // The declared componentCount must equal the actual component-key count.
     ["dskit", "fmkit", "metakit"].forEach(function (lib) {
       var r = deriveRegistry(lib);
@@ -253,49 +80,48 @@ describe("Doc inventory counts match ground truth", function () {
   });
 
   CHECKS.forEach(function (check) {
-    var rel = path.relative(REPO_ROOT, check.file);
+    var rel = check.file;
     describe(rel, function () {
-      var content = fs.existsSync(check.file)
-        ? fs.readFileSync(check.file, "utf8")
-        : null;
+      var abs = path.join(REPO_ROOT, check.file);
+      var content = fs.existsSync(abs) ? fs.readFileSync(abs, "utf8") : null;
 
       it("exists", function () {
         assert.ok(content !== null, "managed doc not found: " + rel);
       });
 
-      (check.mustContain || []).forEach(function (needle) {
-        it('states "' + needle + '"', function () {
+      (check.contains || []).forEach(function (item) {
+        it('states "' + item.str + '"', function () {
           assert.ok(
-            content && content.indexOf(needle) !== -1,
+            content && content.indexOf(item.str) !== -1,
             rel +
               ' is missing expected count string "' +
-              needle +
+              item.str +
               '".\nGround truth: ' +
-              SKILLS +
+              COUNTS.SKILLS +
               " skills / " +
-              AGENTS +
+              COUNTS.AGENTS +
               " agents / " +
-              RECIPES +
+              COUNTS.RECIPES +
               " recipes / DS " +
-              DS.count +
+              COUNTS.DS.count +
               "(" +
-              DS.sets +
+              COUNTS.DS.sets +
               " sets) / FM " +
-              FM.count +
+              COUNTS.FM.count +
               "(" +
-              FM.sets +
+              COUNTS.FM.sets +
               " sets) / Meta " +
-              META.count +
+              COUNTS.META.count +
               "(" +
-              META.sets +
+              COUNTS.META.sets +
               " sets) / " +
-              GUIDE.total +
-              " guideline docs.\nUpdate the doc to match.",
+              COUNTS.GUIDE.total +
+              " guideline docs.\nRun `node scripts/vendor/sync-doc-counts.js` to fix, or update the doc to match.",
           );
         });
       });
 
-      (check.mustNotContain || []).forEach(function (needle) {
+      (check.notContains || []).forEach(function (needle) {
         it('does not contain stale "' + needle + '"', function () {
           assert.ok(
             content && content.indexOf(needle) === -1,

--- a/plugins/actian-design-system/tests/integration/sync-doc-counts.test.js
+++ b/plugins/actian-design-system/tests/integration/sync-doc-counts.test.js
@@ -1,0 +1,124 @@
+#!/usr/bin/env node
+"use strict";
+
+/**
+ * sync-doc-counts.test.js — Tests for the doc-count FIXER (the write side of
+ * the doc-counts contract). doc-counts.test.js GUARDS that the managed docs
+ * state the derived counts; this fixer REWRITES them to match when a vendor
+ * refresh changes a registry count, so count-changing refreshes self-heal
+ * instead of failing CI and leaving the auto-merge PR stuck.
+ *
+ * Shared source of truth: scripts/lib/doc-counts.js (deriveCounts + buildChecks
+ * + fixContent) — the same module the guard consumes, so guard and fixer can
+ * never disagree.
+ *
+ * Zero dependencies — Node.js built-ins only.
+ */
+
+var { describe, it } = require("node:test");
+var assert = require("node:assert");
+var fs = require("fs");
+var path = require("path");
+
+var {
+  deriveCounts,
+  buildChecks,
+  fixContent,
+  syncDocCounts,
+} = require("../../scripts/lib/doc-counts.js");
+
+var PLUGIN_ROOT = path.resolve(__dirname, "..", "..");
+var REPO_ROOT = path.resolve(PLUGIN_ROOT, "..", "..");
+
+describe("doc-count fixer (fixContent)", function () {
+  it("replaces a stale numeric phrase with the canonical string via its fixRx", function () {
+    var items = [
+      {
+        str: "319 DS Kit components (80 sets)",
+        fixRx: /\d+ DS Kit components \(\d+ sets\)/g,
+      },
+    ];
+    assert.equal(
+      fixContent("we ship 312 DS Kit components (77 sets) today", items),
+      "we ship 319 DS Kit components (80 sets) today",
+    );
+  });
+
+  it("rewrites every occurrence (global), not just the first", function () {
+    var items = [{ str: "9 agents", fixRx: /\d+ agents/g }];
+    assert.equal(
+      fixContent("8 agents here and 8 agents there", items),
+      "9 agents here and 9 agents there",
+    );
+  });
+
+  it("leaves literal items (no fixRx) untouched", function () {
+    var items = [{ str: "WCAG 2.2 AA" }];
+    assert.equal(fixContent("WCAG 2.1 AA stuff", items), "WCAG 2.1 AA stuff");
+  });
+
+  it("treats the replacement as a literal (no $-pattern interpretation)", function () {
+    var items = [{ str: "a$1b", fixRx: /XX/g }];
+    assert.equal(fixContent("zzXXzz", items), "zza$1bzz");
+  });
+});
+
+describe("doc-count fixer × real managed docs", function () {
+  var counts = deriveCounts();
+  var checks = buildChecks(counts);
+
+  it("is idempotent on the real docs when counts are already correct", function () {
+    // Safety net against an over-greedy fixRx: if any pattern would rewrite a
+    // CORRECT doc (e.g. clobber the foundations "8 JSON files" while fixing the
+    // "45 JSON files, all curated" guideline count), the doc changes here and
+    // this fails. (It guards GREEDINESS, not COMPLETENESS — a count phrase with
+    // no fixRx simply isn't synced; the doc-counts guard covers presence.)
+    checks.forEach(function (check) {
+      var p = path.join(REPO_ROOT, check.file);
+      if (!fs.existsSync(p)) return;
+      var content = fs.readFileSync(p, "utf8");
+      var fixed = fixContent(content, check.contains);
+      assert.equal(
+        fixed,
+        content,
+        check.file +
+          " was modified by the fixer despite correct counts — a fixRx is too greedy.",
+      );
+    });
+  });
+
+  it("restores a perturbed README count to the derived value", function () {
+    var readme = checks.find(function (c) {
+      return c.file === "README.md";
+    });
+    var content = fs.readFileSync(path.join(REPO_ROOT, "README.md"), "utf8");
+    var stale = content.replace(
+      counts.DS.count + " DS Kit + " + counts.FM.count + " FM Kit",
+      counts.DS.count - 1 + " DS Kit + " + counts.FM.count + " FM Kit",
+    );
+    assert.notEqual(stale, content, "perturbation should have changed README");
+    var fixed = fixContent(stale, readme.contains);
+    assert.equal(
+      fixed,
+      content,
+      "fixer should restore the perturbed README to the correct counts",
+    );
+  });
+});
+
+describe("syncDocCounts (file-level)", function () {
+  it("reports no changes on the current repo in dry-run (docs already correct)", function () {
+    var res = syncDocCounts(REPO_ROOT, { write: false });
+    assert.deepEqual(
+      res.changed,
+      [],
+      "dry run should report no stale docs, got: " + res.changed.join(", "),
+    );
+  });
+
+  it("returns the derived counts alongside the change list", function () {
+    var res = syncDocCounts(REPO_ROOT, { write: false });
+    assert.equal(typeof res.counts.DS.count, "number");
+    assert.ok(Array.isArray(res.changed));
+  });
+});


### PR DESCRIPTION
## Problem

The `vendor-snapshot.yml` workflow re-vendors `vendor/**` (a new knowledge snapshot) but did **not** update the plugin's human-facing inventory counts in prose (README, llms.txt, marketplace.json, plugin.json, companion-context, figma-push-patterns). So a refresh that changes a component count makes the `doc-counts` guard fail, and since the vendor PR auto-merges (`gh pr merge --auto --squash`), it sits **stuck** until a human hand-edits the counts.

Hit live on **#161** (v0.30.5: DS Kit 318→319) — I had to hand-fix the six `318→319` references to unblock the auto-merge. **The nightly cron has the same exposure.**

## Fix — make count-changing refreshes self-heal

- **`scripts/lib/doc-counts.js`** — new single source of truth: `deriveCounts()` (registries via `PATHS`, skills/agents/recipes from the filesystem), `buildChecks(counts)` (per managed doc: `contains: [{str, fixRx?}]` + `notContains`), `fixContent()` (pure, literal replacement — no `$`-pattern interpretation), `syncDocCounts(repoRoot, {write})`.
- **`tests/integration/doc-counts.test.js`** refactored to **consume** the shared module (guard side) — same coverage, now sharing `buildChecks()` with the fixer so the guard and fixer **can never drift**.
- **`scripts/vendor/sync-doc-counts.js`** — new CLI: `--check` (report drift, exit 1) / default (rewrite in place).
- **`vendor-snapshot.yml`** — new "Sync doc inventory counts" step after the registry-mirror regen; the managed docs added to the create-PR `add-paths` so the fixes are committed.

## Coverage & safety

Self-heals: component counts (`319 DS Kit + 287 FM Kit + 28 Meta Kit`, `319 DS Kit components (80 sets)`, the llms/figma/companion variants), the **per-kit set breakdown** (`80 / 33 / 11`), guideline **total** (`45 … guideline docs`) and the **canonical/alias split** (`37 components + 8 …`).

- Every `fixRx` is anchored tightly (e.g. the llms.txt guideline count is `\d+ JSON files, all curated` so it never clobbers the sibling "Foundations subtree (8 JSON files)" line; companion rows are label-anchored; the guideline-split fixRx matches only the `<n> components + <n>` prefix so the trailing "(registry-key) aliases" wording is preserved).
- A **real-doc idempotency test** runs the fixer over the actual docs and asserts **no change** — the guard against an over-greedy regex.
- Vendor reads route through `PATHS` (no bare `vendor/` literals; `no-bare-vendor-paths` guard passes).

## Verification

- Full suite **1363/1364** CI-parity (`find tests -name '*.test.js' | xargs node --test`); lone fail = the gitignored superpowers federation plan, absent in CI.
- TDD throughout (RED→GREEN per function); end-to-end verified by perturbing real docs and confirming the CLI restores them exactly.
- Independent code-review pass (subagent): **no Critical/Important**; its 3 Minor findings applied (sets + guideline-split coverage, robust guideline-dir resolution, idempotency-test comment).
- `plugin.json` 1.104.6 → **1.105.0** (MINOR — new pipeline tooling) + CHANGELOG.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
