### PR TITLE
feat(versioning): switch plugin to calendar versioning (YYYY.MM.PATCH)

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -66,10 +66,12 @@ Per MIGRATIONS.md (parallel-change rule):
 
 ## Version bump
 
-- [ ] `plugins/actian-design-system/.claude-plugin/plugin.json` bumped per semver
-      (PATCH = fix, MINOR = feature, MAJOR = breaking). The `plugin.json bumped`
-      CI check enforces the bump exists; it does not check the bump kind — pick
-      it correctly.
+- [ ] `plugins/actian-design-system/.claude-plugin/plugin.json` bumped per
+      calendar versioning `YYYY.MM.PATCH` (same month → PATCH+1; new month →
+      `YYYY.MM.0`). From the repo root, run: `node
+      plugins/actian-design-system/scripts/lib/bump-version.js
+      plugins/actian-design-system/.claude-plugin/plugin.json calendar`. The
+      `plugin.json bumped` CI check enforces the bump exists.
 
 ## Out-of-scope / follow-up
 

--- a/.github/workflows/scripts/check-version-bump.js
+++ b/.github/workflows/scripts/check-version-bump.js
@@ -23,9 +23,8 @@
  *   - If source files changed and version is unchanged from base: fail
  *   - If source files changed and version is bumped: pass
  *
- * The auto-bump-on-data-sync workflow (sync-from-figma.yml, derive-foundations
- * via shared bump-version.js) covers automated bumps; this gate covers
- * human-authored PRs.
+ * The vendor-snapshot workflow auto-bumps via the shared bump-version.js
+ * (calendar mode) on a data refresh; this gate covers human-authored PRs.
  */
 
 var fs = require("fs");
@@ -141,7 +140,8 @@ function main() {
     );
     process.stderr.write(
       "  Bump plugins/actian-design-system/.claude-plugin/plugin.json " +
-        "version (PATCH for fixes, MINOR for features, MAJOR for breaking).\n",
+        "version (calendar versioning YYYY.MM.PATCH — same month bumps PATCH, " +
+        "a new month resets to YYYY.MM.0; see CLAUDE.md 'Versioning').\n",
     );
     return 1;
   }

--- a/.github/workflows/vendor-snapshot.yml
+++ b/.github/workflows/vendor-snapshot.yml
@@ -4,8 +4,8 @@ name: Vendor knowledge-repo snapshot
 # volivarii/actian-ds-knowledge into plugins/actian-design-system/vendor/.
 # Runs nightly via cron + manual via workflow_dispatch. Regenerates the
 # *-components.md mirrors via render-component-reference.js after each
-# pull. Auto-bumps plugin.json patch when there's a content diff so the
-# marketplace cache propagates new content to designers.
+# pull. Auto-bumps plugin.json (calendar YYYY.MM.PATCH) when there's a content
+# diff so the marketplace cache propagates new content to designers.
 #
 # Required repo settings:
 #   Settings → Actions → General → Workflow permissions → Allow GH Actions
@@ -135,18 +135,17 @@ jobs:
             git diff --stat -- plugins/actian-design-system/vendor/ plugins/actian-design-system/vendored.json
           fi
 
-      - name: Auto-bump plugin.json patch
+      - name: Auto-bump plugin.json (calendar)
         if: steps.diff.outputs.changed == 'true'
+        # Calendar versioning (YYYY.MM.PATCH) — same month bumps PATCH, a new
+        # month resets to YYYY.MM.0. Delegates to the shared, unit-tested bumper
+        # so CI and manual bumps share one implementation. See CLAUDE.md
+        # "Versioning". Runs from repo root (no working-directory) — both paths
+        # are repo-root-relative; don't add a working-directory without also
+        # stripping the plugins/actian-design-system/ prefix.
         run: |
-          CURRENT=$(jq -r '.version' plugins/actian-design-system/.claude-plugin/plugin.json)
-          MAJOR=$(echo "$CURRENT" | cut -d. -f1)
-          MINOR=$(echo "$CURRENT" | cut -d. -f2)
-          PATCH=$(echo "$CURRENT" | cut -d. -f3)
-          NEW_PATCH=$((PATCH + 1))
-          NEW="$MAJOR.$MINOR.$NEW_PATCH"
-          jq ".version = \"$NEW\"" plugins/actian-design-system/.claude-plugin/plugin.json > /tmp/plugin.json
-          mv /tmp/plugin.json plugins/actian-design-system/.claude-plugin/plugin.json
-          echo "Bumped $CURRENT → $NEW"
+          node plugins/actian-design-system/scripts/lib/bump-version.js \
+            plugins/actian-design-system/.claude-plugin/plugin.json calendar
 
       - name: Open pull request
         if: steps.diff.outputs.changed == 'true'
@@ -164,7 +163,7 @@ jobs:
 
             See https://github.com/volivarii/actian-ds-knowledge/tree/${{ steps.target.outputs.sha }} for source state.
 
-            Auto-bumps plugin.json patch so the marketplace cache propagates the new content to designers.
+            Auto-bumps plugin.json (calendar `YYYY.MM.PATCH`) so the marketplace cache propagates the new content to designers.
           branch: "vendor/refresh-${{ steps.target.outputs.short_sha }}"
           labels: vendor,knowledge-snapshot,auto-merge
           delete-branch: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,18 +2,33 @@
 
 All notable changes to the Actian Design System plugin are documented here.
 
-The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
-and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
-in `plugins/actian-design-system/.claude-plugin/plugin.json`:
-**MAJOR** = breaking, **MINOR** = features, **PATCH** = fixes.
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
+Since `2026.6.0` the plugin uses **calendar versioning** (`YYYY.MM.PATCH`) in
+`plugins/actian-design-system/.claude-plugin/plugin.json`: same month bumps
+**PATCH**, a new month resets to `YYYY.MM.0`. (Versions through `1.108.0` were
+semver; `2026.6.0 > 1.108.0` numerically, so release ordering is preserved.)
 
 Routine `vendor(knowledge): refresh to vX.Y.Z` commits are automated nightly
-patch bumps that propagate a pinned snapshot from
+version bumps (PATCH within a month, or a `YYYY.MM.0` reset at a month boundary)
+that propagate a pinned snapshot from
 [`volivarii/actian-ds-knowledge`](https://github.com/volivarii/actian-ds-knowledge);
 they are not individually listed below unless they changed user-facing behavior.
 
 This file was seeded at v1.97.0 from the commit history; entries before that
 are summarized at the release level.
+
+## [2026.6.0] — 2026-06-13
+
+### Changed
+
+- **Versioning switched to calendar versioning** (`YYYY.MM.PATCH`). The plugin
+  is an end-user tool whose version is a release counter, not an API contract,
+  so month-granularity recency is the meaningful signal rather than a
+  major/minor/patch semantic. Same month → PATCH+1; new month → `YYYY.MM.0`. CI
+  auto-bump (`vendor-snapshot.yml`) and the manual `scripts/lib/bump-version.js`
+  now share one `calendar` mode. Knowledge-repo versioning is unaffected (it
+  stays semver — it's resolved through a version range). Prior plugin history
+  through `1.108.0` was semver.
 
 ## [1.106.1] — 2026-06-10
 

--- a/plugins/actian-design-system/.claude-plugin/plugin.json
+++ b/plugins/actian-design-system/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "actian-design-system",
   "description": "Actian Design System toolkit — generate wireframe flows with prototype wiring, create component briefs, audit designs, compare flows, and build presentations. 8 skills (with tiered generation: recognized / adapted / improvised), 9 agents, 155 tokens (3 themes, 8 collections), WCAG 2.2 AA. DS knowledge vendored from volivarii/actian-ds-knowledge.",
-  "version": "1.108.1",
+  "version": "2026.6.0",
   "author": {
     "name": "Actian UX Team"
   },

--- a/plugins/actian-design-system/ARCHITECTURE.md
+++ b/plugins/actian-design-system/ARCHITECTURE.md
@@ -102,4 +102,4 @@ No `tests/hooks/` — shell guards aren't unit-tested.
 6. If it has HTML/JSON templates, add files under `templates/`.
 7. Add tests under `tests/` (PR-3 will create the integration/ subdir for cross-cutting tests).
 8. Update this `ARCHITECTURE.md` Section 2 with the new row.
-9. Bump version in `.claude-plugin/plugin.json`.
+9. Bump version in `.claude-plugin/plugin.json` (calendar `YYYY.MM.PATCH` — see CLAUDE.md "Versioning").

--- a/plugins/actian-design-system/CLAUDE.md
+++ b/plugins/actian-design-system/CLAUDE.md
@@ -63,7 +63,7 @@ Data flows: `Figma -> volivarii/actian-ds-knowledge CI -> vendor/ (snapshot pull
 - `vendor/content/dist/words-to-avoid.json` — structured words-to-avoid rules (content's first JSON dist); each rule = `{ avoid, reason, example: { do, dont } }`, advisory rules carry `avoid: []`. Read by `validate-flow-data.js` (avoid-word soft-check); `global.md` keeps the prose table for humans. Resolve via `PATHS.content.wordsToAvoid`.
 - `vendor/app-context/app-context.json`
 
-`vendored.json` records the pinned knowledge-repo SHA. Run `vendor-snapshot.yml` workflow (manual or nightly cron) to refresh; auto-bumps plugin.json patch on diff so the marketplace picks up the new content.
+`vendored.json` records the pinned knowledge-repo SHA. Run `vendor-snapshot.yml` workflow (manual or nightly cron) to refresh; auto-bumps plugin.json (calendar `YYYY.MM.PATCH`) on diff so the marketplace picks up the new content.
 
 **Scripts** (utilities — NOT used for Figma push):
 - `scripts/renderers/assemble-preview.js` — generates HTML previews from data models
@@ -100,7 +100,14 @@ When generating code or docs in this plugin, consult `ARCHITECTURE.md` for place
 
 ## Versioning
 
-Semver in `.claude-plugin/plugin.json`. PATCH = fixes, MINOR = features, MAJOR = breaking. Bump as part of the feature/fix commit, not separately. Batch related changes.
+**Calendar versioning** (`YYYY.MM.PATCH`) in `.claude-plugin/plugin.json` — e.g. `2026.6.3` is the 4th release in June 2026. The version is a release counter, not an API contract: this is an end-user plugin and nothing pins it by semver range, so the meaningful signal is *recency at month granularity*, not a major/minor/patch semantic.
+
+- **Same month:** bump PATCH (`2026.6.3` → `2026.6.4`).
+- **New month:** reset to `YYYY.MM.0` (`2026.6.4` → `2026.7.0`).
+- **Bump as part of the feature/fix commit**, not separately. Batch related changes into one bump.
+- **Tooling:** `node scripts/lib/bump-version.js .claude-plugin/plugin.json calendar` does the right thing for the current UTC month; `vendor-snapshot.yml` calls it on a data refresh. Legacy `patch`/`minor`/`major` modes remain for explicit manual bumps.
+- **Ordering:** versions compare **segment-wise as integers** (the YYYY.MM key increments before PATCH resets), so each release is strictly greater than the last — `2026.7.0 > 2026.6.47` — and every CalVer release beats the pre-CalVer tail (`2026.6.0 > 1.108.0`). Months are intentionally **not** zero-padded (`2026.6.0`, not `2026.06.0`): leading zeros are illegal in SemVer, so padding would risk `claude plugin validate` / parser rejection — and unpadded stays valid SemVer. The trade-off is that *naive lexical* string sort is unreliable for two-digit months (`"2026.10.0"` sorts before `"2026.9.0"` as a raw string), so **don't lexically sort versions — compare numerically.** Claude Code's update detection is string-**equality**, which is unaffected either way.
+- `marketplace.json` carries no version; `plugin.json#version` is the single source of truth.
 
 ---
 

--- a/plugins/actian-design-system/scripts/lib/bump-version.js
+++ b/plugins/actian-design-system/scripts/lib/bump-version.js
@@ -1,11 +1,15 @@
 "use strict";
 
-// Pure semver bump utility used by the auto-sync GitHub Action workflow and
-// foundations-derive workflow to PATCH-bump plugin.json when generated data
-// (registries, styles, foundations JSONs) changes.
+// Pure version bump utility for plugin.json, used by the vendor-snapshot
+// GitHub Action to bump the version when vendored/generated data changes.
 //
-// Returns the bumped version string. Throws on invalid semver or unknown
-// level. No I/O — caller reads/writes plugin.json.
+// The plugin uses CALENDAR versioning (YYYY.MM.PATCH) — see CLAUDE.md
+// "Versioning". `calendarBump(version, date)` is the primary path: same month
+// → PATCH+1, new month/year → YYYY.MM.0. The legacy `bumpVersion(version,
+// level)` semver math (patch/minor/major) is kept for explicit manual bumps.
+//
+// Both functions are pure (date is passed in, no clock read) and do no I/O —
+// the caller reads/writes plugin.json. They throw on a malformed version.
 
 var SEMVER_RE = /^(\d+)\.(\d+)\.(\d+)$/;
 var LEVELS = ["major", "minor", "patch"];
@@ -13,13 +17,19 @@ var LEVELS = ["major", "minor", "patch"];
 function bumpVersion(version, level) {
   if (LEVELS.indexOf(level) === -1) {
     throw new Error(
-      "Invalid level: " + level + " (expected one of: " + LEVELS.join(", ") + ")",
+      "Invalid level: " +
+        level +
+        " (expected one of: " +
+        LEVELS.join(", ") +
+        ")",
     );
   }
   var match = SEMVER_RE.exec(version);
   if (!match) {
     throw new Error(
-      "Invalid semver: " + version + " (expected x.y.z with non-negative integers)",
+      "Invalid semver: " +
+        version +
+        " (expected x.y.z with non-negative integers)",
     );
   }
   var major = parseInt(match[1], 10);
@@ -31,23 +41,64 @@ function bumpVersion(version, level) {
   return major + "." + minor + "." + (patch + 1);
 }
 
-module.exports = bumpVersion;
+// Calendar bump: YYYY.MM.PATCH keyed off the UTC date.
+//   - Same train (version's YYYY.MM matches the date's): PATCH + 1.
+//   - New month or new year: reset to YYYY.MM.0.
+// Migrating from a legacy semver (e.g. 1.108.0) naturally resets to the
+// current YYYY.MM.0. `date` is required so the function stays pure/testable;
+// the CLI passes `new Date()`. Uses UTC to match the CI runner clock.
+//
+// The month is emitted UNPADDED (2026.6.0, 2026.10.0) on purpose: leading
+// zeros are illegal in SemVer, so a padded "2026.06.0" would risk
+// `claude plugin validate`/parser rejection. Unpadded stays valid SemVer and
+// compares correctly segment-wise as integers. The only cost is that naive
+// lexical string sort mis-orders two-digit months — but nothing sorts plugin
+// versions lexically (update detection is string-equality). Do NOT zero-pad.
+function calendarBump(version, date) {
+  var match = SEMVER_RE.exec(version);
+  if (!match) {
+    throw new Error(
+      "Invalid version: " +
+        version +
+        " (expected YYYY.MM.PATCH with non-negative integers)",
+    );
+  }
+  var year = date.getUTCFullYear();
+  var month = date.getUTCMonth() + 1; // getUTCMonth is 0-based
+  var sameTrain =
+    parseInt(match[1], 10) === year && parseInt(match[2], 10) === month;
+  var patch = sameTrain ? parseInt(match[3], 10) + 1 : 0;
+  return year + "." + month + "." + patch;
+}
 
-// CLI: node bump-version.js <plugin.json path> <level>
-// Reads, bumps, writes back. Used by GitHub workflows.
+module.exports = bumpVersion;
+module.exports.calendarBump = calendarBump;
+
+// CLI: node bump-version.js <plugin.json path> <calendar|patch|minor|major>
+// Reads, bumps, writes back. Used by GitHub workflows. `calendar` is the
+// plugin's default scheme (see CLAUDE.md "Versioning").
 if (require.main === module) {
   var fs = require("fs");
   var args = process.argv.slice(2);
   if (args.length !== 2) {
-    process.stderr.write("Usage: bump-version.js <plugin.json path> <patch|minor|major>\n");
+    process.stderr.write(
+      "Usage: bump-version.js <plugin.json path> <calendar|patch|minor|major>\n",
+    );
     process.exit(1);
   }
   var pluginJsonPath = args[0];
   var level = args[1];
   var plugin = JSON.parse(fs.readFileSync(pluginJsonPath, "utf8"));
   var oldVersion = plugin.version;
-  var newVersion = bumpVersion(oldVersion, level);
+  var newVersion =
+    level === "calendar"
+      ? calendarBump(oldVersion, new Date())
+      : bumpVersion(oldVersion, level);
   plugin.version = newVersion;
-  fs.writeFileSync(pluginJsonPath, JSON.stringify(plugin, null, 2) + "\n", "utf8");
+  fs.writeFileSync(
+    pluginJsonPath,
+    JSON.stringify(plugin, null, 2) + "\n",
+    "utf8",
+  );
   process.stdout.write(oldVersion + " -> " + newVersion + "\n");
 }

--- a/plugins/actian-design-system/scripts/vendor/vendor-snapshot.js
+++ b/plugins/actian-design-system/scripts/vendor/vendor-snapshot.js
@@ -21,7 +21,7 @@
 //   node scripts/vendor/vendor-snapshot.js --resolve-only
 //
 // vendored.json#knowledge_repo_version_range pins the snapshot; vendor-snapshot.yml
-// refreshes it nightly and bumps plugin.json patch on diff.
+// refreshes it nightly and bumps plugin.json (calendar YYYY.MM.PATCH) on diff.
 
 var fs = require("fs");
 var path = require("path");

--- a/plugins/actian-design-system/tests/lib/bump-version.test.js
+++ b/plugins/actian-design-system/tests/lib/bump-version.test.js
@@ -1,9 +1,12 @@
 #!/usr/bin/env node
 "use strict";
 
-// Verifies the semver bump utility used by the auto-sync GitHub Action and
-// foundations-derive workflow to PATCH-bump plugin.json when generated data
-// changes (registries, styles, foundations JSONs). Pure semver math; no I/O.
+// Verifies the version bump utility used by the vendor-snapshot GitHub Action
+// to bump plugin.json when generated/vendored data changes. Pure math; no I/O.
+//
+// The plugin uses calendar versioning (YYYY.MM.PATCH) — see CLAUDE.md
+// "Versioning". The legacy semver level bumps (patch/minor/major) are retained
+// for explicit manual bumps and exercised here too.
 //
 // Covered cases:
 //   1. Patch bump from x.y.z → x.y.(z+1)
@@ -12,11 +15,14 @@
 //   4. Multi-digit components (1.99.99 → 1.99.100)
 //   5. Invalid semver throws
 //   6. Invalid level throws
+//   7. Calendar bump: same month → PATCH+1; new month/year → YYYY.MM.0;
+//      migration from legacy semver; UTC-based; invalid version throws
 
 var { describe, it } = require("node:test");
 var assert = require("node:assert");
 
 var bumpVersion = require("../../scripts/lib/bump-version.js");
+var calendarBump = bumpVersion.calendarBump;
 
 describe("bump-version", function () {
   describe("patch bumps", function () {
@@ -78,6 +84,70 @@ describe("bump-version", function () {
       assert.throws(function () {
         bumpVersion("1.x.0", "patch");
       }, /Invalid semver/);
+    });
+  });
+
+  describe("calendar bumps", function () {
+    // Date.UTC(year, monthIndex, day) — monthIndex is 0-based, so 5 = June.
+    it("same month → PATCH+1 (2026.6.0 → 2026.6.1)", function () {
+      assert.strictEqual(
+        calendarBump("2026.6.0", new Date(Date.UTC(2026, 5, 13))),
+        "2026.6.1",
+      );
+    });
+
+    it("multi-digit patch, same month (2026.6.47 → 2026.6.48)", function () {
+      assert.strictEqual(
+        calendarBump("2026.6.47", new Date(Date.UTC(2026, 5, 30))),
+        "2026.6.48",
+      );
+    });
+
+    it("new month → reset to YYYY.MM.0 (2026.6.4 → 2026.7.0)", function () {
+      assert.strictEqual(
+        calendarBump("2026.6.4", new Date(Date.UTC(2026, 6, 1))),
+        "2026.7.0",
+      );
+    });
+
+    it("new year → reset to YYYY.MM.0 (2026.12.9 → 2027.1.0)", function () {
+      assert.strictEqual(
+        calendarBump("2026.12.9", new Date(Date.UTC(2027, 0, 5))),
+        "2027.1.0",
+      );
+    });
+
+    it("double-digit month resets unpadded (2026.9.5 → 2026.10.0)", function () {
+      // Month is emitted UNPADDED by design (valid SemVer — no leading zero).
+      // Pins the October output as "2026.10.0", not "2026.010.0"/"2026.10.0"
+      // padded. Lexical sort would mis-order this vs 2026.9.x; numeric compare
+      // (the only kind anything uses) is correct. See calendarBump comment.
+      assert.strictEqual(
+        calendarBump("2026.9.5", new Date(Date.UTC(2026, 9, 1))),
+        "2026.10.0",
+      );
+    });
+
+    it("migrates from legacy semver (1.108.0 → 2026.6.0)", function () {
+      assert.strictEqual(
+        calendarBump("1.108.0", new Date(Date.UTC(2026, 5, 13))),
+        "2026.6.0",
+      );
+    });
+
+    it("uses UTC, not local time", function () {
+      // 2026-07-01T00:30:00Z is still June 30 in US timezones; the bump must
+      // key off the UTC month (July → reset), matching the CI runner clock.
+      assert.strictEqual(
+        calendarBump("2026.6.9", new Date(Date.UTC(2026, 6, 1, 0, 30))),
+        "2026.7.0",
+      );
+    });
+
+    it("throws on a malformed version string", function () {
+      assert.throws(function () {
+        calendarBump("not-a-version", new Date(Date.UTC(2026, 5, 13)));
+      }, /Invalid version/);
     });
   });
 });


### PR DESCRIPTION
## Summary

Switches the plugin from SemVer to **calendar versioning** (`YYYY.MM.PATCH`), starting `2026.6.0`. The plugin version is a release counter, not an API contract — nothing pins this end-user plugin by a semver range, and ~313 commits reached `1.108.0` in ~80 days. Month-granularity recency is the meaningful signal.

- **Same month** → bump PATCH (`2026.6.3` → `2026.6.4`); **new month** → reset to `YYYY.MM.0`.
- `2026.6.0 > 1.108.0` numerically, so release ordering is preserved.

### Changes
- **`scripts/lib/bump-version.js`** — new pure `calendarBump(version, date)` + CLI `calendar` mode (legacy `patch`/`minor`/`major` kept for explicit manual bumps). Months emitted **unpadded** on purpose: leading zeros are illegal in SemVer, so padding would risk `claude plugin validate`/parser rejection — versions compare numerically, not lexically.
- **`vendor-snapshot.yml`** — CI auto-bump now delegates to the shared, unit-tested bumper instead of inline `jq` (one implementation, no drift).
- **`check-version-bump.js`** — gate is scheme-agnostic (string-equality); guidance message reworded.
- **Docs** — CLAUDE.md, ARCHITECTURE.md, CHANGELOG.md (+ `[2026.6.0]` entry), PR template, and vendor prose updated; residual "patch bump" language cleaned repo-wide.

### Scope
Plugin only. **Knowledge repo stays SemVer** (resolved by plugin + docs through a `<1.0.0` range — CalVer would break both resolvers). Docs repo untouched.

## Test Plan
- [x] `tests/lib/bump-version.test.js` — +8 calendar cases (same-month, new-month, new-year, **double-digit-month unpadded reset**, legacy-semver migration, multi-digit patch, UTC boundary, throws). 19/19 pass.
- [x] Full plugin suite: 1509/1509 relevant pass (the lone failure is the pre-existing local-only `vendor-paths-resolve` from gitignored `docs/superpowers/**`, which CI never checks out).
- [x] CLI dry-run: `1.108.0 → 2026.6.0` (migration) and `2026.6.0 → 2026.6.1` (same train).
- [x] `claude plugin validate` (plugin + `--strict` marketplace) — both pass; `2026.6.0` accepted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)