### PR TITLE
feat(fidelity): Finish Gate-1 — consume single-component default.webp oracles (SP1 PR-P)

### DIFF
--- a/plugins/actian-design-system/.claude-plugin/plugin.json
+++ b/plugins/actian-design-system/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "actian-design-system",
   "description": "Actian Design System toolkit — generate wireframe flows with prototype wiring, create component briefs, audit designs, compare flows, and build presentations. 8 skills (with tiered generation: recognized / adapted / improvised), 9 agents, 155 tokens (3 themes, 8 collections), WCAG 2.2 AA. DS knowledge vendored from volivarii/actian-ds-knowledge.",
-  "version": "2026.6.1",
+  "version": "2026.6.2",
   "author": {
     "name": "Actian UX Team"
   },

--- a/plugins/actian-design-system/scripts/fidelity/default-props.json
+++ b/plugins/actian-design-system/scripts/fidelity/default-props.json
@@ -1,5 +1,9 @@
 {
-  "button": { "Label": "Button", "Leading icon show": true },
+  "button": {
+    "Label": "Button",
+    "Leading icon show": true,
+    "Trailing icon show": true
+  },
   "checkbox-with-label": { "Label": "Inline label for checkbox" },
   "alert-banner": { "Message": "Primary" }
 }

--- a/plugins/actian-design-system/scripts/fidelity/default-props.json
+++ b/plugins/actian-design-system/scripts/fidelity/default-props.json
@@ -1,0 +1,5 @@
+{
+  "button": { "Label": "Button", "Leading icon show": true },
+  "checkbox-with-label": { "Label": "Inline label for checkbox" },
+  "alert-banner": { "Message": "Primary" }
+}

--- a/plugins/actian-design-system/scripts/fidelity/render-leaf.js
+++ b/plugins/actian-design-system/scripts/fidelity/render-leaf.js
@@ -22,10 +22,35 @@ function readCss() {
   return _cssCache;
 }
 
+var _defaultProps = null;
+function defaultProps() {
+  if (_defaultProps === null) {
+    _defaultProps = JSON.parse(
+      fs.readFileSync(path.join(__dirname, "default-props.json"), "utf8"),
+    );
+  }
+  return _defaultProps;
+}
+
+// Read the captured variant from the anatomy substrate so the rendered leaf
+// matches the oracle's state; merge per-slug content from default-props.json
+// (the variant string can't carry Label/Message text). Missing anatomy →
+// empty variant; missing map entry → empty props (the leaf renders its own
+// defaults and simply won't pixel-match, which is visible, not a crash).
 function defaultNodeForSlug(slug) {
-  // v1: render the default variant. Per-slug variant strings may need tuning to
-  // match the oracle's captured state (Spec §7 variant-mismatch risk).
-  return { dsSlug: slug, variant: "", props: {} };
+  var variant = "";
+  try {
+    var anatomy = JSON.parse(
+      fs.readFileSync(PATHS.components.anatomy.byKey(slug), "utf8"),
+    );
+    if (anatomy && anatomy.source && anatomy.source.variant) {
+      variant = anatomy.source.variant;
+    }
+  } catch (_) {
+    // no anatomy file → render the empty variant (component defaults)
+  }
+  var props = defaultProps()[slug] || {};
+  return { dsSlug: slug, variant: variant, props: props };
 }
 
 function renderLeafFragment(slug) {

--- a/plugins/actian-design-system/scripts/fidelity/run-fidelity.js
+++ b/plugins/actian-design-system/scripts/fidelity/run-fidelity.js
@@ -21,6 +21,20 @@ function oracleFor(slug, exists) {
   if (exists(prev)) return prev;
   return null;
 }
+
+// Per-slug Gate-1 threshold overrides (max diff ratio that still passes).
+// Empty by default; populated during calibration only for components whose text
+// anti-aliasing pushes them above the global default with no real regression.
+// Keep this list short and justified.
+var THRESHOLD_OVERRIDES = {};
+var DEFAULT_THRESHOLD = 0.06;
+
+function thresholdFor(slug, def, overrides) {
+  overrides = overrides || THRESHOLD_OVERRIDES;
+  return Object.prototype.hasOwnProperty.call(overrides, slug)
+    ? overrides[slug]
+    : def;
+}
 var LEDGER = path.join(
   PLUGIN_DIR,
   "tests",
@@ -107,9 +121,13 @@ function runPixel(slug, chrome, tmp, opts) {
     pmThreshold: opts.pmThreshold,
   });
   // threshold default 0.06 (≤6% of pixels may differ) is provisional — calibrate in Task 7.
+  // Per-slug overrides go through thresholdFor (DEFAULT_THRESHOLD / THRESHOLD_OVERRIDES);
+  // an explicit opts.threshold still wins for callers that pass one.
   var v = P.gridVerdict(
     [d.ratio],
-    opts.threshold == null ? 0.06 : opts.threshold,
+    opts.threshold == null
+      ? thresholdFor(slug, DEFAULT_THRESHOLD)
+      : opts.threshold,
   );
   v.ratio = d.ratio;
   v.dims = { w: norm.w, h: norm.h };
@@ -195,4 +213,11 @@ if (require.main === module) {
   });
 }
 
-module.exports = { run, runStructural, runPixel, ledgerRow, oracleFor };
+module.exports = {
+  run,
+  runStructural,
+  runPixel,
+  ledgerRow,
+  oracleFor,
+  thresholdFor,
+};

--- a/plugins/actian-design-system/scripts/fidelity/run-fidelity.js
+++ b/plugins/actian-design-system/scripts/fidelity/run-fidelity.js
@@ -72,9 +72,12 @@ function shoot(chrome, htmlPath, outPng, w, h) {
   return P.decodePng(fs.readFileSync(outPng));
 }
 
-function runPixel(slug, chrome, tmp, opts) {
+function runPixel(slug, chrome, tmp, opts, oracle) {
   opts = opts || {};
-  var oracle = oracleFor(slug);
+  // The oracle is resolved once per slug in run() and threaded in so runPixel
+  // and ledgerRow agree on exactly which file was diffed. Direct callers
+  // (tests) may omit it; resolve on demand for backward compatibility.
+  if (oracle === undefined) oracle = oracleFor(slug);
   if (!oracle) return { pass: null, skipped: "no-oracle" };
 
   // 1. render the leaf → PNG → decode
@@ -134,8 +137,11 @@ function runPixel(slug, chrome, tmp, opts) {
   return v;
 }
 
-function ledgerRow(slug, gate1, gate2) {
-  var chosenOracle = oracleFor(slug);
+function ledgerRow(slug, gate1, gate2, oracle) {
+  // Same oracle instance runPixel diffed against (threaded from run()); falls
+  // back to a fresh resolve only for direct callers that omit it — so the
+  // recorded reference can never disagree with what was actually compared.
+  var chosenOracle = oracle === undefined ? oracleFor(slug) : oracle;
   var g1 =
     gate1.pass === null
       ? "skip(" + (gate1.skipped || "") + ")"
@@ -177,11 +183,15 @@ function run(slugs, opts) {
   var tmp = fs.mkdtempSync(path.join(os.tmpdir(), "fid-"));
   try {
     var rows = slugs.map(function (slug) {
+      // Resolve the Gate-1 oracle ONCE per slug and thread it to both runPixel
+      // (diff) and ledgerRow (provenance) so they can never disagree, and so
+      // the filesystem is probed once instead of three times.
+      var oracle = oracleFor(slug);
       var gate2 = runStructural(slug, resolved.chrome, tmp);
       // Gate 1 always runs (pure-JS diff, Chrome present); pass:null only when the
-      // component has no preview.webp oracle to compare against.
-      var gate1 = runPixel(slug, resolved.chrome, tmp, opts);
-      var row = ledgerRow(slug, gate1, gate2);
+      // component has no single-component oracle to compare against.
+      var gate1 = runPixel(slug, resolved.chrome, tmp, opts, oracle);
+      var row = ledgerRow(slug, gate1, gate2, oracle);
       if (opts.write !== false)
         fs.appendFileSync(LEDGER, JSON.stringify(row) + "\n");
       return row;

--- a/plugins/actian-design-system/scripts/fidelity/run-fidelity.js
+++ b/plugins/actian-design-system/scripts/fidelity/run-fidelity.js
@@ -10,10 +10,17 @@ var S = require("./structural-check");
 var PATHS = require("../lib/paths");
 
 var PLUGIN_DIR = path.resolve(__dirname, "..", "..");
-// Resolve the Gate-1 oracle via PATHS (guarded by no-bare-vendor-paths.test.js).
-var ORACLE = function (slug) {
-  return PATHS.components.media(slug);
-};
+// Resolve the Gate-1 oracle: prefer the single-component default.webp; fall
+// back to the legacy preview.webp board (which runPixel still skips on aspect
+// mismatch). Returns null when neither exists. `exists` is injectable for tests.
+function oracleFor(slug, exists) {
+  exists = exists || fs.existsSync;
+  var def = PATHS.components.mediaDefault(slug);
+  if (exists(def)) return def;
+  var prev = PATHS.components.media(slug);
+  if (exists(prev)) return prev;
+  return null;
+}
 var LEDGER = path.join(
   PLUGIN_DIR,
   "tests",
@@ -53,8 +60,8 @@ function shoot(chrome, htmlPath, outPng, w, h) {
 
 function runPixel(slug, chrome, tmp, opts) {
   opts = opts || {};
-  var oracle = ORACLE(slug);
-  if (!fs.existsSync(oracle)) return { pass: null, skipped: "no preview.webp" };
+  var oracle = oracleFor(slug);
+  if (!oracle) return { pass: null, skipped: "no-oracle" };
 
   // 1. render the leaf → PNG → decode
   var lhp = path.join(tmp, slug + "-leaf.html");
@@ -110,6 +117,7 @@ function runPixel(slug, chrome, tmp, opts) {
 }
 
 function ledgerRow(slug, gate1, gate2) {
+  var chosenOracle = oracleFor(slug);
   var g1 =
     gate1.pass === null
       ? "skip(" + (gate1.skipped || "") + ")"
@@ -130,7 +138,12 @@ function ledgerRow(slug, gate1, gate2) {
       method: "Program C two-gate (pixel + structural)",
     },
     reference: {
-      media: ["components/dist/media/" + slug + "/preview.webp"],
+      media: [
+        "components/dist/media/" +
+          slug +
+          "/" +
+          (chosenOracle ? path.basename(chosenOracle) : "default.webp"),
+      ],
     },
     pixel: gate1,
     structural: gate2,
@@ -182,4 +195,4 @@ if (require.main === module) {
   });
 }
 
-module.exports = { run, runStructural, runPixel, ledgerRow };
+module.exports = { run, runStructural, runPixel, ledgerRow, oracleFor };

--- a/plugins/actian-design-system/scripts/lib/paths.js
+++ b/plugins/actian-design-system/scripts/lib/paths.js
@@ -120,6 +120,12 @@ PATHS.components.media = function (slug) {
   return path.join(VENDOR, "components", "dist", "media", slug, "preview.webp");
 };
 
+// Single-component oracle for the fidelity gate (Gate-1). Additive overlay,
+// mirroring PATHS.components.media — NOT manifest-driven (media is plugin-only).
+PATHS.components.mediaDefault = function (slug) {
+  return path.join(VENDOR, "components", "dist", "media", slug, "default.webp");
+};
+
 // NOTE: anatomy resolution is NOT overlaid here. The knowledge `anatomy` domain
 // is declared in paths-manifest.json (components.anatomy.byKey collection +
 // components.anatomy.bundle path), so buildPathsFromManifest already produces

--- a/plugins/actian-design-system/tests/fidelity/default-props.test.js
+++ b/plugins/actian-design-system/tests/fidelity/default-props.test.js
@@ -1,0 +1,13 @@
+"use strict";
+var test = require("node:test");
+var assert = require("node:assert/strict");
+var props = require("../../scripts/fidelity/default-props.json");
+var BUILT = require("../../scripts/renderers/html-renderers/ds-html-map.js").BUILT_SLUGS;
+
+test("every default-props key is a built slug with a plain-object value", function () {
+  Object.keys(props).forEach(function (slug) {
+    assert.ok(BUILT.indexOf(slug) !== -1, slug + " is not in BUILT_SLUGS");
+    var v = props[slug];
+    assert.ok(v && typeof v === "object" && !Array.isArray(v), slug + " props must be an object");
+  });
+});

--- a/plugins/actian-design-system/tests/fidelity/fidelity-report.test.js
+++ b/plugins/actian-design-system/tests/fidelity/fidelity-report.test.js
@@ -19,7 +19,7 @@ test("aggregate computes mean over SCORED rows + counts skipped", function () {
       slug: "checkbox-with-label",
       fidelity: { score: null },
       gates: {
-        pixel_diff: "skip(no preview.webp)",
+        pixel_diff: "skip(no-oracle)",
         responsive_structural: "pass",
       },
     },

--- a/plugins/actian-design-system/tests/fidelity/oracle-select.test.js
+++ b/plugins/actian-design-system/tests/fidelity/oracle-select.test.js
@@ -1,0 +1,22 @@
+"use strict";
+var test = require("node:test");
+var assert = require("node:assert/strict");
+var path = require("node:path");
+var RF = require("../../scripts/fidelity/run-fidelity");
+
+test("oracleFor prefers default.webp, falls back to preview.webp", function () {
+  var fakeExists = function (p) { return p.endsWith("default.webp"); };
+  var chosen = RF.oracleFor("button", fakeExists);
+  assert.ok(chosen.endsWith(path.join("button", "default.webp")), "chose default: " + chosen);
+});
+
+test("oracleFor falls back to preview.webp when default is absent", function () {
+  var fakeExists = function (p) { return p.endsWith("preview.webp"); };
+  var chosen = RF.oracleFor("button", fakeExists);
+  assert.ok(chosen.endsWith(path.join("button", "preview.webp")), "chose preview: " + chosen);
+});
+
+test("oracleFor returns null when neither exists", function () {
+  var chosen = RF.oracleFor("button", function () { return false; });
+  assert.equal(chosen, null);
+});

--- a/plugins/actian-design-system/tests/fidelity/oracle-select.test.js
+++ b/plugins/actian-design-system/tests/fidelity/oracle-select.test.js
@@ -5,18 +5,56 @@ var path = require("node:path");
 var RF = require("../../scripts/fidelity/run-fidelity");
 
 test("oracleFor prefers default.webp, falls back to preview.webp", function () {
-  var fakeExists = function (p) { return p.endsWith("default.webp"); };
+  var fakeExists = function (p) {
+    return p.endsWith("default.webp");
+  };
   var chosen = RF.oracleFor("button", fakeExists);
-  assert.ok(chosen.endsWith(path.join("button", "default.webp")), "chose default: " + chosen);
+  assert.ok(
+    chosen.endsWith(path.join("button", "default.webp")),
+    "chose default: " + chosen,
+  );
 });
 
 test("oracleFor falls back to preview.webp when default is absent", function () {
-  var fakeExists = function (p) { return p.endsWith("preview.webp"); };
+  var fakeExists = function (p) {
+    return p.endsWith("preview.webp");
+  };
   var chosen = RF.oracleFor("button", fakeExists);
-  assert.ok(chosen.endsWith(path.join("button", "preview.webp")), "chose preview: " + chosen);
+  assert.ok(
+    chosen.endsWith(path.join("button", "preview.webp")),
+    "chose preview: " + chosen,
+  );
 });
 
 test("oracleFor returns null when neither exists", function () {
-  var chosen = RF.oracleFor("button", function () { return false; });
+  var chosen = RF.oracleFor("button", function () {
+    return false;
+  });
   assert.equal(chosen, null);
+});
+
+test("oracleFor prefers default.webp when BOTH default and preview exist", function () {
+  // Pins the precedence: with both files present, the single-component oracle
+  // must win over the legacy preview.webp board. Guards against a regression
+  // that silently reverts Gate-1 to the board oracle (which skips on aspect).
+  var probed = [];
+  var fakeExists = function (p) {
+    probed.push(p);
+    return true; // both default.webp AND preview.webp exist
+  };
+  var chosen = RF.oracleFor("button", fakeExists);
+  assert.ok(
+    chosen.endsWith(path.join("button", "default.webp")),
+    "default must win when both exist: " + chosen,
+  );
+  // and it short-circuits — preview.webp is never probed once default exists
+  assert.ok(
+    probed[0].endsWith("default.webp"),
+    "default.webp must be probed first",
+  );
+  assert.equal(
+    probed.length,
+    1,
+    "preview.webp must not be probed when default exists",
+  );
 });

--- a/plugins/actian-design-system/tests/fidelity/pilot-fidelity.integration.test.js
+++ b/plugins/actian-design-system/tests/fidelity/pilot-fidelity.integration.test.js
@@ -1,0 +1,68 @@
+"use strict";
+var test = require("node:test");
+var assert = require("node:assert/strict");
+var fs = require("node:fs");
+var path = require("node:path");
+var R = require("../../scripts/fidelity/resolve-binaries");
+var RF = require("../../scripts/fidelity/run-fidelity");
+var PATHS = require("../../scripts/lib/paths");
+
+var chrome = R.resolveChrome();
+var PILOT = ["button", "checkbox-with-label", "alert-banner"];
+var haveOracles = PILOT.every(function (s) {
+  return fs.existsSync(PATHS.components.mediaDefault(s));
+});
+
+// Honest Gate-1 lock (SP1, calibrated 2026-06-14). The gate now CONSUMES the
+// single-component default.webp oracles and produces real comparisons. We do
+// NOT assert the trio passes pixel-diff: calibration showed the hand-authored
+// ds-html-map leaves diverge from the Figma defaults (button brand-blue is
+// darker than Figma; checkbox square is proportionally taller; alert-banner is
+// a hug-width card vs Figma's full-width banner with action + close). Those are
+// real fidelity gaps the gate is correctly surfacing — tracked as the
+// leaf-regeneration follow-on, NOT papered over with threshold/aspect hacks.
+//
+// What this locks is the substrate win this slice delivered:
+//   (1) every pilot row references the single-component default.webp oracle
+//       (not the legacy multi-variant preview.webp board), and
+//   (2) at least one structurally-matching component (button) yields a NON-NULL
+//       Gate-1 verdict — proving the render -> rasterize -> diff pipeline runs
+//       end-to-end against a real single-component oracle instead of skipping.
+test(
+  "pilot trio consumes the default.webp oracles and Gate-1 produces a real comparison",
+  {
+    skip: !chrome
+      ? "Chrome not resolvable"
+      : !haveOracles
+        ? "default.webp oracles not vendored"
+        : false,
+  },
+  function () {
+    var rows = RF.run(PILOT, { write: false });
+    var bySlug = {};
+    rows.forEach(function (r) {
+      bySlug[r.slug] = r;
+    });
+
+    PILOT.forEach(function (slug) {
+      var r = bySlug[slug];
+      assert.ok(r, slug + " produced a ledger row");
+      assert.equal(
+        path.basename(r.reference.media[0]),
+        "default.webp",
+        slug + " must reference the default.webp oracle",
+      );
+    });
+
+    // button structurally matches its oracle (leading + trailing icon, label),
+    // so the pipeline produces a real (non-null) Gate-1 verdict rather than an
+    // aspect-mismatch skip. This proves the oracle is consumed end-to-end.
+    assert.notEqual(
+      bySlug.button.pixel.pass,
+      null,
+      "button Gate-1 should be a real comparison, not a skip (ratio " +
+        (bySlug.button.pixel && bySlug.button.pixel.ratio) +
+        ")",
+    );
+  },
+);

--- a/plugins/actian-design-system/tests/fidelity/render-leaf.test.js
+++ b/plugins/actian-design-system/tests/fidelity/render-leaf.test.js
@@ -3,12 +3,19 @@ var test = require("node:test");
 var assert = require("node:assert/strict");
 var H = require("../../scripts/fidelity/render-leaf");
 
-test("defaultNodeForSlug uses dsSlug shape", function () {
-  assert.deepEqual(H.defaultNodeForSlug("button"), {
-    dsSlug: "button",
-    variant: "",
-    props: {},
-  });
+test("defaultNodeForSlug reads anatomy variant + merges default-props", function () {
+  var node = H.defaultNodeForSlug("button");
+  assert.equal(node.dsSlug, "button");
+  // variant comes from vendored anatomy source.variant
+  assert.match(node.variant, /Type=Primary/);
+  // props come from default-props.json
+  assert.equal(node.props.Label, "Button");
+});
+
+test("defaultNodeForSlug falls back to empty props for an unmapped slug", function () {
+  var node = H.defaultNodeForSlug("radio-button");
+  assert.equal(node.dsSlug, "radio-button");
+  assert.deepEqual(node.props, {});
 });
 
 test("buildLeafHtml embeds the rendered leaf + a fonts.ready measure hook", function () {

--- a/plugins/actian-design-system/tests/fidelity/render-leaf.test.js
+++ b/plugins/actian-design-system/tests/fidelity/render-leaf.test.js
@@ -18,6 +18,16 @@ test("defaultNodeForSlug falls back to empty props for an unmapped slug", functi
   assert.deepEqual(node.props, {});
 });
 
+test("defaultNodeForSlug yields an empty variant when the slug has no anatomy", function () {
+  // A slug with no vendored anatomy file: the anatomy read throws (ENOENT, or
+  // byKey rejects the unknown slug) and the try/catch degrades to variant="".
+  // Every BUILT_SLUG has anatomy, so this fabricated slug is the only way to
+  // exercise the fail-soft branch the gate relies on.
+  var node = H.defaultNodeForSlug("definitely-not-a-real-slug-xyz");
+  assert.equal(node.variant, "");
+  assert.deepEqual(node.props, {});
+});
+
 test("buildLeafHtml embeds the rendered leaf + a fonts.ready measure hook", function () {
   var html = H.buildLeafHtml("button", "<button class='ds-button'>Go</button>");
   assert.ok(html.indexOf("ds-button") >= 0, "leaf fragment present");

--- a/plugins/actian-design-system/tests/fidelity/threshold-override.test.js
+++ b/plugins/actian-design-system/tests/fidelity/threshold-override.test.js
@@ -7,3 +7,11 @@ test("thresholdFor returns the per-slug override when present, else the default"
   assert.equal(RF.thresholdFor("button", 0.06, { button: 0.09 }), 0.09);
   assert.equal(RF.thresholdFor("badge", 0.06, { button: 0.09 }), 0.06);
 });
+
+test("thresholdFor falls back to the module THRESHOLD_OVERRIDES table when none is passed", function () {
+  // This 2-arg form is the production call site (runPixel). With the default
+  // table empty, every slug resolves to the global default — guards the
+  // `overrides || THRESHOLD_OVERRIDES` default-arg wiring against regression.
+  assert.equal(RF.thresholdFor("button", 0.06), 0.06);
+  assert.equal(RF.thresholdFor("alert-banner", 0.06), 0.06);
+});

--- a/plugins/actian-design-system/tests/fidelity/threshold-override.test.js
+++ b/plugins/actian-design-system/tests/fidelity/threshold-override.test.js
@@ -1,0 +1,9 @@
+"use strict";
+var test = require("node:test");
+var assert = require("node:assert/strict");
+var RF = require("../../scripts/fidelity/run-fidelity");
+
+test("thresholdFor returns the per-slug override when present, else the default", function () {
+  assert.equal(RF.thresholdFor("button", 0.06, { button: 0.09 }), 0.09);
+  assert.equal(RF.thresholdFor("badge", 0.06, { button: 0.09 }), 0.06);
+});

--- a/plugins/actian-design-system/tests/lib/paths-media-default.test.js
+++ b/plugins/actian-design-system/tests/lib/paths-media-default.test.js
@@ -1,0 +1,13 @@
+"use strict";
+var test = require("node:test");
+var assert = require("node:assert/strict");
+var path = require("node:path");
+var PATHS = require("../../scripts/lib/paths");
+
+test("mediaDefault resolves to the per-slug default.webp oracle", function () {
+  var p = PATHS.components.mediaDefault("button");
+  assert.ok(
+    p.endsWith(path.join("vendor", "components", "dist", "media", "button", "default.webp")),
+    "got: " + p,
+  );
+});


### PR DESCRIPTION
## Summary

Plugin half of **SP1 — "Finish Gate-1: single-component fidelity oracles."** Makes the fidelity gate's Gate-1 (pixel-diff) **consume the newly-vendored single-component `default.webp` oracles** (knowledge v0.34.2 → vendored at `2026.6.1`). Gate-1 went from *skips every component* (the board oracles had incomparable aspect ratios) → *produces real per-component comparisons*.

This is the consumer for the knowledge-side capture phase (knowledge PR #238/#239).

## What changed

- **`PATHS.components.mediaDefault(slug)`** — additive overlay resolving `vendor/components/dist/media/<slug>/default.webp`.
- **`oracleFor(slug)`** in `run-fidelity.js` — prefers `default.webp`, falls back to the legacy `preview.webp` board, returns null → graceful `skip(no-oracle)`. Resolved **once per slug** in `run()` and threaded to both `runPixel` (diff) and `ledgerRow` (provenance) so they never disagree.
- **`defaultNodeForSlug`** now renders the **captured anatomy variant** (`source.variant`) + merges curated `default-props.json` content, so the rendered leaf matches the oracle's state.
- **`thresholdFor`** — optional per-slug Gate-1 threshold override (default `0.06`, `THRESHOLD_OVERRIDES` intentionally empty).
- Plugin calendar bump `2026.6.1 → 2026.6.2`.

## Honest landing (the gate earns its keep on day one)

Calibrating the pilot trio against the real oracles surfaced genuine **leaf-vs-Figma gaps** — which is exactly Gate-1's job:
- **button** — structure matches after adding the trailing chevron; residual ~0.078 dominated by a **brand-blue delta** (leaf `#0F5FDC` vs Figma's lighter blue) — a real token question, not noise.
- **checkbox-with-label** — checkbox-square proportions differ.
- **alert-banner** — leaf is a hug-width card; Figma default is a full-width banner with action + close.

We did **not** paper these over with threshold/aspect hacks. The integration test locks the **substrate win** — every pilot row references `default.webp` (not the board), and button yields a **non-null** verdict (real render→rasterize→diff end-to-end) — **without** asserting a pass. The three gaps are the gate's first findings, tracked for the leaf-regeneration follow-on.

## Test Plan

- [x] Full plugin suite **1517/1518** (the 1 fail is the pre-existing `vendor-paths-resolve` from a gitignored local spec — unrelated to this branch).
- [x] Fidelity suite **39/39** including the Chrome-gated pilot integration test (self-skips where Chrome is absent).
- [x] Full multi-angle review before push — threading + 3 recall tests (oracleFor precedence, thresholdFor default-arg, missing-anatomy branch) added as hardening.

## Follow-on (tracked, out of scope)
Leaf-regeneration to close the 3 fidelity gaps; author `default-props.json` for the remaining 16 built slugs; promote the gate to a Chrome-having CI job.