### PR TITLE
docs: refresh for substrate-grounding (S1–S3c) + version 2026.6.21

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,55 @@ they are not individually listed below unless they changed user-facing behavior.
 This file was seeded at v1.97.0 from the commit history; entries before that
 are summarized at the release level.
 
+## [2026.6.21] — 2026-06-29
+
+### Added
+- **Typed rendering in generated flows (S3c).** Entity properties carry a `type`
+  through the flow glossary, and the screen-generator now renders it: `type:"enum"`
+  columns become `fmTableCell Type=Pill` status badges (HTML `.fm-table-cell__pill`,
+  token-bound, mirroring `.fm-badge`), and `type:"date"` values follow the content
+  guideline's date format. Property labels are humanized from camelCase
+  (`apiVersion` → "Api version"). New non-blocking advisory `enum-not-typed` flags an
+  enum-bearing flow that renders no pill.
+
+### Fixed
+- The `properties-ungrounded` grounding check now tokenizes the rendered property
+  **label**, not just the raw field name, so camelCase-named columns
+  (`apiVersion` → "Api version") still ground and don't trip a spurious advisory.
+
+## [2026.6.20] — 2026-06-28
+
+### Added
+- **Entity-property-grounded tables & forms (S3b).** Table column headers and form
+  field labels are resolved from the entity's `properties` in `app-context.json`
+  (`resolve-properties.js` → `meta._glossary`) instead of invented per screen. New
+  non-blocking advisory `properties-ungrounded` flags a flow whose tables/forms reflect
+  none of the entity's standard fields.
+
+## [2026.6.19] — 2026-06-28
+
+### Added
+- **Relationship-grounded detail content (S3).** Detail-view screens draw their tab bar
+  and related sub-lists from the entity's relationship graph (`resolve-relationships.js`),
+  so a detail page reflects the entity's real connections. New non-blocking advisory
+  `relationships-ungrounded`.
+
+## [2026.6.17] — 2026-06-28
+
+### Added
+- **App-grounded authoring + pattern resolution (S2).** The target app is an explicit
+  choice; flows resolve one of the app-scoped named UX patterns (`resolve-patterns.js`)
+  into an idiomatic scaffold, with app-scope enforced (an app can't borrow another app's
+  pattern). New non-blocking advisory `pattern-ungrounded`.
+
+## [2026.6.14] — 2026-06-26
+
+### Added
+- **App-chrome grounding (S1).** Generated screens take their sidebar / header / nav from
+  the structured `app-context.json` for the target app (`resolve-chrome.js`), eliminating
+  generic or hallucinated navigation. New non-blocking advisories `chrome-divergence` /
+  `chrome-drift` / `chrome-ungrounded` / `chrome-incoherent`.
+
 ## [2026.6.0] — 2026-06-13
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -227,7 +227,7 @@ The companion has always-loaded knowledge of:
 - **Content rules** — sentence case, action verbs, error message patterns, empty state CTAs
 - **App context** — Studio (integration/catalog), Explorer (discovery), Administration (settings/users) — a structured, queryable domain (3 apps, 30 entities with typed properties + a relationship graph, 30 named UX patterns, terminology rules) that now **grounds flow authoring** directly: chrome, patterns, entities, and properties are resolved into the flow before screens are generated
 - **Component inventory** — 318 DS Kit + 287 FM Kit + 28 Meta Kit components (80 / 33 / 11 sets) — dynamically derived from synced registries
-- **Component guidelines** — 58 per-component guideline docs (50 components + 8 registry-key aliases), all curated in the current snapshot; components without a doc fall back to per-category structural defaults
+- **Component guidelines** — 58 per-component guideline docs (51 components + 7 registry-key aliases), all curated in the current snapshot; components without a doc fall back to per-category structural defaults
 
 It loads detailed references on demand: per-component guidelines, accessibility standards, UX patterns, foundation docs.
 
@@ -262,7 +262,7 @@ volivarii/actian-ds-knowledge CI (sync-from-figma + foundations-derive)
     |
 plugin's vendor/ snapshot (refreshed nightly via vendor-snapshot.yml)
     ├─ vendor/components/dist/registries/  -- DS Kit + FM Kit + Meta Kit registries
-    ├─ vendor/components/dist/guidelines/  -- 58 per-component guideline docs (50 components + 8 aliases)
+    ├─ vendor/components/dist/guidelines/  -- 58 per-component guideline docs (51 components + 7 aliases)
     ├─ vendor/foundations/            -- foundations.md + 8 derived JSONs
     ├─ vendor/tokens/                 -- DTCG + CSS custom properties
     ├─ vendor/{content,accessibility,presentation,app-context,fm-to-ds-map}/

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ The guidelines hold throughout — tokens, spacing, content rules, accessibility
 
 DS knowledge (tokens, components, foundations, content + accessibility guidelines) is vendored from [`volivarii/actian-ds-knowledge`](https://github.com/volivarii/actian-ds-knowledge) — the canonical source-of-truth repo synced directly from Figma. The plugin pulls a pinned snapshot nightly via `vendor-snapshot.yml`.
 
-**v1.97.0** · 8 skills (tiered generation: recognized / adapted / improvised) · 9 agents · 25 recipes · 155 design tokens across 8 collections · 3 themes · WCAG 2.2 AA · surgical refine engine · vision-grounded references · interactive gates · federated knowledge substrate · component briefs with Section 1 supercard (anatomy + variation + tokens + specs / usages / content / motion / accessibility) — Section 6 (real platform examples) deferred
+**2026.6.21** · 8 skills (tiered generation: recognized / adapted / improvised) · 9 agents · 25 recipes · 155 design tokens across 8 collections · 3 themes · WCAG 2.2 AA · **substrate-grounded flow authoring** (app chrome, UX patterns, and entity relationships + typed properties → idiomatic lo-fi screens, with enum columns rendered as status pills) · surgical refine engine · vision-grounded references · interactive gates · federated knowledge substrate · component briefs with Section 1 supercard (anatomy + variation + tokens + specs / usages / content / motion / accessibility) — Section 6 (real platform examples) deferred
 
 ---
 
@@ -225,9 +225,9 @@ The companion has always-loaded knowledge of:
 - **Tokens** — 155 design tokens in W3C DTCG format across 8 collections (color, spacing, border, size, breakpoint, focus-ring, font, icon), 3 theme modes, CSS custom properties (`--zen-*`)
 - **Foundations** — `foundations.md` is the source of truth (v1.60.0+): a CI workflow regenerates 8 derived JSONs (color roles, spacing scale, type ramp, etc.) on every change, with PR comments confirming the regen
 - **Content rules** — sentence case, action verbs, error message patterns, empty state CTAs
-- **App context** — Studio (integration/catalog), Explorer (discovery), Administration (settings/users) — structured as queryable JSON with entities, terminology rules, and UI patterns
+- **App context** — Studio (integration/catalog), Explorer (discovery), Administration (settings/users) — a structured, queryable domain (3 apps, 30 entities with typed properties + a relationship graph, 30 named UX patterns, terminology rules) that now **grounds flow authoring** directly: chrome, patterns, entities, and properties are resolved into the flow before screens are generated
 - **Component inventory** — 318 DS Kit + 287 FM Kit + 28 Meta Kit components (80 / 33 / 11 sets) — dynamically derived from synced registries
-- **Component guidelines** — 58 per-component guideline docs (51 components + 7 registry-key aliases), all curated in the current snapshot; components without a doc fall back to per-category structural defaults
+- **Component guidelines** — 58 per-component guideline docs (50 components + 8 registry-key aliases), all curated in the current snapshot; components without a doc fall back to per-category structural defaults
 
 It loads detailed references on demand: per-component guidelines, accessibility standards, UX patterns, foundation docs.
 
@@ -262,7 +262,7 @@ volivarii/actian-ds-knowledge CI (sync-from-figma + foundations-derive)
     |
 plugin's vendor/ snapshot (refreshed nightly via vendor-snapshot.yml)
     ├─ vendor/components/dist/registries/  -- DS Kit + FM Kit + Meta Kit registries
-    ├─ vendor/components/dist/guidelines/  -- 58 per-component guideline docs (51 components + 7 aliases)
+    ├─ vendor/components/dist/guidelines/  -- 58 per-component guideline docs (50 components + 8 aliases)
     ├─ vendor/foundations/            -- foundations.md + 8 derived JSONs
     ├─ vendor/tokens/                 -- DTCG + CSS custom properties
     ├─ vendor/{content,accessibility,presentation,app-context,fm-to-ds-map}/
@@ -282,8 +282,8 @@ Companion + skills read at runtime
 
 **Pipeline quality gates:**
 - **Foundations MD-as-SoT** (v1.60.0+) — `foundations.md` is the editable source; CI regenerates 8 derived JSONs and posts a PR comment confirming the regen.
-- **Flow glossary** — before generating screens, the skill builds a shared vocabulary (`_glossary`) with entity names, action verbs, and CTA labels. All parallel screen-generators use it, ensuring consistent terminology across screens.
-- **Validation** — `validate-flow-data.js` runs before every push: banned placeholder text (P0, blocks push), unresolved token references (P1), terminology violations checked against `app-context.json` (P1), and avoid-word warnings from `vendor/content/dist/words-to-avoid.json` (non-blocking; `--skip-avoid-words` to suppress).
+- **Substrate-grounded glossary** — before generating screens, the skill resolves a shared `_glossary` directly from the structured `app-context.json` (deterministic resolvers under `scripts/lib/app-context/`): the app **chrome** (sidebar/header), the matched **UX pattern**, entity **relationships** (→ detail tabs + related sub-lists), and typed entity **properties** (→ table columns / form field labels, with `type:"enum"` columns rendered as status pills and dates formatted per the content guideline) — alongside entity names, action verbs, and CTA labels. All parallel screen-generators read it, so screens are idiomatic to the app rather than generic SaaS, with consistent terminology.
+- **Validation** — `validate-flow-data.js` runs before every push: banned placeholder text (P0, blocks push), unresolved token references (P1), terminology violations checked against `app-context.json` (P1), avoid-word warnings from `vendor/content/dist/words-to-avoid.json` (non-blocking; `--skip-avoid-words` to suppress), plus non-blocking **grounding advisories** that flag when a flow drifts from the substrate — ungrounded chrome/patterns, or tables/forms that don't reflect the entity's relationships, properties, or typed (enum→pill) rendering.
 - **Stub-aware brief validation** (v1.64.0+) — when a brief is generated against an auto-stub guideline, the validator downgrades severity for missing-content findings and adds a `stub-guideline-used` finding so the designer sees "this came from a stub" rather than "this is broken."
 - **Scope-aware filtering** (v1.55.0+) — refines pass `--scope single-unit:<id>` so findings on untouched screens don't drown out findings on the screen the designer actually edited.
 - **Refine engine** (v1.56.0+) — `resolve-unit.js` maps a Figma URL to a `pushedNodes` entry, `snapshot-store.js` reads/writes a `flow-data.snapshot.json` sidecar, `derive-scope.js` diffs before/after by `screens[].id` to produce the canonical scope tag. Surgical push deletes and recreates only the changed screen frames.
@@ -329,7 +329,7 @@ actian-design-system-plugin/
 │   ├── schemas/                           # JSON schemas (brief-data, flow-data, slide-data)
 │   ├── templates/                         # HTML wrappers (flow, fm, component-playground, annotation-layer)
 │   ├── vendor/                            # pinned knowledge-repo snapshot — the DS substrate
-│   │   ├── components/                    # registries (dskit/fmkit/metakit) + 44 guideline docs + bundles
+│   │   ├── components/                    # registries (dskit/fmkit/metakit) + 58 guideline docs + bundles
 │   │   ├── foundations/                   # foundations.md (source of truth) + 8 derived JSONs
 │   │   ├── tokens/                        # W3C DTCG JSON + CSS custom properties
 │   │   ├── accessibility/                 # per-section WCAG 2.2 AA docs

--- a/plugins/actian-design-system/ARCHITECTURE.md
+++ b/plugins/actian-design-system/ARCHITECTURE.md
@@ -80,6 +80,7 @@ Each row is a user-facing skill (slash command). Use this table to find every fi
 
 > **Removed in Federation Phase 1.5 (v1.79.0):** `sync/`, `foundations/`, `changelog/` — moved to `volivarii/actian-ds-knowledge` CI.
 - `lib/` — Shared utilities used by 2+ scripts (constants, ID stamping, scope derivation, snapshot store, intent resolver, unit resolver, Node binary resolver). New shared utilities go here.
+  - `lib/app-context/` — substrate-grounding resolvers (`resolve-chrome.js`, `resolve-patterns.js`, `resolve-relationships.js`, `resolve-properties.js`) that read the structured `vendor/app-context/dist/app-context.json` and populate the flow's `meta._glossary` (chrome, UX pattern, entity relationships, typed entity properties) before screen generation. Each exposes a `--entity`/`--app` CLI and a `loadAppContext(ctx)` injection seam. Consumed by `generate-flow` Step 3.5 + the `screen-generator` agent; grounding is checked (advisory, non-blocking) by `scripts/validation/validate-flow-data.js`.
 - `office/` — Python Office-document renderer (engine + mappers + dispatcher). Consumes the medium-agnostic data models (`slide-data.json` now; `brief-data`/`audit-data` later) and emits branded `.pptx`/`.docx`. Brand assets in `assets/office/`; reference docs in `references/office/`. Invoked opt-in from skills via `scripts/lib/resolve-python.sh` + `render-office.py`.
 
 ### `tests/` subdirs

--- a/plugins/actian-design-system/CLAUDE.md
+++ b/plugins/actian-design-system/CLAUDE.md
@@ -69,7 +69,8 @@ Data flows: `Figma -> volivarii/actian-ds-knowledge CI -> vendor/ (snapshot pull
 - `scripts/renderers/assemble-preview.js` — generates HTML previews from data models
 - `scripts/renderers/render-component-reference.js` — generates `*-components.md` mirrors from vendored registries (called by vendor-snapshot.yml post-pull)
 - `scripts/lib/shared-constants.js` — dynamic registry loaders, key maps, palette
-- `scripts/validation/validate-flow-data.js` — pipeline validation (banned text, tokens, terminology) + `avoid-word` soft-check (warnings, non-blocking; `--skip-avoid-words`) against `vendor/content/dist/words-to-avoid.json`
+- `scripts/lib/app-context/resolve-{chrome,patterns,relationships,properties}.js` — deterministic resolvers that read `vendor/app-context/dist/app-context.json` and populate the flow's `meta._glossary` (app chrome, matched UX pattern, entity relationships, typed entity properties) so screen authoring is substrate-grounded. Each has a `--entity`/`--app` CLI and a `loadAppContext(ctx)` injection seam for tests.
+- `scripts/validation/validate-flow-data.js` — pipeline validation (banned text, tokens, terminology) + `avoid-word` soft-check (warnings, non-blocking; `--skip-avoid-words`) against `vendor/content/dist/words-to-avoid.json`, plus non-blocking **substrate-grounding advisories** (`chrome-*`, `pattern-ungrounded`, `relationships-ungrounded`, `properties-ungrounded`, `enum-not-typed` — all `info`, flow-level `screen:""`, NOT in `HARD_KINDS`; new finding kinds must also be registered in `CLI_VISIBLE_KINDS`). Note: flow-data is **not** ajv-validated — schema checks go through the hand-rolled `scripts/validation/validate-schema.js` (no `oneOf`).
 - `scripts/transformers/fm-tree-to-flow-data.js` — converts FM Figma tree to flow-data.json
 - `scripts/vendor/vendor-snapshot.js` — pulls pinned snapshot from `volivarii/actian-ds-knowledge`
 


### PR DESCRIPTION
## Docs refresh — substrate-grounding (S1–S3c) + version

Brings the docs current with the generate-flow substrate-grounding program (merged through #201) and the `2026.6.21` release. **Docs-only — no version bump, no behavior change.**

### Changed
- **README** — version `v1.97.0` → `2026.6.21`; added substrate-grounded flow authoring to the capability summary; expanded the glossary + validation pipeline gates and the app-context knowledge entry to cover chrome / pattern / relationship / property grounding + typed (enum→pill) rendering; corrected guideline-doc counts (50 + 8 breakdown; fixed a stray `44` → `58`).
- **CHANGELOG** — added `2026.6.14`–`2026.6.21` entries for the grounding program (S1 app-chrome → S2 patterns → S3 relationships → S3b properties → S3c typed rendering), with verified versions/dates and the real advisory-kind names.
- **CLAUDE.md** — documented the `scripts/lib/app-context/` resolvers and the validator's substrate-grounding advisories (`chrome-*`, `pattern-ungrounded`, `relationships-ungrounded`, `properties-ungrounded`, `enum-not-typed`).
- **ARCHITECTURE.md** — added `lib/app-context/` to the scripts map.

### Verification
- Prose-path CI guard passes (no new unresolvable `vendor/` references; only the known `docs/superpowers` LOCAL-ONLY false positive).
- USAGE.md and llms.txt left unchanged — neither was stale on this work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
