### PR TITLE
fix(vendor): authenticate GitHub API calls in nightly snapshot sync

### DIFF
--- a/.github/workflows/vendor-snapshot.yml
+++ b/.github/workflows/vendor-snapshot.yml
@@ -64,7 +64,32 @@ jobs:
 
       - name: Pull vendor snapshot
         working-directory: plugins/actian-design-system
+        env:
+          # The vendor core (vendor-snapshot-core.js) resolves the knowledge
+          # release by calling the GitHub tags/refs API via curl. Those calls
+          # are unauthenticated — capped at 60 req/hr PER IP — and GitHub
+          # Actions runners share egress IPs across tenants, so the budget is
+          # frequently already spent by neighbors. That surfaced as an
+          # intermittent FATAL: `GitHub tags API returned non-array:
+          # {"message":"API rate limit exceeded for <ip> ..."}` and a failed
+          # nightly (run 28095989590, 2026-06-24). We seed a curl config with
+          # the minted App-installation token (15,000 req/hr) so every curl the
+          # core runs authenticates. This is done at the workflow level — NOT
+          # by editing the snapshot core, which is vendored from the knowledge
+          # repo (`clients` is in vendor-include.json) and would be reverted by
+          # the next refresh, breaking the byte-identity drift guard.
+          GH_VENDOR_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
+          # Scope the auth header to THIS step only via CURL_HOME (curl reads
+          # $CURL_HOME/.curlrc ahead of $HOME/.curlrc). Each `run` is a fresh
+          # shell, so the export does not leak to later steps. curl strips the
+          # Authorization header on cross-host redirects (github.com →
+          # codeload), so the tarball download never carries the token.
+          CURL_HOME="$(mktemp -d)"
+          export CURL_HOME
+          umask 077
+          printf 'header = "Authorization: Bearer %s"\n' "$GH_VENDOR_TOKEN" \
+            > "$CURL_HOME/.curlrc"
           INPUT_SHA="${{ github.event.inputs.sha }}"
           INPUT_RANGE="${{ github.event.inputs.range }}"
           if [ -n "$INPUT_SHA" ]; then


### PR DESCRIPTION
## Problem

The nightly **Vendor knowledge-repo snapshot** workflow failed (run [28095989590](https://github.com/volivarii/Actian-DS-Claude-plugin/actions/runs/28095989590), 2026-06-24) at the `Pull vendor snapshot` step:

```
[vendor] FATAL: GitHub tags API returned non-array:
{"message":"API rate limit exceeded for 52.225.25.54.
 (But here's the good news: Authenticated requests get a higher rate limit...)"}
```

The vendored snapshot core resolves the knowledge release by calling the GitHub **tags/refs API via `curl`** with no auth. Unauthenticated requests are capped at **60/hr per IP**, and GitHub Actions runners share egress IPs across tenants — so the budget is frequently already spent by neighbors. Hence the **intermittent** failure (only the latest run failed; the prior 8 succeeded).

## Fix

Seed a **step-scoped** `CURL_HOME/.curlrc` with an `Authorization: Bearer` header using the **already-minted App-installation token** (15,000/hr) so every `curl` the core runs authenticates.

Done at the **workflow level, not in the script**, because `vendor/clients/vendor-snapshot.js` is the canonical and is **vendored from the knowledge repo** (`clients` ∈ `vendor-include.json`) — editing it would be reverted by the next refresh and break the byte-identity drift guard.

- Scoped to the one step (fresh shell; `umask 077` → `.curlrc` is `600`).
- `curl` strips the `Authorization` header on the cross-host tarball redirect (github.com → codeload), so the token never leaks.

## Verification

- curl mechanism proven locally: header injected with `CURL_HOME`, absent without it.
- 20/20 vendor tests + drift guard pass (core untouched — YAML-only change).
- End-to-end: triggering a manual `workflow_dispatch` on this branch.

## Follow-up (separate, recommended)

The durable home for this is the **knowledge repo** canonical (`clients/vendor-snapshot.js`) — make its curl helpers read `GH_TOKEN` so the fix survives independently of the workflow shim.