### PR TITLE
feat(anatomy): consume the vendored anatomy domain (Program A Phase 2, v1.108.0)

### DIFF
--- a/plugins/actian-design-system/.claude-plugin/plugin.json
+++ b/plugins/actian-design-system/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "actian-design-system",
   "description": "Actian Design System toolkit — generate wireframe flows with prototype wiring, create component briefs, audit designs, compare flows, and build presentations. 8 skills (with tiered generation: recognized / adapted / improvised), 9 agents, 155 tokens (3 themes, 8 collections), WCAG 2.2 AA. DS knowledge vendored from volivarii/actian-ds-knowledge.",
-  "version": "1.107.1",
+  "version": "1.108.0",
   "author": {
     "name": "Actian UX Team"
   },

--- a/plugins/actian-design-system/.claude-plugin/plugin.json
+++ b/plugins/actian-design-system/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "actian-design-system",
   "description": "Actian Design System toolkit — generate wireframe flows with prototype wiring, create component briefs, audit designs, compare flows, and build presentations. 8 skills (with tiered generation: recognized / adapted / improvised), 9 agents, 155 tokens (3 themes, 8 collections), WCAG 2.2 AA. DS knowledge vendored from volivarii/actian-ds-knowledge.",
-  "version": "1.108.0",
+  "version": "1.107.2",
   "author": {
     "name": "Actian UX Team"
   },

--- a/plugins/actian-design-system/scripts/lib/paths.js
+++ b/plugins/actian-design-system/scripts/lib/paths.js
@@ -120,18 +120,12 @@ PATHS.components.media = function (slug) {
   return path.join(VENDOR, "components", "dist", "media", slug, "preview.webp");
 };
 
-// Anatomy: machine-extracted, Figma-synced structure-tree facts (knowledge's
-// `anatomy` domain, v0.32.x). byKey(slug) → the per-component artifact; bundle →
-// the slug-keyed roll-up. Consumers interpret the normalized layout-intent tree.
-PATHS.components.anatomy = function (slug) {
-  return path.join(VENDOR, "components", "dist", "anatomy", slug + ".json");
-};
-PATHS.components.anatomyBundle = path.join(
-  VENDOR,
-  "components",
-  "dist",
-  "anatomy.bundle.json",
-);
+// NOTE: anatomy resolution is NOT overlaid here. The knowledge `anatomy` domain
+// is declared in paths-manifest.json (components.anatomy.byKey collection +
+// components.anatomy.bundle path), so buildPathsFromManifest already produces
+// PATHS.components.anatomy.byKey(slug) + PATHS.components.anatomy.bundle. Adding a
+// plugin overlay here would CLOBBER the manifest-built object (anatomy is
+// manifest-driven, unlike `media` which is plugin-only). Consume the manifest API.
 
 // Synthesized helper: byKit("ds"/"fm"/"meta") maps to registry leaf paths.
 // Preserved from pre-manifest API for backward compat with validate-flow-data.js etc.

--- a/plugins/actian-design-system/scripts/lib/paths.js
+++ b/plugins/actian-design-system/scripts/lib/paths.js
@@ -120,6 +120,19 @@ PATHS.components.media = function (slug) {
   return path.join(VENDOR, "components", "dist", "media", slug, "preview.webp");
 };
 
+// Anatomy: machine-extracted, Figma-synced structure-tree facts (knowledge's
+// `anatomy` domain, v0.32.x). byKey(slug) → the per-component artifact; bundle →
+// the slug-keyed roll-up. Consumers interpret the normalized layout-intent tree.
+PATHS.components.anatomy = function (slug) {
+  return path.join(VENDOR, "components", "dist", "anatomy", slug + ".json");
+};
+PATHS.components.anatomyBundle = path.join(
+  VENDOR,
+  "components",
+  "dist",
+  "anatomy.bundle.json",
+);
+
 // Synthesized helper: byKit("ds"/"fm"/"meta") maps to registry leaf paths.
 // Preserved from pre-manifest API for backward compat with validate-flow-data.js etc.
 PATHS.components.registries = PATHS.components.registries || {};

--- a/plugins/actian-design-system/tests/integration/anatomy-paths.test.js
+++ b/plugins/actian-design-system/tests/integration/anatomy-paths.test.js
@@ -1,30 +1,43 @@
 "use strict";
-// PATHS.components.anatomy resolves the vendored anatomy artifacts (knowledge's
-// `anatomy` domain). v0.32.x vendors a placeholder bundle + .gitkeep; real
-// <slug>.json artifacts land on the next knowledge Figma sync.
+// The knowledge `anatomy` domain is manifest-driven: paths-manifest.json declares
+// components.anatomy.byKey (collection) + components.anatomy.bundle (path), so
+// buildPathsFromManifest produces PATHS.components.anatomy.byKey(slug) +
+// PATHS.components.anatomy.bundle — no plugin overlay needed. v0.32.x vendors a
+// placeholder bundle + .gitkeep; real <slug>.json land on the next Figma sync.
 var test = require("node:test");
 var assert = require("node:assert/strict");
 var fs = require("node:fs");
+var path = require("node:path");
 var PATHS = require("../../scripts/lib/paths");
 
-test("PATHS.components.anatomy(slug) builds the per-component path", function () {
-  var p = PATHS.components.anatomy("button");
+test("manifest builds PATHS.components.anatomy.byKey(slug)", function () {
+  assert.equal(typeof PATHS.components.anatomy.byKey, "function");
+  var p = PATHS.components.anatomy.byKey("button");
   assert.ok(/components\/dist\/anatomy\/button\.json$/.test(p), p);
 });
 
-test("PATHS.components.anatomyBundle points at the vendored bundle", function () {
+test("manifest builds PATHS.components.anatomy.bundle", function () {
   assert.ok(
-    /components\/dist\/anatomy\.bundle\.json$/.test(PATHS.components.anatomyBundle),
-    PATHS.components.anatomyBundle,
+    /components\/dist\/anatomy\.bundle\.json$/.test(
+      PATHS.components.anatomy.bundle,
+    ),
+    PATHS.components.anatomy.bundle,
   );
 });
 
-test("the anatomy dir + bundle are actually vendored (resolvable)", function () {
-  // dir-level check (per-slug artifacts are CI-generated; .gitkeep holds the dir)
-  var dir = require("path").dirname(PATHS.components.anatomy("button"));
+test("the vendored anatomy dir + bundle actually resolve", function () {
+  var dir = path.dirname(PATHS.components.anatomy.byKey("button"));
   assert.ok(fs.existsSync(dir), "anatomy dir vendored: " + dir);
   assert.ok(
-    fs.existsSync(PATHS.components.anatomyBundle),
-    "bundle vendored: " + PATHS.components.anatomyBundle,
+    fs.existsSync(PATHS.components.anatomy.bundle),
+    "bundle vendored: " + PATHS.components.anatomy.bundle,
+  );
+  // vendored bundle is the placeholder envelope (real data lands on next sync)
+  var bundle = JSON.parse(
+    fs.readFileSync(PATHS.components.anatomy.bundle, "utf8"),
+  );
+  assert.ok(
+    bundle.components && typeof bundle.components === "object",
+    "bundle has a components envelope",
   );
 });

--- a/plugins/actian-design-system/tests/integration/anatomy-paths.test.js
+++ b/plugins/actian-design-system/tests/integration/anatomy-paths.test.js
@@ -1,0 +1,30 @@
+"use strict";
+// PATHS.components.anatomy resolves the vendored anatomy artifacts (knowledge's
+// `anatomy` domain). v0.32.x vendors a placeholder bundle + .gitkeep; real
+// <slug>.json artifacts land on the next knowledge Figma sync.
+var test = require("node:test");
+var assert = require("node:assert/strict");
+var fs = require("node:fs");
+var PATHS = require("../../scripts/lib/paths");
+
+test("PATHS.components.anatomy(slug) builds the per-component path", function () {
+  var p = PATHS.components.anatomy("button");
+  assert.ok(/components\/dist\/anatomy\/button\.json$/.test(p), p);
+});
+
+test("PATHS.components.anatomyBundle points at the vendored bundle", function () {
+  assert.ok(
+    /components\/dist\/anatomy\.bundle\.json$/.test(PATHS.components.anatomyBundle),
+    PATHS.components.anatomyBundle,
+  );
+});
+
+test("the anatomy dir + bundle are actually vendored (resolvable)", function () {
+  // dir-level check (per-slug artifacts are CI-generated; .gitkeep holds the dir)
+  var dir = require("path").dirname(PATHS.components.anatomy("button"));
+  assert.ok(fs.existsSync(dir), "anatomy dir vendored: " + dir);
+  assert.ok(
+    fs.existsSync(PATHS.components.anatomyBundle),
+    "bundle vendored: " + PATHS.components.anatomyBundle,
+  );
+});


### PR DESCRIPTION
## What this is

**Program A — Phase 2** (the plugin side): now that the knowledge `anatomy` domain is merged (knowledge PR #231, v0.32.x) and **vendored** into the plugin (vendor refresh #168), this makes the plugin able to *resolve* it.

- `PATHS.components.anatomy(slug)` → `vendor/components/dist/anatomy/<slug>.json`
- `PATHS.components.anatomyBundle` → `vendor/components/dist/anatomy.bundle.json`
- Integration test (3) confirming the path shapes + that the vendored anatomy dir + bundle actually resolve.

This completes the substrate loop end-to-end: **Figma → knowledge extracts anatomy facts → vendored → plugin resolves them**. Consumers (render tier, future surfaces) can now read the normalized structure-tree facts.

## Honest scope

There's **no real anatomy data yet** — the vendored artifact is the placeholder bundle + `.gitkeep`; real `<slug>.json` files are CI-generated on the **next knowledge Figma sync** (the extractor walks every registry component then). This PR deposits the *resolution capability* (substrate-first); it consumes nothing real until that sync runs. The test checks at the dir level for exactly this reason.

## Tests

- New `tests/integration/anatomy-paths.test.js` — 3/3 pass.
- `no-bare-vendor-paths` guard — green (the new entries use the `VENDOR` const, no bare literals).
- `vendor-paths-resolve` has 1 **pre-existing** local failure (it scans a *gitignored* federation plan referencing stale paths — red locally, green in CI; identical on `main`, not caused by this change). The anatomy entries resolve cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)