### PR TITLE
hifi(slice1): anatomy-grounded hi-fi leaf expansion

### DIFF
--- a/plugins/actian-design-system/.claude-plugin/plugin.json
+++ b/plugins/actian-design-system/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "actian-design-system",
   "description": "Actian Design System toolkit — generate wireframe flows with prototype wiring, create component briefs, audit designs, compare flows, and build presentations. 8 skills (with tiered generation: recognized / adapted / improvised), 9 agents, 155 tokens (3 themes, 8 collections), WCAG 2.2 AA. DS knowledge vendored from volivarii/actian-ds-knowledge.",
-  "version": "2026.6.24",
+  "version": "2026.6.25",
   "author": {
     "name": "Actian UX Team"
   },

--- a/plugins/actian-design-system/.claude-plugin/plugin.json
+++ b/plugins/actian-design-system/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "actian-design-system",
   "description": "Actian Design System toolkit — generate wireframe flows with prototype wiring, create component briefs, audit designs, compare flows, and build presentations. 8 skills (with tiered generation: recognized / adapted / improvised), 9 agents, 155 tokens (3 themes, 8 collections), WCAG 2.2 AA. DS knowledge vendored from volivarii/actian-ds-knowledge.",
-  "version": "2026.6.22",
+  "version": "2026.6.23",
   "author": {
     "name": "Actian UX Team"
   },

--- a/plugins/actian-design-system/.claude-plugin/plugin.json
+++ b/plugins/actian-design-system/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "actian-design-system",
   "description": "Actian Design System toolkit — generate wireframe flows with prototype wiring, create component briefs, audit designs, compare flows, and build presentations. 8 skills (with tiered generation: recognized / adapted / improvised), 9 agents, 155 tokens (3 themes, 8 collections), WCAG 2.2 AA. DS knowledge vendored from volivarii/actian-ds-knowledge.",
-  "version": "2026.6.23",
+  "version": "2026.6.24",
   "author": {
     "name": "Actian UX Team"
   },

--- a/plugins/actian-design-system/scripts/quality/quality-gates-cli.js
+++ b/plugins/actian-design-system/scripts/quality/quality-gates-cli.js
@@ -15,7 +15,25 @@ var runFidelity = require("../fidelity/run-fidelity.js");
 var fidelityReport = require("../fidelity/fidelity-report.js");
 var q = require("./quality-score.js");
 
-var PILOT = ["button", "checkbox-with-label", "alert-banner"];
+var PILOT = [
+  // Original pilot trio
+  "button",
+  "checkbox-with-label",
+  "alert-banner",
+  // Hi-Fi Slice 1 (Task 4) override leaves — all tier:override in ds-html-map,
+  // render correctly server-side (real switch-case, no window.__dsAnatomyMap needed).
+  // Anatomy-tier slugs are intentionally excluded: ds-html-map's default case reads
+  // window.__dsAnatomyMap, which is only populated in the browser; in the Node/gate
+  // render path they chip-degrade, producing misleadingly low structural scores.
+  "notification",
+  "stepper",
+  "tooltip",
+  "input-date",
+  "rich-text",
+  "dropdown-select-default",
+  "progress-bar-small",
+  "tag-interactive",
+];
 var DIFF_DIR = path.join(
   __dirname,
   "..",

--- a/plugins/actian-design-system/scripts/renderers/anatomy-render.js
+++ b/plugins/actian-design-system/scripts/renderers/anatomy-render.js
@@ -10,23 +10,49 @@ var PATHS = require(path.join(__dirname, "..", "lib", "paths.js"));
 
 function esc(s) {
   return String(s == null ? "" : s).replace(/[&<>"']/g, function (c) {
-    return { "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;", "'": "&#39;" }[c];
+    return {
+      "&": "&amp;",
+      "<": "&lt;",
+      ">": "&gt;",
+      '"': "&quot;",
+      "'": "&#39;",
+    }[c];
   });
 }
 function loadAnatomy(slug, loader) {
   if (typeof loader === "function") return loader(slug);
-  try { return JSON.parse(fs.readFileSync(PATHS.components.anatomy.byKey(slug), "utf8")); }
-  catch (e) { return null; }
+  try {
+    return JSON.parse(
+      fs.readFileSync(PATHS.components.anatomy.byKey(slug), "utf8"),
+    );
+  } catch (e) {
+    return null;
+  }
 }
 function mapAlign(v) {
-  return { center: "center", end: "flex-end", "flex-end": "flex-end", "space-between": "space-between", start: "flex-start", "flex-start": "flex-start" }[v] || "flex-start";
+  return (
+    {
+      center: "center",
+      end: "flex-end",
+      "flex-end": "flex-end",
+      "space-between": "space-between",
+      start: "flex-start",
+      "flex-start": "flex-start",
+    }[v] || "flex-start"
+  );
 }
 function flexStyle(layout) {
   if (!layout || typeof layout !== "object") return "";
   var p = layout.padding || {};
-  var parts = ["display:flex", "flex-direction:" + (layout.axis === "row" ? "row" : "column")];
+  var parts = [
+    "display:flex",
+    "flex-direction:" + (layout.axis === "row" ? "row" : "column"),
+  ];
   if (layout.gap) parts.push("gap:" + layout.gap);
-  parts.push("padding:" + [p.top || "0", p.right || "0", p.bottom || "0", p.left || "0"].join(" "));
+  parts.push(
+    "padding:" +
+      [p.top || "0", p.right || "0", p.bottom || "0", p.left || "0"].join(" "),
+  );
   var a = layout.align || {};
   if (a.main) parts.push("justify-content:" + mapAlign(a.main));
   if (a.cross) parts.push("align-items:" + mapAlign(a.cross));
@@ -34,18 +60,35 @@ function flexStyle(layout) {
 }
 function renderNode(node) {
   if (!node || typeof node !== "object") return "";
-  var kind = node.kind, cls = "ds-anatomy__" + (kind || "node");
-  if (kind === "text") return '<span class="' + cls + '">' + esc(node.text || "") + "</span>";
-  if (kind === "image" || kind === "vector") return '<div class="' + cls + '" aria-hidden="true"></div>';
-  var kids = Array.isArray(node.children) ? node.children.map(renderNode).join("") : "";
-  return '<div class="' + cls + '" style="' + esc(flexStyle(node.layout)) + '">' + kids + "</div>";
+  var kind = node.kind,
+    cls = "ds-anatomy__" + (kind || "node");
+  if (kind === "text")
+    return '<span class="' + cls + '">' + esc(node.text || "") + "</span>";
+  if (kind === "image" || kind === "vector")
+    return '<div class="' + cls + '" aria-hidden="true"></div>';
+  var kids = Array.isArray(node.children)
+    ? node.children.map(renderNode).join("")
+    : "";
+  return (
+    '<div class="' +
+    cls +
+    '" style="' +
+    esc(flexStyle(node.layout)) +
+    '">' +
+    kids +
+    "</div>"
+  );
 }
 function renderAnatomy(dsSlug, opts) {
+  if (!dsSlug) return null;
   opts = opts || {};
   var minRatio = typeof opts.minRatio === "number" ? opts.minRatio : 0.6;
   var data = loadAnatomy(dsSlug, opts.loader);
   if (!data || !data.root || typeof data.root !== "object") return null;
-  var ratio = data.quality && typeof data.quality.ratio === "number" ? data.quality.ratio : 0;
+  var ratio =
+    data.quality && typeof data.quality.ratio === "number"
+      ? data.quality.ratio
+      : 0;
   if (ratio < minRatio) return null;
 
   // Base root classes
@@ -57,7 +100,13 @@ function renderAnatomy(dsSlug, opts) {
   if (binding && typeof binding === "object") {
     // Append binding classes
     if (Array.isArray(binding.classes) && binding.classes.length > 0) {
-      rootClass += " " + binding.classes.map(function (c) { return esc(c); }).join(" ");
+      rootClass +=
+        " " +
+        binding.classes
+          .map(function (c) {
+            return esc(c);
+          })
+          .join(" ");
     }
     // Build style string from cssVars
     if (binding.cssVars && typeof binding.cssVars === "object") {
@@ -70,6 +119,20 @@ function renderAnatomy(dsSlug, opts) {
     }
   }
 
-  return '<div class="' + rootClass + '" data-ds-slug="' + esc(dsSlug) + '"' + styleAttr + ">" + renderNode(data.root) + "</div>";
+  return (
+    '<div class="' +
+    rootClass +
+    '" data-ds-slug="' +
+    esc(dsSlug) +
+    '"' +
+    styleAttr +
+    ">" +
+    renderNode(data.root) +
+    "</div>"
+  );
 }
-module.exports = { renderAnatomy: renderAnatomy, loadAnatomy: loadAnatomy, flexStyle: flexStyle };
+module.exports = {
+  renderAnatomy: renderAnatomy,
+  loadAnatomy: loadAnatomy,
+  flexStyle: flexStyle,
+};

--- a/plugins/actian-design-system/scripts/renderers/anatomy-render.js
+++ b/plugins/actian-design-system/scripts/renderers/anatomy-render.js
@@ -1,0 +1,75 @@
+#!/usr/bin/env node
+"use strict";
+// Assemble-time (Node) interpreter: a DS component's vendored anatomy
+// part-tree → structural HTML. Returns null when the slug has no usable
+// anatomy so the caller falls back. NOT for client runtime — the result is
+// embedded into the deliverable by assemble-preview.js.
+var fs = require("fs");
+var path = require("path");
+var PATHS = require(path.join(__dirname, "..", "lib", "paths.js"));
+
+function esc(s) {
+  return String(s == null ? "" : s).replace(/[&<>"']/g, function (c) {
+    return { "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;", "'": "&#39;" }[c];
+  });
+}
+function loadAnatomy(slug, loader) {
+  if (typeof loader === "function") return loader(slug);
+  try { return JSON.parse(fs.readFileSync(PATHS.components.anatomy.byKey(slug), "utf8")); }
+  catch (e) { return null; }
+}
+function mapAlign(v) {
+  return { center: "center", end: "flex-end", "flex-end": "flex-end", "space-between": "space-between", start: "flex-start", "flex-start": "flex-start" }[v] || "flex-start";
+}
+function flexStyle(layout) {
+  if (!layout || typeof layout !== "object") return "";
+  var p = layout.padding || {};
+  var parts = ["display:flex", "flex-direction:" + (layout.axis === "row" ? "row" : "column")];
+  if (layout.gap) parts.push("gap:" + layout.gap);
+  parts.push("padding:" + [p.top || "0", p.right || "0", p.bottom || "0", p.left || "0"].join(" "));
+  var a = layout.align || {};
+  if (a.main) parts.push("justify-content:" + mapAlign(a.main));
+  if (a.cross) parts.push("align-items:" + mapAlign(a.cross));
+  return parts.join(";");
+}
+function renderNode(node) {
+  if (!node || typeof node !== "object") return "";
+  var kind = node.kind, cls = "ds-anatomy__" + (kind || "node");
+  if (kind === "text") return '<span class="' + cls + '">' + esc(node.text || "") + "</span>";
+  if (kind === "image" || kind === "vector") return '<div class="' + cls + '" aria-hidden="true"></div>';
+  var kids = Array.isArray(node.children) ? node.children.map(renderNode).join("") : "";
+  return '<div class="' + cls + '" style="' + esc(flexStyle(node.layout)) + '">' + kids + "</div>";
+}
+function renderAnatomy(dsSlug, opts) {
+  opts = opts || {};
+  var minRatio = typeof opts.minRatio === "number" ? opts.minRatio : 0.6;
+  var data = loadAnatomy(dsSlug, opts.loader);
+  if (!data || !data.root || typeof data.root !== "object") return null;
+  var ratio = data.quality && typeof data.quality.ratio === "number" ? data.quality.ratio : 0;
+  if (ratio < minRatio) return null;
+
+  // Base root classes
+  var rootClass = "ds-anatomy ds-anatomy--" + esc(dsSlug);
+
+  // Apply opts.binding to root wrapper only
+  var binding = opts.binding;
+  var styleAttr = "";
+  if (binding && typeof binding === "object") {
+    // Append binding classes
+    if (Array.isArray(binding.classes) && binding.classes.length > 0) {
+      rootClass += " " + binding.classes.map(function (c) { return esc(c); }).join(" ");
+    }
+    // Build style string from cssVars
+    if (binding.cssVars && typeof binding.cssVars === "object") {
+      var declarations = Object.keys(binding.cssVars).map(function (k) {
+        return k + ":" + binding.cssVars[k];
+      });
+      if (declarations.length > 0) {
+        styleAttr = ' style="' + esc(declarations.join(";")) + '"';
+      }
+    }
+  }
+
+  return '<div class="' + rootClass + '" data-ds-slug="' + esc(dsSlug) + '"' + styleAttr + ">" + renderNode(data.root) + "</div>";
+}
+module.exports = { renderAnatomy: renderAnatomy, loadAnatomy: loadAnatomy, flexStyle: flexStyle };

--- a/plugins/actian-design-system/scripts/renderers/assemble-flow-share.js
+++ b/plugins/actian-design-system/scripts/renderers/assemble-flow-share.js
@@ -53,6 +53,17 @@ function assembleFlowShare(data) {
   var flowRenderer = require("./html-renderers/flow-renderer.js");
   var renderScreen = flowRenderer.renderScreen;
 
+  // Hi-fi anatomy tier: this deliverable pre-renders each screen server-side in
+  // Node (no `window`), so the assemble-time anatomy map for non-override DS
+  // slugs must be injected into the renderer module rather than embedded for the
+  // browser. Build it from the flow-data (content-shaped) and inject; the loop
+  // below resets it in a finally so module state never leaks across calls.
+  var dsHtmlMap = require("./html-renderers/ds-html-map.js");
+  var anatomyHelpers = require("./ds-anatomy-map.js");
+  var anatomyMap = anatomyHelpers.buildDsAnatomyMap(
+    anatomyHelpers.collectDsSlugs(data),
+  );
+
   // Assets (fail loudly if missing — same contract as readFileChecked).
   var wrapper = readFileChecked(WRAPPER_PATH);
   var alpine = readFileChecked(VENDOR_ALPINE);
@@ -80,28 +91,34 @@ function assembleFlowShare(data) {
   // target in Overview (enter that screen); display:contents in Prototype.
   var screensHtml = "";
   var navArray = [];
-  for (var s = 0; s < screens.length; s++) {
-    var id = s + 1;
-    var sc = screens[s];
-    if (metaLibrary && !sc.library) {
-      sc = Object.assign({}, sc, { library: metaLibrary });
+  dsHtmlMap.setAnatomyMap(anatomyMap);
+  try {
+    for (var s = 0; s < screens.length; s++) {
+      var id = s + 1;
+      var sc = screens[s];
+      if (metaLibrary && !sc.library) {
+        sc = Object.assign({}, sc, { library: metaLibrary });
+      }
+      navArray.push({ id: id, label: sc.name || "Screen " + id });
+      screensHtml +=
+        '<div class="proto-screen-cell" @click="view === \'overview\' && enter(' +
+        id +
+        ')">' +
+        '<div class="proto-screen" data-screen="' +
+        id +
+        '"' +
+        " :aria-hidden=\"view === 'prototype' && screen !== " +
+        id +
+        '"' +
+        " x-show=\"view === 'overview' || screen === " +
+        id +
+        '">' +
+        renderScreen(sc) +
+        "</div></div>\n";
     }
-    navArray.push({ id: id, label: sc.name || "Screen " + id });
-    screensHtml +=
-      '<div class="proto-screen-cell" @click="view === \'overview\' && enter(' +
-      id +
-      ')">' +
-      '<div class="proto-screen" data-screen="' +
-      id +
-      '"' +
-      " :aria-hidden=\"view === 'prototype' && screen !== " +
-      id +
-      '"' +
-      " x-show=\"view === 'overview' || screen === " +
-      id +
-      '">' +
-      renderScreen(sc) +
-      "</div></div>\n";
+  } finally {
+    // Reset module-level state so it never leaks into a later assembly.
+    dsHtmlMap.setAnatomyMap(null);
   }
   // navJson sits inside a double-quoted HTML attribute (x-data="{ screens: … }").
   // esc (not escapeJsonForScript) is required: a bare " in a screen name would

--- a/plugins/actian-design-system/scripts/renderers/assemble-preview.js
+++ b/plugins/actian-design-system/scripts/renderers/assemble-preview.js
@@ -27,8 +27,9 @@ var fs = require("fs");
 var path = require("path");
 var PATHS = require("../lib/paths");
 var shared = require("./assemble-shared");
-var renderAnatomy = require("./anatomy-render").renderAnatomy;
-var bindTokens = require("./ds-token-binding").bindTokens;
+var anatomyMapHelpers = require("./ds-anatomy-map");
+var collectDsSlugs = anatomyMapHelpers.collectDsSlugs;
+var buildDsAnatomyMap = anatomyMapHelpers.buildDsAnatomyMap;
 
 // ---------------------------------------------------------------------------
 // Paths (via shared module)
@@ -189,92 +190,9 @@ function writeOutput(outputPath, html) {
   );
 }
 
-// ---------------------------------------------------------------------------
-// DS anatomy map helpers
-// ---------------------------------------------------------------------------
-
-/**
- * Collect every unique dsSlug from a flow data tree (screens → frames → nodes).
- * Returns a deduplicated array of slug strings.
- */
-function collectDsSlugs(data) {
-  var seen = {};
-  var slugs = [];
-  function walk(nodes) {
-    if (!Array.isArray(nodes)) return;
-    for (var i = 0; i < nodes.length; i++) {
-      var n = nodes[i];
-      if (!n || typeof n !== "object") continue;
-      if (typeof n.dsSlug === "string" && n.dsSlug && !seen[n.dsSlug]) {
-        seen[n.dsSlug] = true;
-        slugs.push(n.dsSlug);
-      }
-      if (Array.isArray(n.children)) walk(n.children);
-      if (Array.isArray(n.nodes)) walk(n.nodes);
-    }
-  }
-  var screens = (data && data.screens) || [];
-  for (var s = 0; s < screens.length; s++) {
-    walk((screens[s] && screens[s].frames) || []);
-  }
-  return slugs;
-}
-
-/**
- * Build the anatomy map { slug → htmlString } for all non-override DS slugs.
- *
- * @param {string[]} slugs - candidate slug list (typically from collectDsSlugs)
- * @param {object}   opts
- *   opts.builtSlugs          - override list (default: BUILT_SLUGS from ds-html-map.js)
- *   opts.anatomyLoader       - injectable loader(slug) for anatomy JSON (default: fs read)
- *   opts.tokenBindingsLoader - injectable loader(slug) → [{token,context}] (default: fs read)
- * @returns {{ [slug: string]: string }}
- */
-function buildDsAnatomyMap(slugs, opts) {
-  opts = opts || {};
-  // Default builtSlugs: load from the renderer to keep it as single source of truth
-  var builtSlugs = Array.isArray(opts.builtSlugs)
-    ? opts.builtSlugs
-    : require("./html-renderers/ds-html-map.js").BUILT_SLUGS;
-  var builtSet = {};
-  for (var b = 0; b < builtSlugs.length; b++) builtSet[builtSlugs[b]] = true;
-
-  var map = {};
-  for (var i = 0; i < slugs.length; i++) {
-    var slug = slugs[i];
-    // Override slugs have hand-authored HTML leaves — skip them
-    if (builtSet[slug]) continue;
-
-    // Read token bindings for this slug
-    var tokenBindings = [];
-    if (typeof opts.tokenBindingsLoader === "function") {
-      tokenBindings = opts.tokenBindingsLoader(slug) || [];
-    } else {
-      try {
-        var guidelineDoc = JSON.parse(
-          fs.readFileSync(PATHS.components.guidelineDoc.byKey(slug), "utf8"),
-        );
-        var domains = (guidelineDoc && guidelineDoc.domains) || {};
-        tokenBindings = (domains.tokens && domains.tokens.bindings) || [];
-      } catch (e) {
-        tokenBindings = [];
-      }
-    }
-
-    // Build binding context from token bindings
-    var binding = bindTokens(slug, { tokenBindings: tokenBindings });
-
-    // Render anatomy with binding applied
-    var html = renderAnatomy(slug, {
-      loader: opts.anatomyLoader,
-      binding: binding,
-    });
-
-    // Drop nulls (quality too low, missing root, or no anatomy file)
-    if (html) map[slug] = html;
-  }
-  return map;
-}
+// DS anatomy map helpers (collectDsSlugs / buildDsAnatomyMap) were extracted to
+// ./ds-anatomy-map.js so the flow-share assembler can build the map too. They are
+// re-imported above and re-exported below for back-compat.
 
 // ---------------------------------------------------------------------------
 // Main

--- a/plugins/actian-design-system/scripts/renderers/assemble-preview.js
+++ b/plugins/actian-design-system/scripts/renderers/assemble-preview.js
@@ -27,6 +27,8 @@ var fs = require("fs");
 var path = require("path");
 var PATHS = require("../lib/paths");
 var shared = require("./assemble-shared");
+var renderAnatomy = require("./anatomy-render").renderAnatomy;
+var bindTokens = require("./ds-token-binding").bindTokens;
 
 // ---------------------------------------------------------------------------
 // Paths (via shared module)
@@ -188,6 +190,93 @@ function writeOutput(outputPath, html) {
 }
 
 // ---------------------------------------------------------------------------
+// DS anatomy map helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Collect every unique dsSlug from a flow data tree (screens → frames → nodes).
+ * Returns a deduplicated array of slug strings.
+ */
+function collectDsSlugs(data) {
+  var seen = {};
+  var slugs = [];
+  function walk(nodes) {
+    if (!Array.isArray(nodes)) return;
+    for (var i = 0; i < nodes.length; i++) {
+      var n = nodes[i];
+      if (!n || typeof n !== "object") continue;
+      if (typeof n.dsSlug === "string" && n.dsSlug && !seen[n.dsSlug]) {
+        seen[n.dsSlug] = true;
+        slugs.push(n.dsSlug);
+      }
+      if (Array.isArray(n.children)) walk(n.children);
+      if (Array.isArray(n.nodes)) walk(n.nodes);
+    }
+  }
+  var screens = (data && data.screens) || [];
+  for (var s = 0; s < screens.length; s++) {
+    walk((screens[s] && screens[s].frames) || []);
+  }
+  return slugs;
+}
+
+/**
+ * Build the anatomy map { slug → htmlString } for all non-override DS slugs.
+ *
+ * @param {string[]} slugs - candidate slug list (typically from collectDsSlugs)
+ * @param {object}   opts
+ *   opts.builtSlugs          - override list (default: BUILT_SLUGS from ds-html-map.js)
+ *   opts.anatomyLoader       - injectable loader(slug) for anatomy JSON (default: fs read)
+ *   opts.tokenBindingsLoader - injectable loader(slug) → [{token,context}] (default: fs read)
+ * @returns {{ [slug: string]: string }}
+ */
+function buildDsAnatomyMap(slugs, opts) {
+  opts = opts || {};
+  // Default builtSlugs: load from the renderer to keep it as single source of truth
+  var builtSlugs = Array.isArray(opts.builtSlugs)
+    ? opts.builtSlugs
+    : require("./html-renderers/ds-html-map.js").BUILT_SLUGS;
+  var builtSet = {};
+  for (var b = 0; b < builtSlugs.length; b++) builtSet[builtSlugs[b]] = true;
+
+  var map = {};
+  for (var i = 0; i < slugs.length; i++) {
+    var slug = slugs[i];
+    // Override slugs have hand-authored HTML leaves — skip them
+    if (builtSet[slug]) continue;
+
+    // Read token bindings for this slug
+    var tokenBindings = [];
+    if (typeof opts.tokenBindingsLoader === "function") {
+      tokenBindings = opts.tokenBindingsLoader(slug) || [];
+    } else {
+      try {
+        var guidelineDoc = JSON.parse(
+          fs.readFileSync(PATHS.components.guidelineDoc.byKey(slug), "utf8"),
+        );
+        var domains = (guidelineDoc && guidelineDoc.domains) || {};
+        tokenBindings = (domains.tokens && domains.tokens.bindings) || [];
+      } catch (e) {
+        tokenBindings = [];
+      }
+    }
+
+    // Build binding context from token bindings
+    var binding = bindTokens(slug, { tokenBindings: tokenBindings });
+
+    // Render anatomy with binding applied
+    var html = renderAnatomy(slug, {
+      loader: opts.anatomyLoader,
+      binding: binding,
+    });
+
+    // Drop nulls (quality too low, missing root, or no anatomy file)
+    if (html) map[slug] = html;
+  }
+  return map;
+}
+
+// ---------------------------------------------------------------------------
 // Main
 // ---------------------------------------------------------------------------
 
@@ -311,6 +400,16 @@ function main() {
   });
   if (inlinesDs) {
     rendererScripts += shared.buildDsIconsScript() + "\n";
+    // Build anatomy map at assemble-time and embed it so the client renderer
+    // can dispatch non-override slugs without reading any substrate at runtime.
+    var anatomySlugs = collectDsSlugs(data);
+    var anatomyMap = buildDsAnatomyMap(anatomySlugs);
+    var anatomyMapJson = escapeJsonForScript(JSON.stringify(anatomyMap));
+    rendererScripts +=
+      "  <script>\n  /* ds-anatomy-map (assemble-time) */\n" +
+      "  window.__dsAnatomyMap = " +
+      anatomyMapJson +
+      ";\n  </script>\n";
   }
   for (var r = 0; r < config.renderers.length; r++) {
     var rendererPath = config.renderers[r];
@@ -393,4 +492,15 @@ function main() {
   writeOutput(args.output, html);
 }
 
-main();
+// Only run main() when executed directly — not when require()'d by tests.
+if (require.main === module) {
+  main();
+}
+
+// ---------------------------------------------------------------------------
+// Exports (for testing and programmatic use)
+// ---------------------------------------------------------------------------
+module.exports = {
+  collectDsSlugs: collectDsSlugs,
+  buildDsAnatomyMap: buildDsAnatomyMap,
+};

--- a/plugins/actian-design-system/scripts/renderers/ds-anatomy-map.js
+++ b/plugins/actian-design-system/scripts/renderers/ds-anatomy-map.js
@@ -1,0 +1,106 @@
+#!/usr/bin/env node
+"use strict";
+
+/**
+ * ds-anatomy-map.js — Assemble-time helpers that turn a flow's non-override DS
+ * slugs into a { slug → structural-HTML } map.
+ *
+ * Extracted from assemble-preview.js so BOTH the strip renderer (assemble-preview)
+ * and the canonical shareable deliverable (assemble-flow-share) can build the map
+ * without one renderer depending on the other's CLI module. No side effects at
+ * load. Pure functions; substrate reads happen via injectable loaders (defaults
+ * read the vendored anatomy + guideline docs).
+ */
+
+var fs = require("fs");
+var PATHS = require("../lib/paths");
+var renderAnatomy = require("./anatomy-render").renderAnatomy;
+var bindTokens = require("./ds-token-binding").bindTokens;
+
+/**
+ * Collect every unique dsSlug from a flow data tree (screens → content → nodes).
+ * Returns a deduplicated array of slug strings.
+ */
+function collectDsSlugs(data) {
+  var seen = {};
+  var slugs = [];
+  function walk(nodes) {
+    if (!Array.isArray(nodes)) return;
+    for (var i = 0; i < nodes.length; i++) {
+      var n = nodes[i];
+      if (!n || typeof n !== "object") continue;
+      if (typeof n.dsSlug === "string" && n.dsSlug && !seen[n.dsSlug]) {
+        seen[n.dsSlug] = true;
+        slugs.push(n.dsSlug);
+      }
+      if (Array.isArray(n.children)) walk(n.children);
+      if (Array.isArray(n.nodes)) walk(n.nodes);
+    }
+  }
+  var screens = (data && data.screens) || [];
+  for (var s = 0; s < screens.length; s++) {
+    walk((screens[s] && screens[s].content) || []);
+  }
+  return slugs;
+}
+
+/**
+ * Build the anatomy map { slug → htmlString } for all non-override DS slugs.
+ *
+ * @param {string[]} slugs - candidate slug list (typically from collectDsSlugs)
+ * @param {object}   opts
+ *   opts.builtSlugs          - override list (default: BUILT_SLUGS from ds-html-map.js)
+ *   opts.anatomyLoader       - injectable loader(slug) for anatomy JSON (default: fs read)
+ *   opts.tokenBindingsLoader - injectable loader(slug) → [{token,context}] (default: fs read)
+ * @returns {{ [slug: string]: string }}
+ */
+function buildDsAnatomyMap(slugs, opts) {
+  opts = opts || {};
+  // Default builtSlugs: load from the renderer to keep it as single source of truth
+  var builtSlugs = Array.isArray(opts.builtSlugs)
+    ? opts.builtSlugs
+    : require("./html-renderers/ds-html-map.js").BUILT_SLUGS;
+  var builtSet = {};
+  for (var b = 0; b < builtSlugs.length; b++) builtSet[builtSlugs[b]] = true;
+
+  var map = {};
+  for (var i = 0; i < slugs.length; i++) {
+    var slug = slugs[i];
+    // Override slugs have hand-authored HTML leaves — skip them
+    if (builtSet[slug]) continue;
+
+    // Read token bindings for this slug
+    var tokenBindings = [];
+    if (typeof opts.tokenBindingsLoader === "function") {
+      tokenBindings = opts.tokenBindingsLoader(slug) || [];
+    } else {
+      try {
+        var guidelineDoc = JSON.parse(
+          fs.readFileSync(PATHS.components.guidelineDoc.byKey(slug), "utf8"),
+        );
+        var domains = (guidelineDoc && guidelineDoc.domains) || {};
+        tokenBindings = (domains.tokens && domains.tokens.bindings) || [];
+      } catch (e) {
+        tokenBindings = [];
+      }
+    }
+
+    // Build binding context from token bindings
+    var binding = bindTokens(slug, { tokenBindings: tokenBindings });
+
+    // Render anatomy with binding applied
+    var html = renderAnatomy(slug, {
+      loader: opts.anatomyLoader,
+      binding: binding,
+    });
+
+    // Drop nulls (quality too low, missing root, or no anatomy file)
+    if (html) map[slug] = html;
+  }
+  return map;
+}
+
+module.exports = {
+  collectDsSlugs: collectDsSlugs,
+  buildDsAnatomyMap: buildDsAnatomyMap,
+};

--- a/plugins/actian-design-system/scripts/renderers/ds-coverage-report.js
+++ b/plugins/actian-design-system/scripts/renderers/ds-coverage-report.js
@@ -57,12 +57,14 @@ if (require.main === module) {
   // Print table
   var col1 = Math.max(
     "slug".length,
-    Math.max.apply(
-      null,
-      rows.map(function (r) {
-        return r.slug.length;
-      }),
-    ),
+    rows.length
+      ? Math.max.apply(
+          null,
+          rows.map(function (r) {
+            return r.slug.length;
+          }),
+        )
+      : "slug".length,
   );
   var col2 = 8; // "degraded".length
   var col3 = 5; // "ratio".length

--- a/plugins/actian-design-system/scripts/renderers/ds-coverage-report.js
+++ b/plugins/actian-design-system/scripts/renderers/ds-coverage-report.js
@@ -1,0 +1,63 @@
+#!/usr/bin/env node
+"use strict";
+var path = require("path");
+var { renderAnatomy, loadAnatomy } = require(path.join(__dirname, "anatomy-render.js"));
+
+function coverage(slugs, opts) {
+  opts = opts || {};
+  var minRatio = typeof opts.minRatio === "number" ? opts.minRatio : 0.6;
+  var built = {};
+  (opts.builtSlugs || []).forEach(function (s) { built[s] = true; });
+  return (slugs || []).map(function (slug) {
+    if (built[slug]) return { slug: slug, tier: "override", ratio: null };
+    var spec = loadAnatomy(slug, opts.anatomyLoader);
+    if (!spec || !spec.root) return { slug: slug, tier: "chip", ratio: null };
+    var ratio = spec.quality && typeof spec.quality.ratio === "number" ? spec.quality.ratio : 0;
+    var html = renderAnatomy(slug, { loader: opts.anatomyLoader, minRatio: minRatio });
+    return { slug: slug, tier: html ? "anatomy" : "degraded", ratio: ratio };
+  });
+}
+
+module.exports = { coverage: coverage };
+
+if (require.main === module) {
+  var fs = require("fs");
+  var BUILT_SLUGS = require(path.join(__dirname, "html-renderers", "ds-html-map.js")).BUILT_SLUGS;
+
+  // Parse authorable slugs from the markdown table in ds-components-authoring.md
+  var mdPath = path.resolve(__dirname, "..", "..", "references", "generate-flow", "ds-components-authoring.md");
+  var mdContent = fs.readFileSync(mdPath, "utf8");
+  var authorableSlugs = [];
+  mdContent.split("\n").forEach(function (line) {
+    var m = line.match(/^\|\s*`([^`]+)`/);
+    if (m) authorableSlugs.push(m[1]);
+  });
+
+  var rows = coverage(authorableSlugs, { builtSlugs: BUILT_SLUGS });
+
+  // Print table
+  var col1 = Math.max("slug".length, Math.max.apply(null, rows.map(function (r) { return r.slug.length; })));
+  var col2 = 8; // "degraded".length
+  var col3 = 5; // "ratio".length
+
+  function pad(s, n) { return String(s == null ? "" : s) + " ".repeat(Math.max(0, n - String(s == null ? "" : s).length)); }
+
+  console.log(pad("slug", col1) + "  " + pad("tier", col2) + "  " + "ratio");
+  console.log("-".repeat(col1) + "  " + "-".repeat(col2) + "  " + "-".repeat(6));
+  rows.forEach(function (r) {
+    var ratioStr = r.ratio != null ? r.ratio.toFixed(2) : "—";
+    console.log(pad(r.slug, col1) + "  " + pad(r.tier, col2) + "  " + ratioStr);
+  });
+
+  // Counts summary
+  var counts = { override: 0, anatomy: 0, degraded: 0, chip: 0 };
+  rows.forEach(function (r) { if (counts[r.tier] != null) counts[r.tier]++; });
+  console.log("\n--- Counts ---");
+  console.log("override: " + counts.override);
+  console.log("anatomy:  " + counts.anatomy);
+  console.log("degraded: " + counts.degraded);
+  console.log("chip:     " + counts.chip);
+  console.log("total:    " + rows.length);
+
+  process.exit(0);
+}

--- a/plugins/actian-design-system/scripts/renderers/ds-coverage-report.js
+++ b/plugins/actian-design-system/scripts/renderers/ds-coverage-report.js
@@ -1,19 +1,29 @@
 #!/usr/bin/env node
 "use strict";
 var path = require("path");
-var { renderAnatomy, loadAnatomy } = require(path.join(__dirname, "anatomy-render.js"));
+var { renderAnatomy, loadAnatomy } = require(
+  path.join(__dirname, "anatomy-render.js"),
+);
 
 function coverage(slugs, opts) {
   opts = opts || {};
   var minRatio = typeof opts.minRatio === "number" ? opts.minRatio : 0.6;
   var built = {};
-  (opts.builtSlugs || []).forEach(function (s) { built[s] = true; });
+  (opts.builtSlugs || []).forEach(function (s) {
+    built[s] = true;
+  });
   return (slugs || []).map(function (slug) {
     if (built[slug]) return { slug: slug, tier: "override", ratio: null };
     var spec = loadAnatomy(slug, opts.anatomyLoader);
     if (!spec || !spec.root) return { slug: slug, tier: "chip", ratio: null };
-    var ratio = spec.quality && typeof spec.quality.ratio === "number" ? spec.quality.ratio : 0;
-    var html = renderAnatomy(slug, { loader: opts.anatomyLoader, minRatio: minRatio });
+    var ratio =
+      spec.quality && typeof spec.quality.ratio === "number"
+        ? spec.quality.ratio
+        : null;
+    var html = renderAnatomy(slug, {
+      loader: opts.anatomyLoader,
+      minRatio: minRatio,
+    });
     return { slug: slug, tier: html ? "anatomy" : "degraded", ratio: ratio };
   });
 }
@@ -22,10 +32,19 @@ module.exports = { coverage: coverage };
 
 if (require.main === module) {
   var fs = require("fs");
-  var BUILT_SLUGS = require(path.join(__dirname, "html-renderers", "ds-html-map.js")).BUILT_SLUGS;
+  var BUILT_SLUGS = require(
+    path.join(__dirname, "html-renderers", "ds-html-map.js"),
+  ).BUILT_SLUGS;
 
   // Parse authorable slugs from the markdown table in ds-components-authoring.md
-  var mdPath = path.resolve(__dirname, "..", "..", "references", "generate-flow", "ds-components-authoring.md");
+  var mdPath = path.resolve(
+    __dirname,
+    "..",
+    "..",
+    "references",
+    "generate-flow",
+    "ds-components-authoring.md",
+  );
   var mdContent = fs.readFileSync(mdPath, "utf8");
   var authorableSlugs = [];
   mdContent.split("\n").forEach(function (line) {
@@ -36,14 +55,29 @@ if (require.main === module) {
   var rows = coverage(authorableSlugs, { builtSlugs: BUILT_SLUGS });
 
   // Print table
-  var col1 = Math.max("slug".length, Math.max.apply(null, rows.map(function (r) { return r.slug.length; })));
+  var col1 = Math.max(
+    "slug".length,
+    Math.max.apply(
+      null,
+      rows.map(function (r) {
+        return r.slug.length;
+      }),
+    ),
+  );
   var col2 = 8; // "degraded".length
   var col3 = 5; // "ratio".length
 
-  function pad(s, n) { return String(s == null ? "" : s) + " ".repeat(Math.max(0, n - String(s == null ? "" : s).length)); }
+  function pad(s, n) {
+    return (
+      String(s == null ? "" : s) +
+      " ".repeat(Math.max(0, n - String(s == null ? "" : s).length))
+    );
+  }
 
   console.log(pad("slug", col1) + "  " + pad("tier", col2) + "  " + "ratio");
-  console.log("-".repeat(col1) + "  " + "-".repeat(col2) + "  " + "-".repeat(6));
+  console.log(
+    "-".repeat(col1) + "  " + "-".repeat(col2) + "  " + "-".repeat(6),
+  );
   rows.forEach(function (r) {
     var ratioStr = r.ratio != null ? r.ratio.toFixed(2) : "—";
     console.log(pad(r.slug, col1) + "  " + pad(r.tier, col2) + "  " + ratioStr);
@@ -51,7 +85,9 @@ if (require.main === module) {
 
   // Counts summary
   var counts = { override: 0, anatomy: 0, degraded: 0, chip: 0 };
-  rows.forEach(function (r) { if (counts[r.tier] != null) counts[r.tier]++; });
+  rows.forEach(function (r) {
+    if (counts[r.tier] != null) counts[r.tier]++;
+  });
   console.log("\n--- Counts ---");
   console.log("override: " + counts.override);
   console.log("anatomy:  " + counts.anatomy);

--- a/plugins/actian-design-system/scripts/renderers/ds-token-binding.js
+++ b/plugins/actian-design-system/scripts/renderers/ds-token-binding.js
@@ -3,6 +3,53 @@
 // Token/state binding seam. Maps registry variant axes → state classes and
 // guideline domains.tokens bindings → CSS custom-property assignments. The
 // enrichment point for a future Figma-MCP / Zen·zng-ui token/state harvest.
+//
+// cssVars behaviour: a binding's `context` field must be a recognized CSS
+// property (see CSS_PROPS allowlist below) for a var() to be emitted.
+// Descriptive contexts (e.g. "Card padding", "Badge fill (error/notification)")
+// which represent the current substrate norm are SKIPPED — they produce no
+// output and leave `cssVars` empty. This keeps the seam clean and honest: it
+// lights up automatically when a render-grade token harvest supplies
+// CSS-property contexts instead of human descriptions.
+//
+// Token resolution: tokens already prefixed with "--" are used as-is inside
+// var(); bare tokens (e.g. "color-bg-default") are resolved to the --zen-
+// namespace → var(--zen-color-bg-default).
+
+var CSS_PROPS = new Set([
+  "background",
+  "background-color",
+  "color",
+  "border-color",
+  "border",
+  "border-top-color",
+  "border-bottom-color",
+  "padding",
+  "padding-top",
+  "padding-right",
+  "padding-bottom",
+  "padding-left",
+  "margin",
+  "gap",
+  "row-gap",
+  "column-gap",
+  "height",
+  "min-height",
+  "max-height",
+  "width",
+  "min-width",
+  "max-width",
+  "font-size",
+  "font-weight",
+  "line-height",
+  "letter-spacing",
+  "border-radius",
+  "box-shadow",
+  "fill",
+  "stroke",
+  "opacity",
+]);
+
 function bindTokens(dsSlug, ctx) {
   var out = { classes: [], cssVars: {} };
   if (!ctx || typeof ctx !== "object") return out;
@@ -11,7 +58,12 @@ function bindTokens(dsSlug, ctx) {
     Object.keys(v).forEach(function (axis) {
       var val = v[axis];
       if (typeof val === "string" && val) {
-        out.classes.push("ds--" + axis.toLowerCase() + "-" + String(val).toLowerCase().replace(/\s+/g, "-"));
+        out.classes.push(
+          "ds--" +
+            axis.toLowerCase() +
+            "-" +
+            String(val).toLowerCase().replace(/\s+/g, "-"),
+        );
       }
     });
   }
@@ -19,7 +71,12 @@ function bindTokens(dsSlug, ctx) {
   if (Array.isArray(tb)) {
     tb.forEach(function (b) {
       if (b && typeof b.token === "string" && typeof b.context === "string") {
-        out.cssVars[b.context] = "var(" + b.token + ")";
+        if (!CSS_PROPS.has(b.context)) return; // descriptive context — skip
+        var ref =
+          b.token.indexOf("--") === 0
+            ? "var(" + b.token + ")"
+            : "var(--zen-" + b.token + ")";
+        out.cssVars[b.context] = ref;
       }
     });
   }

--- a/plugins/actian-design-system/scripts/renderers/ds-token-binding.js
+++ b/plugins/actian-design-system/scripts/renderers/ds-token-binding.js
@@ -1,0 +1,28 @@
+#!/usr/bin/env node
+"use strict";
+// Token/state binding seam. Maps registry variant axes → state classes and
+// guideline domains.tokens bindings → CSS custom-property assignments. The
+// enrichment point for a future Figma-MCP / Zen·zng-ui token/state harvest.
+function bindTokens(dsSlug, ctx) {
+  var out = { classes: [], cssVars: {} };
+  if (!ctx || typeof ctx !== "object") return out;
+  var v = ctx.variants;
+  if (v && typeof v === "object") {
+    Object.keys(v).forEach(function (axis) {
+      var val = v[axis];
+      if (typeof val === "string" && val) {
+        out.classes.push("ds--" + axis.toLowerCase() + "-" + String(val).toLowerCase().replace(/\s+/g, "-"));
+      }
+    });
+  }
+  var tb = ctx.tokenBindings;
+  if (Array.isArray(tb)) {
+    tb.forEach(function (b) {
+      if (b && typeof b.token === "string" && typeof b.context === "string") {
+        out.cssVars[b.context] = "var(" + b.token + ")";
+      }
+    });
+  }
+  return out;
+}
+module.exports = { bindTokens: bindTokens };

--- a/plugins/actian-design-system/scripts/renderers/html-renderers/ds-base.css
+++ b/plugins/actian-design-system/scripts/renderers/html-renderers/ds-base.css
@@ -1346,6 +1346,452 @@
   line-height: var(--zen-font-lineheight-sm);
 }
 
+/* ============================================================= */
+/* Hi-Fi Slice 1 (Task 4): 8 transform-target leaves              */
+/* All bound to vendored --zen-* tokens; no hardcoded color.      */
+/* ============================================================= */
+
+/* ============ Notification (inline banner + action) ============ */
+/* Registry axis: Type = Default | Critical. Mirrors the .ds-alert idiom:
+ * icon left, message, optional action button right. Critical = error accent. */
+.ds-notification {
+  display: flex;
+  align-items: center;
+  gap: var(--zen-spacing-sm);
+  padding: var(--zen-spacing-sm) var(--zen-spacing-md);
+  background: var(--zen-color-bg-default);
+  border: 1px solid var(--zen-border-default);
+  border-left-width: 4px; /* raw px: status accent strip, DS-conventional */
+  border-left-color: var(--zen-color-icon-primary);
+  border-radius: var(--zen-border-radius-xs);
+  box-shadow: var(--zen-shadow-sm);
+  font-family: var(--zen-font-family-text);
+  font-size: var(--zen-font-size-md);
+}
+.ds-notification--critical {
+  border-left-color: var(--zen-color-icon-error);
+}
+.ds-notification__icon {
+  flex: none;
+  display: inline-flex;
+  align-items: center;
+  color: var(--zen-color-icon-primary);
+  font-size: var(--zen-font-size-lg);
+}
+.ds-notification--critical .ds-notification__icon {
+  color: var(--zen-color-icon-error);
+}
+.ds-notification__message {
+  flex: 1 1 0;
+  min-width: 0;
+  margin: 0;
+  color: var(--zen-color-text-primary);
+  line-height: var(--zen-font-lineheight-md);
+  letter-spacing: var(--zen-font-letterspacing-wide-2);
+}
+.ds-notification__action {
+  flex: none;
+}
+
+/* ============ Stepper (numbered status + title/body) ============ */
+/* Registry axis: State = Complete | Active | Default (Incomplete). */
+.ds-stepper {
+  display: inline-flex;
+  align-items: flex-start;
+  gap: var(--zen-spacing-sm);
+  font-family: var(--zen-font-family-text);
+}
+.ds-stepper__status {
+  flex: 0 0 auto;
+  box-sizing: border-box;
+  width: var(--zen-size-lg); /* 24 */
+  height: var(--zen-size-lg);
+  border-radius: var(--zen-border-radius-full);
+  border: var(--zen-border-width-lg) solid var(--zen-border-default);
+  background: var(--zen-color-bg-default);
+  color: var(--zen-color-text-secondary);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  font-size: var(--zen-font-size-sm);
+  font-weight: var(--zen-font-weight-semibold);
+  line-height: 1;
+}
+.ds-stepper--active .ds-stepper__status {
+  border-color: var(--zen-color-icon-primary);
+  background: var(--zen-color-icon-primary);
+  color: var(--zen-color-text-reverse);
+}
+.ds-stepper--complete .ds-stepper__status {
+  border-color: var(--zen-color-icon-primary);
+  background: var(--zen-color-icon-primary);
+  color: var(--zen-color-text-reverse);
+}
+.ds-stepper__check {
+  width: 14px; /* glyph box geometry (raw px) */
+  height: 14px;
+  display: inline-flex;
+  color: var(--zen-color-text-reverse);
+}
+.ds-stepper__text {
+  display: flex;
+  flex-direction: column;
+  gap: var(--zen-spacing-2xs); /* 4 */
+  padding-top: var(--zen-spacing-3xs);
+}
+.ds-stepper__title {
+  font-size: var(--zen-font-size-md);
+  font-weight: var(--zen-font-weight-medium);
+  line-height: var(--zen-font-lineheight-md);
+  letter-spacing: var(--zen-font-letterspacing-wide-2);
+  color: var(--zen-color-text-primary);
+}
+.ds-stepper--active .ds-stepper__title {
+  color: var(--zen-color-text-primary);
+  font-weight: var(--zen-font-weight-semibold);
+}
+.ds-stepper__body {
+  font-size: var(--zen-font-size-sm);
+  font-weight: var(--zen-font-weight-regular);
+  line-height: var(--zen-font-lineheight-sm);
+  letter-spacing: var(--zen-font-letterspacing-wide-3);
+  color: var(--zen-color-text-secondary);
+}
+
+/* ============ Tooltip (small text bubble) ============ */
+/* Registry axis: Type = Default. */
+.ds-tooltip {
+  position: relative;
+  display: inline-block;
+  max-width: 240px; /* raw px: tooltip bubble max width (slice geometry) */
+  padding: var(--zen-spacing-2xs) var(--zen-spacing-xs);
+  background: var(--zen-color-text-primary); /* dark bubble, light text */
+  color: var(--zen-color-text-reverse);
+  border-radius: var(--zen-border-radius-xs);
+  box-shadow: var(--zen-shadow-md);
+  font-family: var(--zen-font-family-text);
+  font-size: var(--zen-font-size-sm);
+  line-height: var(--zen-font-lineheight-sm);
+  letter-spacing: var(--zen-font-letterspacing-wide-3);
+}
+.ds-tooltip__body {
+  display: block;
+}
+.ds-tooltip__arrow {
+  position: absolute;
+  left: var(--zen-spacing-sm);
+  bottom: -4px; /* raw px: caret tip offset */
+  width: 8px; /* raw px: caret geometry */
+  height: 8px;
+  background: var(--zen-color-text-primary);
+  transform: rotate(45deg);
+}
+
+/* ============ Input date (labeled date field + calendar btn) ============ */
+/* Registry axes: Type = Single date | Date range; States = Enabled | … */
+.ds-input-date {
+  display: flex;
+  flex-direction: column;
+  gap: var(--zen-spacing-xs); /* 8 */
+  width: 320px; /* matches .ds-field width */
+  font-family: var(--zen-font-family-text);
+  box-sizing: border-box;
+}
+.ds-input-date__label-row {
+  display: flex;
+  gap: var(--zen-spacing-2xs);
+  align-items: center;
+}
+.ds-input-date__label {
+  font-size: var(--zen-font-size-md);
+  font-weight: var(--zen-font-weight-medium);
+  line-height: var(--zen-font-lineheight-md);
+  letter-spacing: var(--zen-font-letterspacing-wide-2);
+  color: var(--zen-color-text-primary);
+}
+.ds-input-date__inputs {
+  display: flex;
+  align-items: center;
+  gap: var(--zen-spacing-xs);
+}
+.ds-input-date__field {
+  flex: 1 1 0;
+  min-width: 0;
+  display: flex;
+  align-items: center;
+  gap: var(--zen-spacing-xs);
+  height: 40px; /* matches .ds-input height (raw px) */
+  padding: var(--zen-spacing-xs);
+  background: var(--zen-color-bg-default);
+  border: 1px solid var(--zen-border-default);
+  border-radius: var(--zen-border-radius-xs);
+  box-sizing: border-box;
+}
+.ds-input-date__value {
+  flex: 1 1 0;
+  min-width: 0;
+  font-size: var(--zen-font-size-md);
+  line-height: var(--zen-font-lineheight-md);
+  letter-spacing: var(--zen-font-letterspacing-wide-2);
+  color: var(--zen-color-text-placeholder);
+}
+.ds-input-date__calendar {
+  width: 20px; /* icon box geometry (raw px) */
+  height: 20px;
+  flex: 0 0 auto;
+  display: inline-flex;
+  color: var(--zen-color-icon-default);
+}
+.ds-input-date__calendar svg {
+  width: 100%;
+  height: 100%;
+  display: block;
+}
+.ds-input-date__sep {
+  flex: 0 0 auto;
+  color: var(--zen-color-text-secondary);
+}
+.ds-input-date__helper {
+  font-size: var(--zen-font-size-sm);
+  font-weight: var(--zen-font-weight-regular);
+  line-height: var(--zen-font-lineheight-sm);
+  letter-spacing: var(--zen-font-letterspacing-wide-3);
+  color: var(--zen-color-text-secondary);
+}
+.ds-input-date.is-disabled {
+  opacity: 0.4;
+}
+
+/* ============ Rich text (editor toolbar shell) ============ */
+/* Registry axis: State = Default | Expanded. */
+.ds-rich-text {
+  display: flex;
+  flex-direction: column;
+  width: 480px; /* raw px: editor shell width (forms max-width convention) */
+  border: 1px solid var(--zen-border-default);
+  border-radius: var(--zen-border-radius-sm);
+  background: var(--zen-color-bg-default);
+  font-family: var(--zen-font-family-text);
+  box-sizing: border-box;
+}
+.ds-rich-text__toolbar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--zen-spacing-sm);
+  padding: var(--zen-spacing-2xs) var(--zen-spacing-xs);
+  border-bottom: 1px solid var(--zen-border-default);
+  background: var(--zen-color-bg-subtle);
+}
+.ds-rich-text__group {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--zen-spacing-2xs);
+}
+.ds-rich-text__btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: var(--zen-size-xl); /* 32 */
+  height: var(--zen-size-xl);
+  padding: 0;
+  border: none;
+  border-radius: var(--zen-border-radius-xs);
+  background: transparent;
+  color: var(--zen-color-icon-default);
+  font-size: var(--zen-font-size-lg);
+  cursor: pointer;
+}
+.ds-rich-text__btn:hover {
+  background: var(--zen-color-bg-subtle);
+  color: var(--zen-color-icon-primary);
+}
+.ds-rich-text__content {
+  min-height: 96px; /* raw px: collapsed editor body height */
+  padding: var(--zen-spacing-md);
+}
+.ds-rich-text--expanded .ds-rich-text__content {
+  min-height: 200px; /* raw px: expanded editor body height */
+}
+
+/* ============ Dropdown select (labeled select + helper) ============ */
+/* Registry axes: Type = Default | … ; State = Default | Disabled | … */
+.ds-dropdown-select {
+  display: flex;
+  flex-direction: column;
+  gap: var(--zen-spacing-xs); /* 8 */
+  width: 320px; /* matches .ds-field width */
+  font-family: var(--zen-font-family-text);
+  box-sizing: border-box;
+}
+.ds-dropdown-select__label-row {
+  display: flex;
+  flex-direction: column;
+  gap: var(--zen-spacing-3xs);
+}
+.ds-dropdown-select__label {
+  font-size: var(--zen-font-size-md);
+  font-weight: var(--zen-font-weight-medium);
+  line-height: var(--zen-font-lineheight-md);
+  letter-spacing: var(--zen-font-letterspacing-wide-2);
+  color: var(--zen-color-text-primary);
+}
+.ds-dropdown-select__desc {
+  font-size: var(--zen-font-size-sm);
+  font-weight: var(--zen-font-weight-regular);
+  line-height: var(--zen-font-lineheight-sm);
+  letter-spacing: var(--zen-font-letterspacing-wide-3);
+  color: var(--zen-color-text-secondary);
+}
+.ds-dropdown-select__field {
+  display: flex;
+  align-items: center;
+  gap: var(--zen-spacing-xs);
+  height: 40px; /* matches .ds-input height (raw px) */
+  padding: var(--zen-spacing-xs);
+  background: var(--zen-color-bg-default);
+  border: 1px solid var(--zen-border-default);
+  border-radius: var(--zen-border-radius-xs);
+  box-sizing: border-box;
+}
+.ds-dropdown-select__value {
+  flex: 1 1 0;
+  min-width: 0;
+  font-size: var(--zen-font-size-md);
+  line-height: var(--zen-font-lineheight-md);
+  letter-spacing: var(--zen-font-letterspacing-wide-2);
+  color: var(--zen-color-text-primary);
+}
+.ds-dropdown-select__value--placeholder {
+  color: var(--zen-color-text-placeholder);
+}
+.ds-dropdown-select__chevron {
+  width: 20px; /* icon box geometry (raw px) */
+  height: 20px;
+  flex: 0 0 auto;
+  display: inline-flex;
+  color: var(--zen-color-icon-default);
+}
+.ds-dropdown-select__chevron svg {
+  width: 100%;
+  height: 100%;
+  display: block;
+}
+.ds-dropdown-select__helper {
+  font-size: var(--zen-font-size-sm);
+  font-weight: var(--zen-font-weight-regular);
+  line-height: var(--zen-font-lineheight-sm);
+  letter-spacing: var(--zen-font-letterspacing-wide-3);
+  color: var(--zen-color-text-secondary);
+}
+.ds-dropdown-select.is-disabled {
+  opacity: 0.4;
+}
+
+/* ============ Progress bar (small — track + fill + percent) ============ */
+/* Registry axes: Size = Default | Large; Completeness = 0% | 50% | 100%. */
+.ds-progress {
+  display: flex;
+  align-items: center;
+  gap: var(--zen-spacing-sm);
+  width: 240px; /* raw px: small progress width (slice geometry) */
+  font-family: var(--zen-font-family-text);
+}
+.ds-progress__track {
+  flex: 1 1 0;
+  min-width: 0;
+  height: 4px; /* raw px: small track height */
+  border-radius: var(--zen-border-radius-full);
+  background: var(--zen-color-bg-subtle);
+  overflow: hidden;
+}
+.ds-progress--large .ds-progress__track {
+  height: 8px; /* raw px: large track height */
+}
+.ds-progress__fill {
+  display: block;
+  height: 100%;
+  border-radius: var(--zen-border-radius-full);
+  background: var(--zen-color-icon-primary);
+}
+.ds-progress__percent {
+  flex: 0 0 auto;
+  font-size: var(--zen-font-size-sm);
+  font-weight: var(--zen-font-weight-medium);
+  line-height: var(--zen-font-lineheight-sm);
+  letter-spacing: var(--zen-font-letterspacing-wide-3);
+  color: var(--zen-color-text-secondary);
+}
+
+/* ============ Tag interactive (chip w/ icons + remove) ============ */
+/* Registry axis: State = Default | Hovered | Selected | Disabled | … */
+.ds-tag-interactive {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--zen-spacing-2xs); /* 4 */
+  height: var(--zen-size-lg); /* 24 */
+  padding: 0 var(--zen-spacing-2xs) 0 var(--zen-spacing-xs);
+  border: 1px solid var(--zen-border-default);
+  border-radius: var(--zen-border-radius-sm); /* 6 */
+  background: var(--zen-color-bg-subtle);
+  color: var(--zen-color-text-tertiary);
+  font-family: var(--zen-font-family-text);
+  font-size: var(--zen-font-size-sm);
+  line-height: var(--zen-font-lineheight-sm);
+  font-weight: var(--zen-font-weight-regular);
+  letter-spacing: var(--zen-font-letterspacing-wide-3);
+  box-sizing: border-box;
+  white-space: nowrap;
+  cursor: pointer;
+}
+.ds-tag-interactive--selected {
+  border-color: var(--zen-border-selected);
+  background: var(--zen-color-bg-selected);
+  color: var(--zen-color-text-primary);
+}
+.ds-tag-interactive.is-disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+}
+.ds-tag-interactive__icon {
+  width: 14px; /* icon box geometry (raw px) */
+  height: 14px;
+  flex: 0 0 auto;
+  display: inline-flex;
+  color: var(--zen-color-icon-default);
+}
+.ds-tag-interactive__icon svg {
+  width: 100%;
+  height: 100%;
+  display: block;
+}
+.ds-tag-interactive__label {
+  display: inline-block;
+}
+.ds-tag-interactive__remove {
+  width: 16px; /* tap target geometry (raw px) */
+  height: 16px;
+  flex: 0 0 auto;
+  padding: 0;
+  border: none;
+  border-radius: var(--zen-border-radius-full);
+  background: transparent;
+  color: var(--zen-color-icon-default);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+}
+.ds-tag-interactive__remove:hover {
+  background: var(--zen-color-bg-default);
+  color: var(--zen-color-icon-error);
+}
+.ds-tag-interactive__remove svg {
+  width: 12px; /* glyph geometry (raw px) */
+  height: 12px;
+  display: block;
+}
+
 /* ============ Icon (real DS glyphs) ============ */
 /* Real DS icon glyphs (inlined from the vendored icon substrate via renderIcon). */
 .ds-icon {

--- a/plugins/actian-design-system/scripts/renderers/html-renderers/ds-base.css
+++ b/plugins/actian-design-system/scripts/renderers/html-renderers/ds-base.css
@@ -1804,3 +1804,31 @@
 .ds-icon--rot180 {
   transform: rotate(180deg);
 }
+
+/* ============ Anatomy (structural floor for non-override slugs) ============ */
+/* anatomy-render.js interprets a component's vendored part-tree into structural
+   HTML for DS slugs that have no hand-authored leaf. Containers carry per-node
+   inline flex styles; the rules here give the wrapper sensible hugging, legible
+   text, and — critically — a size + token-bound neutral fill to the aria-hidden
+   media slots, which otherwise render 0x0 and disappear. 100% --zen-* bound. */
+.ds-anatomy {
+  display: inline-flex;
+  max-width: 100%;
+  box-sizing: border-box;
+}
+.ds-anatomy__text {
+  color: var(--zen-color-text-default);
+}
+.ds-anatomy__vector,
+.ds-anatomy__image {
+  display: inline-block;
+  flex: none;
+  min-width: var(--zen-size-md);
+  min-height: var(--zen-size-md);
+  background: var(--zen-color-neutral-100);
+  border-radius: var(--zen-border-radius-xs);
+}
+.ds-anatomy__image {
+  min-width: var(--zen-size-lg);
+  min-height: var(--zen-size-lg);
+}

--- a/plugins/actian-design-system/scripts/renderers/html-renderers/ds-html-map.js
+++ b/plugins/actian-design-system/scripts/renderers/html-renderers/ds-html-map.js
@@ -134,6 +134,22 @@
     return items[0];
   }
 
+  // Anatomy map for non-override slugs. Two supply paths:
+  //   • browser deliverable — embedded as window.__dsAnatomyMap (assemble-time)
+  //   • server-side (Node) — the canonical flow-share deliverable pre-renders
+  //     screens in Node where `window` is undefined, so the assembler injects the
+  //     map here via setAnatomyMap() before rendering and clears it after.
+  var _serverAnatomyMap = null;
+
+  /**
+   * setAnatomyMap(map) — supply the assemble-time anatomy map for server-side
+   * rendering. Pass a plain object { slug → htmlString }, or null/undefined to
+   * clear it (callers MUST reset after a render so state never leaks).
+   */
+  function setAnatomyMap(map) {
+    _serverAnatomyMap = map && typeof map === "object" ? map : null;
+  }
+
   /**
    * renderDSComponent(node)
    * node = { type: 'INSTANCE', library: 'ds', dsSlug: 'button', variant: '...', props: {...}, name: '...' }
@@ -1297,11 +1313,14 @@
         }
 
         default: {
-          // Anatomy dispatch: if an assemble-time anatomy map was embedded,
-          // look up the pre-rendered HTML. Only available in the browser
-          // (window exists); server-side rendering falls through to chip.
+          // Anatomy dispatch: if an assemble-time anatomy map was supplied,
+          // look up the pre-rendered HTML. Browser deliverables embed it on
+          // window.__dsAnatomyMap; server-side (Node) rendering reads the map
+          // injected via setAnatomyMap(). Either path → fall through to chip.
           var m =
-            (typeof window !== "undefined" && window.__dsAnatomyMap) || {};
+            (typeof window !== "undefined" && window.__dsAnatomyMap) ||
+            _serverAnatomyMap ||
+            {};
           if (m[slug]) return m[slug];
           // Unmapped slug with no anatomy: a clean labeled chip.
           return gracefulChip();
@@ -1348,6 +1367,7 @@
   ];
 
   exports.renderDSComponent = renderDSComponent;
+  exports.setAnatomyMap = setAnatomyMap;
   exports.renderIcon = renderIcon;
   exports.esc = esc;
   exports.parseVariant = parseVariant;

--- a/plugins/actian-design-system/scripts/renderers/html-renderers/ds-html-map.js
+++ b/plugins/actian-design-system/scripts/renderers/html-renderers/ds-html-map.js
@@ -993,6 +993,309 @@
           );
         }
 
+        // ── Hi-Fi Slice 1 (Task 4): transform-target leaves ──────────────
+        // These 8 slugs chip-degraded before. Each renders a tokens-only leaf
+        // from its registry variant axes + Figma anatomy part-tree.
+
+        case "notification": {
+          // Registry axis: Type = Default | Critical.
+          // Anatomy: container[Type]{ text[message], instance[Button] } — an
+          // inline banner with a message + a single action button. Mirrors the
+          // alert-banner idiom; Critical → role=alert (like Danger).
+          var notifTypeRaw = (v.Type || "Default").toLowerCase();
+          var notifCritical = notifTypeRaw === "critical";
+          var notifCls =
+            "ds-notification" +
+            (notifCritical ? " ds-notification--critical" : "");
+          var notifRole = notifCritical ? "alert" : "status";
+          var notifMsg = esc(props.Message || "");
+          // Action button is optional — only render when an Action label exists.
+          var notifAction = props.Action
+            ? '<button class="ds-button ds-button--tertiary ds-button--small ds-notification__action" type="button">' +
+              esc(props.Action) +
+              "</button>"
+            : "";
+          return (
+            '<div class="' +
+            notifCls +
+            '" role="' +
+            notifRole +
+            '">' +
+            '<span class="ds-notification__icon">' +
+            renderIcon(notifCritical ? "error-filled" : "info-filled") +
+            "</span>" +
+            '<p class="ds-notification__message">' +
+            notifMsg +
+            "</p>" +
+            notifAction +
+            "</div>"
+          );
+        }
+
+        case "stepper": {
+          // Registry axis: State = Complete | Active | Default (Incomplete) | …
+          // Anatomy: container[State]{ container[Status]{number}, container[Text]
+          // {Title, Body} } — a numbered status circle + title/body. Complete
+          // swaps the number for a check glyph.
+          var stepStateRaw = (v.State || "Default").toLowerCase();
+          var stepComplete = stepStateRaw === "complete";
+          var stepActive = stepStateRaw === "active";
+          var stepperCls = "ds-stepper";
+          if (stepComplete) stepperCls += " ds-stepper--complete";
+          else if (stepActive) stepperCls += " ds-stepper--active";
+          var stepStatus = stepComplete
+            ? '<span class="ds-stepper__check">' +
+              renderIcon("simple-check") +
+              "</span>"
+            : esc(props.Step || "");
+          var stepBody = props.Body
+            ? '<span class="ds-stepper__body">' + esc(props.Body) + "</span>"
+            : "";
+          return (
+            '<div class="' +
+            stepperCls +
+            '">' +
+            '<span class="ds-stepper__status">' +
+            stepStatus +
+            "</span>" +
+            '<span class="ds-stepper__text">' +
+            '<span class="ds-stepper__title">' +
+            esc(props.Title || "") +
+            "</span>" +
+            stepBody +
+            "</span>" +
+            "</div>"
+          );
+        }
+
+        case "tooltip": {
+          // Registry axis: Type = Default. Anatomy: container[Type]{ text[Body] }
+          // — a small text bubble. role=tooltip for assistive tech.
+          return (
+            '<div class="ds-tooltip" role="tooltip">' +
+            '<span class="ds-tooltip__body">' +
+            esc(props.Body || "") +
+            "</span>" +
+            '<span class="ds-tooltip__arrow" aria-hidden="true"></span>' +
+            "</div>"
+          );
+        }
+
+        case "input-date": {
+          // Registry axes: Type = Single date | Date range; States = Enabled |
+          // Disabled | Error | … . Anatomy: container{ container[Label]{text},
+          // container[Input + icon button]{ inputfield, instance[Button] } } —
+          // a labeled date input with a trailing calendar icon button. Mirrors
+          // the .ds-field/.ds-input idiom; Date range adds a second input.
+          var dateRange = v.Type === "Date range";
+          var dateDisabled = v.States === "Disabled";
+          var dateCls = "ds-input-date";
+          if (dateRange) dateCls += " ds-input-date--range";
+          if (dateDisabled) dateCls += " is-disabled";
+          var datePlaceholder = esc(props["Placeholder text"] || "MM/DD/YYYY");
+          function dateInput() {
+            return (
+              '<div class="ds-input-date__field">' +
+              '<span class="ds-input-date__value">' +
+              datePlaceholder +
+              "</span>" +
+              '<span class="ds-input-date__calendar" aria-hidden="true">' +
+              renderIcon("calendar-2") +
+              "</span>" +
+              "</div>"
+            );
+          }
+          var dateInputs = dateRange
+            ? dateInput() +
+              '<span class="ds-input-date__sep">–</span>' +
+              dateInput()
+            : dateInput();
+          var dateHelper = props.Helper
+            ? '<span class="ds-input-date__helper">' +
+              esc(props.Helper) +
+              "</span>"
+            : "";
+          return (
+            '<div class="' +
+            dateCls +
+            '">' +
+            '<div class="ds-input-date__label-row"><span class="ds-input-date__label">' +
+            esc(props.Label || "Date") +
+            "</span></div>" +
+            '<div class="ds-input-date__inputs">' +
+            dateInputs +
+            "</div>" +
+            dateHelper +
+            "</div>"
+          );
+        }
+
+        case "rich-text": {
+          // Registry axis: State = Default | Expanded. Anatomy: container[State]{
+          // container[Toolbar]{ container[Left toolbar], container[Right toolbar]
+          // } } — an editor toolbar shell with grouped controls. Expanded shows
+          // a content area below the toolbar.
+          var rtExpanded = v.State === "Expanded";
+          var rtCls =
+            "ds-rich-text" + (rtExpanded ? " ds-rich-text--expanded" : "");
+          function rtBtn(iconSlug, label) {
+            return (
+              '<button class="ds-rich-text__btn" type="button" aria-label="' +
+              esc(label) +
+              '">' +
+              renderIcon(iconSlug) +
+              "</button>"
+            );
+          }
+          var rtLeft =
+            '<div class="ds-rich-text__group ds-rich-text__group--left">' +
+            rtBtn("text-type", "Text style") +
+            rtBtn("list-bullets", "Bulleted list") +
+            rtBtn("list-numbers", "Numbered list") +
+            "</div>";
+          var rtRight =
+            '<div class="ds-rich-text__group ds-rich-text__group--right">' +
+            rtBtn("link-type", "Insert link") +
+            "</div>";
+          var rtBody = rtExpanded
+            ? '<div class="ds-rich-text__content" aria-label="Editor"></div>'
+            : "";
+          return (
+            '<div class="' +
+            rtCls +
+            '">' +
+            '<div class="ds-rich-text__toolbar">' +
+            rtLeft +
+            rtRight +
+            "</div>" +
+            rtBody +
+            "</div>"
+          );
+        }
+
+        case "dropdown-select-default": {
+          // Registry axes: Type = Default | Search/Multiple | …; State = Default |
+          // Disabled | Focus | … . Anatomy: container{ container[Label + desc],
+          // container[input field]{ value, chevron }, text[helper] } — a labeled
+          // select with an input field + optional helper. Mirrors .ds-field idiom.
+          var ddDisabled = v.State === "Disabled";
+          var ddCls = "ds-dropdown-select";
+          if (ddDisabled) ddCls += " is-disabled";
+          var ddDesc = props.Description
+            ? '<span class="ds-dropdown-select__desc">' +
+              esc(props.Description) +
+              "</span>"
+            : "";
+          var ddValueText = props.Value;
+          var ddValueCls =
+            "ds-dropdown-select__value" +
+            (ddValueText ? "" : " ds-dropdown-select__value--placeholder");
+          var ddValue = esc(ddValueText || props.Placeholder || "Select…");
+          var ddHelper = props.Helper
+            ? '<span class="ds-dropdown-select__helper">' +
+              esc(props.Helper) +
+              "</span>"
+            : "";
+          return (
+            '<div class="' +
+            ddCls +
+            '">' +
+            '<div class="ds-dropdown-select__label-row">' +
+            '<span class="ds-dropdown-select__label">' +
+            esc(props.Label || "Label") +
+            "</span>" +
+            ddDesc +
+            "</div>" +
+            '<div class="ds-dropdown-select__field">' +
+            '<span class="' +
+            ddValueCls +
+            '">' +
+            ddValue +
+            "</span>" +
+            '<span class="ds-dropdown-select__chevron" aria-hidden="true">' +
+            renderIcon("chevron-up", { rotate: 180 }) +
+            "</span>" +
+            "</div>" +
+            ddHelper +
+            "</div>"
+          );
+        }
+
+        case "progress-bar-small": {
+          // Registry axes: Size = Default | Large; Completeness = 0% | 50% | 100%.
+          // Anatomy: container{ container[Bar]{ vector[fill] }, text[percent] } —
+          // a track with a clamped fill + a percent label. Completeness drives the
+          // default fill width; an explicit Percent prop overrides it.
+          var pbLarge = v.Size === "Large";
+          var pbCls = "ds-progress" + (pbLarge ? " ds-progress--large" : "");
+          // Resolve percent: explicit prop wins, else the Completeness variant,
+          // else 0. Parse to a number and clamp to [0, 100].
+          var pbRaw =
+            props.Percent != null && props.Percent !== ""
+              ? props.Percent
+              : v.Completeness;
+          var pbNum = parseInt(
+            String(pbRaw || "0").replace(/[^0-9.-]/g, ""),
+            10,
+          );
+          if (isNaN(pbNum)) pbNum = 0;
+          if (pbNum < 0) pbNum = 0;
+          if (pbNum > 100) pbNum = 100;
+          return (
+            '<div class="' +
+            pbCls +
+            '">' +
+            '<div class="ds-progress__track" role="progressbar" aria-valuemin="0" aria-valuemax="100" aria-valuenow="' +
+            pbNum +
+            '">' +
+            '<span class="ds-progress__fill" style="width:' +
+            pbNum +
+            '%"></span>' +
+            "</div>" +
+            '<span class="ds-progress__percent">' +
+            pbNum +
+            "%</span>" +
+            "</div>"
+          );
+        }
+
+        case "tag-interactive": {
+          // Registry axis: State = Default | Hovered | Selected | Disabled | …
+          // Anatomy: container[State]{ instance[Leading icon], text[Tag-Name],
+          // instance[Trailing icon] } — a tag/chip with optional leading + a
+          // removable trailing control. Mirrors the .ds-tag idiom + state mods.
+          var tiStateRaw = (v.State || "Default").toLowerCase();
+          var tiCls = "ds-tag-interactive";
+          if (tiStateRaw === "selected")
+            tiCls += " ds-tag-interactive--selected";
+          if (tiStateRaw === "disabled") tiCls += " is-disabled";
+          // Leading icon defaults on (anatomy shows one); honor an explicit false.
+          var tiShowLead = props["Leading icon show"] !== false;
+          var tiLead = tiShowLead
+            ? '<span class="ds-tag-interactive__icon ds-tag-interactive__icon--lead">' +
+              renderIcon("directory") +
+              "</span>"
+            : "";
+          // Trailing control defaults on (interactive = removable); honor false.
+          var tiShowTrail = props["Trailing icon show"] !== false;
+          var tiTrail = tiShowTrail
+            ? '<button class="ds-tag-interactive__remove" type="button" aria-label="Remove">' +
+              renderIcon("close") +
+              "</button>"
+            : "";
+          return (
+            '<span class="' +
+            tiCls +
+            '">' +
+            tiLead +
+            '<span class="ds-tag-interactive__label">' +
+            esc(props.Label || "") +
+            "</span>" +
+            tiTrail +
+            "</span>"
+          );
+        }
+
         default: {
           // Anatomy dispatch: if an assemble-time anatomy map was embedded,
           // look up the pre-rendered HTML. Only available in the browser
@@ -1033,6 +1336,15 @@
     "empty-state",
     "alert-banner",
     "chat-with-ai-steward",
+    // Hi-Fi Slice 1 (Task 4): transform-target leaves
+    "notification",
+    "stepper",
+    "tooltip",
+    "input-date",
+    "rich-text",
+    "dropdown-select-default",
+    "progress-bar-small",
+    "tag-interactive",
   ];
 
   exports.renderDSComponent = renderDSComponent;

--- a/plugins/actian-design-system/scripts/renderers/html-renderers/ds-html-map.js
+++ b/plugins/actian-design-system/scripts/renderers/html-renderers/ds-html-map.js
@@ -994,7 +994,13 @@
         }
 
         default: {
-          // Unmapped slug: a clean labeled chip using the human name.
+          // Anatomy dispatch: if an assemble-time anatomy map was embedded,
+          // look up the pre-rendered HTML. Only available in the browser
+          // (window exists); server-side rendering falls through to chip.
+          var m =
+            (typeof window !== "undefined" && window.__dsAnatomyMap) || {};
+          if (m[slug]) return m[slug];
+          // Unmapped slug with no anatomy: a clean labeled chip.
           return gracefulChip();
         }
       }

--- a/plugins/actian-design-system/tests/integration/ds-coverage.test.js
+++ b/plugins/actian-design-system/tests/integration/ds-coverage.test.js
@@ -48,18 +48,10 @@ var DS_HTML_MAP = path.join(
 
 // Slugs reachable from the map but not yet built as hi-fi renderers. SHRINK this
 // as phases land (P1 forms, P2 display/feedback, P3 chrome). Empty = full parity.
-var NOT_YET_IMPLEMENTED = new Set([
-  // P1 — forms core
-  "dropdown-select-default",
-  "input-date",
-  "rich-text",
-  // P2 — display / feedback
-  "tag-interactive",
-  "notification",
-  "progress-bar-small",
-  "tooltip",
-  "stepper",
-]);
+// Hi-Fi Slice 1 (Task 4) built all previously-deferred slugs (notification,
+// stepper, tooltip, input-date, rich-text, dropdown-select-default,
+// progress-bar-small, tag-interactive) → empty = full conversion-reachable parity.
+var NOT_YET_IMPLEMENTED = new Set([]);
 
 function reachableDsSlugs() {
   var map = JSON.parse(fs.readFileSync(MAP, "utf8"));

--- a/plugins/actian-design-system/tests/integration/flow-share-anatomy.test.js
+++ b/plugins/actian-design-system/tests/integration/flow-share-anatomy.test.js
@@ -1,0 +1,90 @@
+"use strict";
+
+// flow-share-anatomy.test.js — End-to-end proof that the CANONICAL flow-share
+// deliverable renders non-override DS slugs as anatomy HTML (not a gray chip).
+// This exercises both fixes together:
+//   C2 — the map is collected from content-shaped flow-data (screens[].content)
+//   C1 — the map is consumed server-side (flow-share pre-renders in Node, where
+//        there is no window) via ds-html-map.setAnatomyMap().
+// Markers: anatomy emits  data-ds-slug="<slug>";  the chip emits  data-slug="<slug>".
+// We assert on those (NOT a bare "ds-anatomy" substring, which also appears in
+// the inlined ds-base.css and would mask a chip regression).
+
+var { describe, it } = require("node:test");
+var assert = require("node:assert");
+
+var {
+  assembleFlowShare,
+} = require("../../scripts/renderers/assemble-flow-share.js");
+var {
+  collectDsSlugs,
+  buildDsAnatomyMap,
+} = require("../../scripts/renderers/ds-anatomy-map.js");
+var ds = require("../../scripts/renderers/html-renderers/ds-html-map.js");
+
+// A non-override DS slug with usable vendored anatomy (quality.ratio >= 0.6).
+var ANATOMY_SLUG = "link";
+
+function fixture() {
+  return {
+    meta: { library: "ds", app: "Test App", feature: "Anatomy wiring" },
+    screens: [
+      {
+        name: "Screen 1",
+        library: "ds",
+        content: [
+          { type: "INSTANCE", library: "ds", dsSlug: ANATOMY_SLUG, props: {} },
+        ],
+      },
+    ],
+  };
+}
+
+describe("flow-share: server-side anatomy rendering (C1 + C2)", function () {
+  it("precondition: chosen slug is non-override and has usable anatomy", function () {
+    var slugs = collectDsSlugs(fixture());
+    assert.ok(
+      slugs.indexOf(ANATOMY_SLUG) !== -1,
+      "collectDsSlugs must find the content-shaped slug",
+    );
+    var map = buildDsAnatomyMap(slugs);
+    assert.ok(
+      map[ANATOMY_SLUG],
+      "substrate must yield anatomy HTML for '" +
+        ANATOMY_SLUG +
+        "' — if this fails the slug became an override or lost anatomy; pick another non-override slug",
+    );
+  });
+
+  it("renders the non-override slug as anatomy HTML, not a chip", function () {
+    var html = assembleFlowShare(fixture());
+    assert.ok(
+      html.indexOf('data-ds-slug="' + ANATOMY_SLUG + '"') !== -1,
+      "anatomy HTML (data-ds-slug) must be present in flow-share output",
+    );
+    assert.strictEqual(
+      html.indexOf('data-slug="' + ANATOMY_SLUG + '"'),
+      -1,
+      "the slug must NOT fall back to a chip (data-slug)",
+    );
+  });
+
+  it("does not leak the server anatomy map after assembly", function () {
+    // After assembleFlowShare returns, a server-side render of the same slug with
+    // no window must chip — proving setAnatomyMap was reset (no cross-call state).
+    assembleFlowShare(fixture());
+    var prev = typeof global.window !== "undefined" ? global.window : undefined;
+    delete global.window;
+    var html = ds.renderDSComponent({
+      type: "INSTANCE",
+      library: "ds",
+      dsSlug: ANATOMY_SLUG,
+      props: {},
+    });
+    if (prev !== undefined) global.window = prev;
+    assert.ok(
+      html.indexOf("ds-component") !== -1,
+      "slug must chip after assembly (server map was reset)",
+    );
+  });
+});

--- a/plugins/actian-design-system/tests/renderers/anatomy-render.test.js
+++ b/plugins/actian-design-system/tests/renderers/anatomy-render.test.js
@@ -1,0 +1,50 @@
+#!/usr/bin/env node
+"use strict";
+var { describe, it } = require("node:test");
+var assert = require("node:assert");
+var path = require("path");
+var { renderAnatomy } = require(path.resolve(__dirname, "..", "..", "scripts", "renderers", "anatomy-render.js"));
+
+var GOOD = { slug: "x", quality: { ratio: 0.9 }, root: {
+  name: "root", kind: "container", layout: { axis: "row", gap: "8px", padding: { top: "0px", right: "12px", bottom: "0px", left: "12px" }, align: { main: "center", cross: "center" } },
+  children: [ { name: "label", kind: "text" }, { name: "icon", kind: "vector" } ] } };
+
+describe("anatomy-render", function () {
+  var loader = function () { return GOOD; };
+  it("renders a container with flex layout + nested text/vector parts", function () {
+    var html = renderAnatomy("x", { loader: loader });
+    assert.ok(html.indexOf("ds-anatomy") !== -1);
+    assert.ok(html.indexOf("display:flex") !== -1 && html.indexOf("flex-direction:row") !== -1);
+    assert.ok(html.indexOf("gap:8px") !== -1 && html.indexOf("padding:0px 12px 0px 12px") !== -1);
+    assert.ok(html.indexOf("ds-anatomy__text") !== -1 && html.indexOf("ds-anatomy__vector") !== -1);
+  });
+  it("returns null when ratio < minRatio", function () {
+    assert.strictEqual(renderAnatomy("x", { loader: function () { return { quality: { ratio: 0.4 }, root: GOOD.root }; } }), null);
+  });
+  it("returns null when missing/no root", function () {
+    assert.strictEqual(renderAnatomy("x", { loader: function () { return null; } }), null);
+    assert.strictEqual(renderAnatomy("x", { loader: function () { return { quality: { ratio: 0.9 } }; } }), null);
+  });
+  it("escapes text content (XSS-safe)", function () {
+    var html = renderAnatomy("x", { loader: function () { return { quality: { ratio: 0.9 }, root: { kind: "text", text: "<script>" } }; } });
+    assert.ok(html.indexOf("<script>") === -1 && html.indexOf("&lt;script&gt;") !== -1);
+  });
+  it("is deterministic", function () {
+    assert.strictEqual(renderAnatomy("x", { loader: loader }), renderAnatomy("x", { loader: loader }));
+  });
+  it("applies binding classes and cssVars to root wrapper", function () {
+    var binding = { classes: ["ds--state-disabled"], cssVars: { background: "var(--zen-color-x)" } };
+    var html = renderAnatomy("x", { loader: loader, binding: binding });
+    assert.ok(html.indexOf("ds--state-disabled") !== -1, "root div should contain binding class");
+    assert.ok(html.indexOf("background:var(--zen-color-x)") !== -1, "root div should contain cssVar style");
+  });
+  it("is neutral (no style= or binding classes) when no binding provided", function () {
+    var html = renderAnatomy("x", { loader: loader });
+    // Root wrapper should have no style attribute and no ds-- binding class
+    var rootDivMatch = html.match(/^<div[^>]*>/);
+    assert.ok(rootDivMatch, "html should start with a root div");
+    var rootDiv = rootDivMatch[0];
+    assert.ok(rootDiv.indexOf("style=") === -1, "root div should have no style attribute when no binding");
+    assert.ok(rootDiv.indexOf("ds--") === -1, "root div should have no ds-- binding class when no binding");
+  });
+});

--- a/plugins/actian-design-system/tests/renderers/ds-anatomy-css.test.js
+++ b/plugins/actian-design-system/tests/renderers/ds-anatomy-css.test.js
@@ -1,0 +1,70 @@
+"use strict";
+
+// ds-anatomy-css.test.js — I1: the anatomy structural floor must be visible.
+// anatomy-render.js emits aria-hidden <div class="ds-anatomy__image|__vector">
+// media boxes that render 0x0 without CSS, and a .ds-anatomy wrapper with no
+// neutral surface. Assert ds-base.css sizes the media slots and fills them from
+// tokens (no hardcoded color — DS rule: 100% token binding).
+
+var { describe, it } = require("node:test");
+var assert = require("node:assert");
+var fs = require("fs");
+var path = require("path");
+
+var CSS = fs.readFileSync(
+  path.join(__dirname, "../../scripts/renderers/html-renderers/ds-base.css"),
+  "utf8",
+);
+
+// Every CSS rule block whose selector list mentions ds-anatomy.
+function anatomyBlocks() {
+  var re = /([^{}]*ds-anatomy[^{}]*)\{([^}]*)\}/g;
+  var blocks = [];
+  var m;
+  while ((m = re.exec(CSS))) {
+    blocks.push({ selector: m[1].trim(), body: m[2] });
+  }
+  return blocks;
+}
+
+describe("ds-base.css: anatomy structural floor (I1)", function () {
+  it("media placeholders (__image/__vector) are sized so they are visible", function () {
+    var media = anatomyBlocks().filter(function (b) {
+      return /ds-anatomy__(image|vector)/.test(b.selector);
+    });
+    assert.ok(
+      media.length > 0,
+      "ds-base.css must style .ds-anatomy__image / .ds-anatomy__vector",
+    );
+    var body = media
+      .map(function (b) {
+        return b.body;
+      })
+      .join("\n");
+    assert.ok(
+      /(min-width|width|min-height|height|min-block-size|block-size|inline-size)\s*:/.test(
+        body,
+      ),
+      "media placeholders must declare a non-zero dimension (else they render 0x0)",
+    );
+    assert.ok(
+      /background[^;]*:\s*var\(--zen-/.test(body),
+      "media placeholders must have a token-bound neutral fill",
+    );
+  });
+
+  it("anatomy rules are tokens-only (no hardcoded color)", function () {
+    var blocks = anatomyBlocks();
+    assert.ok(blocks.length > 0, "expected .ds-anatomy rules to exist");
+    blocks.forEach(function (b) {
+      assert.ok(
+        !/#[0-9a-fA-F]{3,8}\b/.test(b.body),
+        "no hardcoded hex in anatomy rule: " + b.selector,
+      );
+      assert.ok(
+        !/\b(rgb|rgba|hsl|hsla)\(/.test(b.body),
+        "no hardcoded rgb/hsl in anatomy rule: " + b.selector,
+      );
+    });
+  });
+});

--- a/plugins/actian-design-system/tests/renderers/ds-anatomy-map.test.js
+++ b/plugins/actian-design-system/tests/renderers/ds-anatomy-map.test.js
@@ -1,12 +1,16 @@
 "use strict";
 
-// ds-anatomy-map.test.js — Tests for the buildDsAnatomyMap helper in assemble-preview.js.
-// Verifies: override exclusion, anatomy+binding integration, null-anatomy exclusion.
+// ds-anatomy-map.test.js — Tests for the ds-anatomy-map helpers.
+// Verifies: collectDsSlugs (content-shaped traversal), buildDsAnatomyMap
+// (override exclusion, anatomy+binding integration, null-anatomy exclusion).
 
 var { describe, it } = require("node:test");
 var assert = require("node:assert");
 
-var { buildDsAnatomyMap } = require("../../scripts/renderers/assemble-preview.js");
+var {
+  buildDsAnatomyMap,
+  collectDsSlugs,
+} = require("../../scripts/renderers/ds-anatomy-map.js");
 
 // Minimal anatomy data fixture (quality.ratio = 0.9, has a root node)
 var GOOD_ANATOMY = {
@@ -22,6 +26,51 @@ var GOOD_ANATOMY = {
   },
 };
 
+describe("collectDsSlugs", function () {
+  it("collects dsSlugs from real content-shaped screens (screens[].content)", function () {
+    // Real flow-data carries nodes under screens[].content, NOT .frames.
+    var data = {
+      screens: [
+        {
+          name: "Screen 1",
+          content: [
+            { dsSlug: "actian-data-intelligence" },
+            {
+              dsSlug: "card-for-items",
+              children: [{ dsSlug: "avatar" }],
+            },
+          ],
+        },
+        { name: "Screen 2", content: [{ dsSlug: "spinner" }] },
+      ],
+    };
+    var slugs = collectDsSlugs(data);
+    assert.deepEqual(slugs.sort(), [
+      "actian-data-intelligence",
+      "avatar",
+      "card-for-items",
+      "spinner",
+    ]);
+  });
+
+  it("dedupes slugs that appear on multiple screens/nodes", function () {
+    var data = {
+      screens: [
+        { content: [{ dsSlug: "spinner" }, { dsSlug: "spinner" }] },
+        { content: [{ dsSlug: "spinner" }] },
+      ],
+    };
+    assert.deepEqual(collectDsSlugs(data), ["spinner"]);
+  });
+
+  it("returns [] for empty / missing data without throwing", function () {
+    assert.deepEqual(collectDsSlugs(null), []);
+    assert.deepEqual(collectDsSlugs({}), []);
+    assert.deepEqual(collectDsSlugs({ screens: [] }), []);
+    assert.deepEqual(collectDsSlugs({ screens: [{}] }), []);
+  });
+});
+
 describe("buildDsAnatomyMap", function () {
   it("override slug is EXCLUDED from the map", function () {
     // 'button' is in BUILT_SLUGS → must be excluded even if anatomy loader has it
@@ -36,7 +85,10 @@ describe("buildDsAnatomyMap", function () {
       tokenBindingsLoader: tokenBindingsLoader,
     });
     assert.ok(!("button" in map), "override slug must be excluded from map");
-    assert.ok("spinner" in map, "non-override slug with good anatomy is included");
+    assert.ok(
+      "spinner" in map,
+      "non-override slug with good anatomy is included",
+    );
   });
 
   it("non-override slug with good anatomy + token binding → map[slug] contains bound cssVar", function () {
@@ -97,6 +149,9 @@ describe("buildDsAnatomyMap", function () {
         return [];
       },
     });
-    assert.ok("spinner" in map, "spinner included when not in custom builtSlugs");
+    assert.ok(
+      "spinner" in map,
+      "spinner included when not in custom builtSlugs",
+    );
   });
 });

--- a/plugins/actian-design-system/tests/renderers/ds-anatomy-map.test.js
+++ b/plugins/actian-design-system/tests/renderers/ds-anatomy-map.test.js
@@ -1,0 +1,102 @@
+"use strict";
+
+// ds-anatomy-map.test.js — Tests for the buildDsAnatomyMap helper in assemble-preview.js.
+// Verifies: override exclusion, anatomy+binding integration, null-anatomy exclusion.
+
+var { describe, it } = require("node:test");
+var assert = require("node:assert");
+
+var { buildDsAnatomyMap } = require("../../scripts/renderers/assemble-preview.js");
+
+// Minimal anatomy data fixture (quality.ratio = 0.9, has a root node)
+var GOOD_ANATOMY = {
+  quality: { ratio: 0.9 },
+  root: {
+    kind: "container",
+    layout: {
+      axis: "row",
+      gap: "8px",
+      padding: { top: "0px", right: "0px", bottom: "0px", left: "0px" },
+    },
+    children: [{ kind: "text", text: "Label" }],
+  },
+};
+
+describe("buildDsAnatomyMap", function () {
+  it("override slug is EXCLUDED from the map", function () {
+    // 'button' is in BUILT_SLUGS → must be excluded even if anatomy loader has it
+    var anatomyLoader = function (slug) {
+      return GOOD_ANATOMY;
+    };
+    var tokenBindingsLoader = function () {
+      return [];
+    };
+    var map = buildDsAnatomyMap(["button", "spinner"], {
+      anatomyLoader: anatomyLoader,
+      tokenBindingsLoader: tokenBindingsLoader,
+    });
+    assert.ok(!("button" in map), "override slug must be excluded from map");
+    assert.ok("spinner" in map, "non-override slug with good anatomy is included");
+  });
+
+  it("non-override slug with good anatomy + token binding → map[slug] contains bound cssVar", function () {
+    // Inject a fake token binding for 'spinner' to prove the binding seam is wired
+    var anatomyLoader = function (slug) {
+      return GOOD_ANATOMY;
+    };
+    var tokenBindingsLoader = function (slug) {
+      if (slug === "spinner")
+        return [{ token: "--zen-color-primary-500", context: "background" }];
+      return [];
+    };
+    var map = buildDsAnatomyMap(["spinner"], {
+      anatomyLoader: anatomyLoader,
+      tokenBindingsLoader: tokenBindingsLoader,
+    });
+    assert.ok("spinner" in map, "spinner must be in map");
+    assert.ok(
+      map["spinner"].indexOf("background:var(--zen-color-primary-500)") !== -1,
+      "map entry must contain the bound cssVar (background:var(--zen-color-primary-500))",
+    );
+  });
+
+  it("non-override slug whose anatomy loader returns null → EXCLUDED from map", function () {
+    var anatomyLoader = function () {
+      return null;
+    };
+    var tokenBindingsLoader = function () {
+      return [];
+    };
+    var map = buildDsAnatomyMap(["spinner"], {
+      anatomyLoader: anatomyLoader,
+      tokenBindingsLoader: tokenBindingsLoader,
+    });
+    assert.ok(!("spinner" in map), "null anatomy → slug excluded from map");
+  });
+
+  it("empty slug list returns empty map", function () {
+    var map = buildDsAnatomyMap([], {
+      anatomyLoader: function () {
+        return GOOD_ANATOMY;
+      },
+      tokenBindingsLoader: function () {
+        return [];
+      },
+    });
+    assert.deepEqual(map, {});
+  });
+
+  it("can override BUILT_SLUGS list via opts.builtSlugs", function () {
+    // With a custom builtSlugs that excludes 'spinner', spinner should be included
+    var map = buildDsAnatomyMap(["spinner"], {
+      builtSlugs: [],
+      anatomyLoader: function () {
+        return GOOD_ANATOMY;
+      },
+      tokenBindingsLoader: function () {
+        return [];
+      },
+    });
+    assert.ok("spinner" in map, "spinner included when not in custom builtSlugs");
+  });
+});

--- a/plugins/actian-design-system/tests/renderers/ds-coverage-report.test.js
+++ b/plugins/actian-design-system/tests/renderers/ds-coverage-report.test.js
@@ -3,27 +3,57 @@
 var { describe, it } = require("node:test");
 var assert = require("node:assert");
 var path = require("path");
-var { coverage } = require(path.resolve(__dirname, "..", "..", "scripts", "renderers", "ds-coverage-report.js"));
+var { coverage } = require(
+  path.resolve(
+    __dirname,
+    "..",
+    "..",
+    "scripts",
+    "renderers",
+    "ds-coverage-report.js",
+  ),
+);
 
 describe("ds-coverage-report", function () {
   it("classifies override / anatomy / chip", function () {
     var rows = coverage(["button", "stepper", "weird"], {
       builtSlugs: ["button"],
-      anatomyLoader: function (s) { return s === "stepper" ? { quality: { ratio: 0.9 }, root: { kind: "container" } } : null; }
+      anatomyLoader: function (s) {
+        return s === "stepper"
+          ? { quality: { ratio: 0.9 }, root: { kind: "container" } }
+          : null;
+      },
     });
-    var by = {}; rows.forEach(function (r) { by[r.slug] = r.tier; });
+    var by = {};
+    rows.forEach(function (r) {
+      by[r.slug] = r.tier;
+    });
     assert.strictEqual(by["button"], "override");
     assert.strictEqual(by["stepper"], "anatomy");
     assert.strictEqual(by["weird"], "chip");
+  });
+
+  it("degraded with null ratio when spec has root but no quality", function () {
+    var rows = coverage(["alert"], {
+      builtSlugs: [],
+      anatomyLoader: function (s) {
+        if (s === "alert") return { root: { kind: "container" } };
+        return null;
+      },
+    });
+    assert.strictEqual(rows.length, 1);
+    assert.strictEqual(rows[0].tier, "degraded");
+    assert.strictEqual(rows[0].ratio, null);
   });
 
   it("classifies degraded (spec exists but ratio < minRatio)", function () {
     var rows = coverage(["badge"], {
       builtSlugs: [],
       anatomyLoader: function (s) {
-        if (s === "badge") return { quality: { ratio: 0.4 }, root: { kind: "container" } };
+        if (s === "badge")
+          return { quality: { ratio: 0.4 }, root: { kind: "container" } };
         return null;
-      }
+      },
     });
     assert.strictEqual(rows.length, 1);
     assert.strictEqual(rows[0].tier, "degraded");

--- a/plugins/actian-design-system/tests/renderers/ds-coverage-report.test.js
+++ b/plugins/actian-design-system/tests/renderers/ds-coverage-report.test.js
@@ -1,0 +1,32 @@
+#!/usr/bin/env node
+"use strict";
+var { describe, it } = require("node:test");
+var assert = require("node:assert");
+var path = require("path");
+var { coverage } = require(path.resolve(__dirname, "..", "..", "scripts", "renderers", "ds-coverage-report.js"));
+
+describe("ds-coverage-report", function () {
+  it("classifies override / anatomy / chip", function () {
+    var rows = coverage(["button", "stepper", "weird"], {
+      builtSlugs: ["button"],
+      anatomyLoader: function (s) { return s === "stepper" ? { quality: { ratio: 0.9 }, root: { kind: "container" } } : null; }
+    });
+    var by = {}; rows.forEach(function (r) { by[r.slug] = r.tier; });
+    assert.strictEqual(by["button"], "override");
+    assert.strictEqual(by["stepper"], "anatomy");
+    assert.strictEqual(by["weird"], "chip");
+  });
+
+  it("classifies degraded (spec exists but ratio < minRatio)", function () {
+    var rows = coverage(["badge"], {
+      builtSlugs: [],
+      anatomyLoader: function (s) {
+        if (s === "badge") return { quality: { ratio: 0.4 }, root: { kind: "container" } };
+        return null;
+      }
+    });
+    assert.strictEqual(rows.length, 1);
+    assert.strictEqual(rows[0].tier, "degraded");
+    assert.strictEqual(rows[0].ratio, 0.4);
+  });
+});

--- a/plugins/actian-design-system/tests/renderers/ds-html-map.test.js
+++ b/plugins/actian-design-system/tests/renderers/ds-html-map.test.js
@@ -2158,3 +2158,90 @@ describe("ds-html-map: chat-with-ai-steward (Task 11)", function () {
     assert.match(html, /ds-steward--drawer/);
   });
 });
+
+// ---------------------------------------------------------------------------
+// Task 3: dispatch override → anatomy → chip
+// ---------------------------------------------------------------------------
+
+describe("ds-html-map: dispatch override → anatomy → chip", function () {
+  it("non-override slug with embedded anatomy → anatomy html, not chip", function () {
+    // Stub window.__dsAnatomyMap with a fixture anatomy for a permanently-non-override slug
+    var prev = typeof global.window !== "undefined" ? global.window : undefined;
+    global.window = {
+      __dsAnatomyMap: {
+        "anatomy-only-fixture":
+          '<div class="ds-anatomy" data-ds-slug="anatomy-only-fixture"></div>',
+      },
+    };
+    var html = render({
+      type: "INSTANCE",
+      dsSlug: "anatomy-only-fixture",
+      props: {},
+    });
+    global.window = prev;
+    assert.ok(
+      html.indexOf("ds-anatomy") !== -1,
+      "embedded anatomy used for non-override slug",
+    );
+    assert.ok(
+      html.indexOf("ds-component") === -1,
+      "no graceful chip when anatomy present",
+    );
+  });
+
+  it("non-override slug, no anatomy → chip fallback", function () {
+    var prev = typeof global.window !== "undefined" ? global.window : undefined;
+    global.window = { __dsAnatomyMap: {} };
+    var html = render({
+      type: "INSTANCE",
+      dsSlug: "totally-unknown-slug",
+      props: {},
+    });
+    global.window = prev;
+    assert.ok(
+      html.indexOf("ds-component") !== -1,
+      "chip fallback when no anatomy",
+    );
+  });
+
+  it("override slug is NOT intercepted by anatomy map", function () {
+    // Even if anatomy map has an entry for a BUILT_SLUG, override wins
+    var prev = typeof global.window !== "undefined" ? global.window : undefined;
+    global.window = {
+      __dsAnatomyMap: {
+        button: '<div class="ds-anatomy" data-ds-slug="button"></div>',
+      },
+    };
+    var html = render({
+      type: "INSTANCE",
+      dsSlug: "button",
+      variant: "Type=Primary",
+      props: { Label: "Save" },
+    });
+    global.window = prev;
+    assert.ok(
+      html.indexOf("<button") === 0,
+      "override renders real button element",
+    );
+    assert.ok(html.indexOf("ds-button--primary") !== -1, "has primary class");
+    assert.ok(
+      html.indexOf("ds-anatomy") === -1,
+      "anatomy map NOT used for override slug",
+    );
+  });
+
+  it("no window → chip fallback (server-side safety)", function () {
+    var prev = typeof global.window !== "undefined" ? global.window : undefined;
+    delete global.window;
+    var html = render({
+      type: "INSTANCE",
+      dsSlug: "anatomy-only-fixture",
+      props: {},
+    });
+    if (prev !== undefined) global.window = prev;
+    assert.ok(
+      html.indexOf("ds-component") !== -1,
+      "chip when no window (no map available)",
+    );
+  });
+});

--- a/plugins/actian-design-system/tests/renderers/ds-html-map.test.js
+++ b/plugins/actian-design-system/tests/renderers/ds-html-map.test.js
@@ -2160,6 +2160,312 @@ describe("ds-html-map: chat-with-ai-steward (Task 11)", function () {
 });
 
 // ---------------------------------------------------------------------------
+// Hi-Fi Slice 1 — Task 4: 8 new override leaves (transform targets)
+// Each was chip-degrading before; now a full tokens-only leaf.
+// ---------------------------------------------------------------------------
+
+describe("ds-html-map: notification (Task 4)", function () {
+  it("renders a notification leaf — not a chip — with message + action", function () {
+    var html = render({
+      type: "INSTANCE",
+      library: "ds",
+      dsSlug: "notification",
+      props: {
+        Message: "Your export is ready to download.",
+        Action: "View",
+      },
+    });
+    assert.ok(
+      html.indexOf("ds-notification") !== -1,
+      "notification built leaf class",
+    );
+    assert.ok(html.indexOf("ds-component") === -1, "notification not a chip");
+    assert.ok(html.indexOf("Your export is ready") !== -1, "message text");
+    assert.ok(
+      html.indexOf("ds-button") !== -1 && html.indexOf("View") !== -1,
+      "action button reused",
+    );
+  });
+
+  it("Type=Critical adds the critical modifier and role=alert", function () {
+    var html = render({
+      type: "INSTANCE",
+      library: "ds",
+      dsSlug: "notification",
+      variant: "Type=Critical",
+      props: { Message: "Pipeline failed." },
+    });
+    assert.ok(
+      html.indexOf("ds-notification--critical") !== -1,
+      "critical modifier",
+    );
+    assert.ok(html.indexOf('role="alert"') !== -1, "critical uses role=alert");
+  });
+
+  it("escapes XSS in Message", function () {
+    var html = render({
+      type: "INSTANCE",
+      library: "ds",
+      dsSlug: "notification",
+      props: { Message: "<script>alert(1)</script>" },
+    });
+    assert.ok(html.indexOf("<script>") === -1, "script not injected");
+  });
+});
+
+describe("ds-html-map: stepper (Task 4)", function () {
+  it("renders a stepper leaf — not a chip — with number + title/body", function () {
+    var html = render({
+      type: "INSTANCE",
+      library: "ds",
+      dsSlug: "stepper",
+      variant: "State=Active",
+      props: { Step: "2", Title: "Configure source", Body: "Pick a dataset" },
+    });
+    assert.ok(html.indexOf("ds-stepper") !== -1, "stepper built leaf class");
+    assert.ok(html.indexOf("ds-component") === -1, "stepper not a chip");
+    assert.ok(
+      html.indexOf("ds-stepper--active") !== -1,
+      "active state modifier",
+    );
+    assert.ok(html.indexOf("Configure source") !== -1, "title text");
+    assert.ok(html.indexOf("Pick a dataset") !== -1, "body text");
+  });
+
+  it("State=Complete shows a check instead of the number", function () {
+    var html = render({
+      type: "INSTANCE",
+      library: "ds",
+      dsSlug: "stepper",
+      variant: "State=Complete",
+      props: { Step: "1", Title: "Connect" },
+    });
+    assert.ok(html.indexOf("ds-stepper--complete") !== -1, "complete modifier");
+    assert.ok(html.indexOf("ds-icon") !== -1, "complete renders a check glyph");
+  });
+});
+
+describe("ds-html-map: tooltip (Task 4)", function () {
+  it("renders a tooltip bubble — not a chip — with body text", function () {
+    var html = render({
+      type: "INSTANCE",
+      library: "ds",
+      dsSlug: "tooltip",
+      props: { Body: "Only admins can edit this field." },
+    });
+    assert.ok(html.indexOf("ds-tooltip") !== -1, "tooltip built leaf class");
+    assert.ok(html.indexOf("ds-component") === -1, "tooltip not a chip");
+    assert.ok(html.indexOf("Only admins") !== -1, "body text present");
+    assert.ok(html.indexOf('role="tooltip"') !== -1, "has tooltip role");
+  });
+});
+
+describe("ds-html-map: input-date (Task 4)", function () {
+  it("renders a date field — not a chip — label + input + calendar button", function () {
+    var html = render({
+      type: "INSTANCE",
+      library: "ds",
+      dsSlug: "input-date",
+      variant: "Type=Single date,States=Enabled",
+      props: { Label: "Start date", Helper: "MM/DD/YYYY" },
+    });
+    assert.ok(
+      html.indexOf("ds-input-date") !== -1,
+      "input-date built leaf class",
+    );
+    assert.ok(html.indexOf("ds-component") === -1, "input-date not a chip");
+    assert.ok(html.indexOf("Start date") !== -1, "label text");
+    assert.ok(
+      html.indexOf("ds-input-date__calendar") !== -1,
+      "calendar icon button",
+    );
+    assert.ok(html.indexOf("MM/DD/YYYY") !== -1, "helper text");
+  });
+
+  it("Type=Date range renders a second (end) input", function () {
+    var html = render({
+      type: "INSTANCE",
+      library: "ds",
+      dsSlug: "input-date",
+      variant: "Type=Date range,States=Enabled",
+      props: { Label: "Range" },
+    });
+    assert.ok(html.indexOf("ds-input-date--range") !== -1, "range modifier");
+  });
+
+  it("States=Disabled adds the disabled flag", function () {
+    var html = render({
+      type: "INSTANCE",
+      library: "ds",
+      dsSlug: "input-date",
+      variant: "States=Disabled",
+      props: { Label: "Start date" },
+    });
+    assert.ok(html.indexOf("is-disabled") !== -1, "disabled flag");
+  });
+});
+
+describe("ds-html-map: rich-text (Task 4)", function () {
+  it("renders an editor toolbar shell — not a chip — with grouped controls", function () {
+    var html = render({
+      type: "INSTANCE",
+      library: "ds",
+      dsSlug: "rich-text",
+      props: {},
+    });
+    assert.ok(
+      html.indexOf("ds-rich-text") !== -1,
+      "rich-text built leaf class",
+    );
+    assert.ok(html.indexOf("ds-component") === -1, "rich-text not a chip");
+    assert.ok(html.indexOf("ds-rich-text__toolbar") !== -1, "toolbar present");
+    assert.ok(html.indexOf("ds-icon") !== -1, "toolbar control glyphs");
+  });
+
+  it("State=Expanded adds the expanded modifier", function () {
+    var html = render({
+      type: "INSTANCE",
+      library: "ds",
+      dsSlug: "rich-text",
+      variant: "State=Expanded",
+      props: {},
+    });
+    assert.ok(
+      html.indexOf("ds-rich-text--expanded") !== -1,
+      "expanded modifier",
+    );
+  });
+});
+
+describe("ds-html-map: dropdown-select-default (Task 4)", function () {
+  it("renders a labeled select — not a chip — label + field + helper", function () {
+    var html = render({
+      type: "INSTANCE",
+      library: "ds",
+      dsSlug: "dropdown-select-default",
+      variant: "Type=Default,State=Default",
+      props: {
+        Label: "Connection",
+        Description: "Where data lives",
+        Helper: "Required",
+        Value: "Snowflake",
+      },
+    });
+    assert.ok(
+      html.indexOf("ds-dropdown-select") !== -1,
+      "dropdown-select built leaf class",
+    );
+    assert.ok(
+      html.indexOf("ds-component") === -1,
+      "dropdown-select not a chip",
+    );
+    assert.ok(html.indexOf("Connection") !== -1, "label text");
+    assert.ok(html.indexOf("Snowflake") !== -1, "selected value");
+    assert.ok(html.indexOf("Required") !== -1, "helper text");
+    assert.ok(html.indexOf("ds-icon") !== -1, "chevron glyph");
+  });
+
+  it("State=Disabled adds the disabled flag", function () {
+    var html = render({
+      type: "INSTANCE",
+      library: "ds",
+      dsSlug: "dropdown-select-default",
+      variant: "State=Disabled",
+      props: { Label: "Connection" },
+    });
+    assert.ok(html.indexOf("is-disabled") !== -1, "disabled flag");
+  });
+});
+
+describe("ds-html-map: progress-bar-small (Task 4)", function () {
+  it("renders a progress track + fill — not a chip — with percent label", function () {
+    var html = render({
+      type: "INSTANCE",
+      library: "ds",
+      dsSlug: "progress-bar-small",
+      variant: "Size=Default,Completeness=50%",
+      props: {},
+    });
+    assert.ok(
+      html.indexOf("ds-progress") !== -1,
+      "progress-bar built leaf class",
+    );
+    assert.ok(html.indexOf("ds-component") === -1, "progress-bar not a chip");
+    assert.ok(html.indexOf("ds-progress__fill") !== -1, "fill element");
+    assert.ok(html.indexOf("50%") !== -1, "percent label");
+    assert.ok(
+      html.indexOf('role="progressbar"') !== -1,
+      "has progressbar role",
+    );
+  });
+
+  it("Size=Large adds the large modifier and reads Percent prop", function () {
+    var html = render({
+      type: "INSTANCE",
+      library: "ds",
+      dsSlug: "progress-bar-small",
+      variant: "Size=Large,Completeness=100%",
+      props: { Percent: "100" },
+    });
+    assert.ok(html.indexOf("ds-progress--large") !== -1, "large modifier");
+    assert.ok(html.indexOf("100%") !== -1, "percent label");
+  });
+});
+
+describe("ds-html-map: tag-interactive (Task 4)", function () {
+  it("renders an interactive tag — not a chip — leading icon + name + trailing icon", function () {
+    var html = render({
+      type: "INSTANCE",
+      library: "ds",
+      dsSlug: "tag-interactive",
+      props: {
+        Label: "Production",
+        "Leading icon show": true,
+        "Trailing icon show": true,
+      },
+    });
+    assert.ok(
+      html.indexOf("ds-tag-interactive") !== -1,
+      "tag-interactive built leaf class",
+    );
+    assert.ok(
+      html.indexOf("ds-component") === -1,
+      "tag-interactive not a chip",
+    );
+    assert.ok(html.indexOf("Production") !== -1, "tag name");
+    assert.ok(
+      html.indexOf("ds-tag-interactive__remove") !== -1,
+      "trailing remove control",
+    );
+  });
+
+  it("State=Selected adds the selected modifier", function () {
+    var html = render({
+      type: "INSTANCE",
+      library: "ds",
+      dsSlug: "tag-interactive",
+      variant: "State=Selected",
+      props: { Label: "Active" },
+    });
+    assert.ok(
+      html.indexOf("ds-tag-interactive--selected") !== -1,
+      "selected modifier",
+    );
+  });
+
+  it("State=Disabled adds the disabled flag", function () {
+    var html = render({
+      type: "INSTANCE",
+      library: "ds",
+      dsSlug: "tag-interactive",
+      variant: "State=Disabled",
+      props: { Label: "Archived" },
+    });
+    assert.ok(html.indexOf("is-disabled") !== -1, "disabled flag");
+  });
+});
+
+// ---------------------------------------------------------------------------
 // Task 3: dispatch override → anatomy → chip
 // ---------------------------------------------------------------------------
 

--- a/plugins/actian-design-system/tests/renderers/ds-html-map.test.js
+++ b/plugins/actian-design-system/tests/renderers/ds-html-map.test.js
@@ -2495,6 +2495,52 @@ describe("ds-html-map: dispatch override → anatomy → chip", function () {
     );
   });
 
+  it("non-override slug with server-side anatomy map (no window) → anatomy html, not chip", function () {
+    // Server-side (Node) rendering has no window; the canonical flow-share
+    // deliverable pre-renders in Node, so the map is supplied via setAnatomyMap.
+    var prev = typeof global.window !== "undefined" ? global.window : undefined;
+    delete global.window;
+    ds.setAnatomyMap({
+      "anatomy-only-fixture":
+        '<div class="ds-anatomy" data-ds-slug="anatomy-only-fixture"></div>',
+    });
+    var html = render({
+      type: "INSTANCE",
+      dsSlug: "anatomy-only-fixture",
+      props: {},
+    });
+    ds.setAnatomyMap(null);
+    if (prev !== undefined) global.window = prev;
+    assert.ok(
+      html.indexOf("ds-anatomy") !== -1,
+      "server-side anatomy map used when no window",
+    );
+    assert.ok(
+      html.indexOf("ds-component") === -1,
+      "no chip when server-side anatomy present",
+    );
+  });
+
+  it("setAnatomyMap(null) resets — non-override slug chips again server-side", function () {
+    var prev = typeof global.window !== "undefined" ? global.window : undefined;
+    delete global.window;
+    ds.setAnatomyMap({
+      "anatomy-only-fixture":
+        '<div class="ds-anatomy" data-ds-slug="anatomy-only-fixture"></div>',
+    });
+    ds.setAnatomyMap(null);
+    var html = render({
+      type: "INSTANCE",
+      dsSlug: "anatomy-only-fixture",
+      props: {},
+    });
+    if (prev !== undefined) global.window = prev;
+    assert.ok(
+      html.indexOf("ds-component") !== -1,
+      "chip after map reset (no leakage across renders)",
+    );
+  });
+
   it("non-override slug, no anatomy → chip fallback", function () {
     var prev = typeof global.window !== "undefined" ? global.window : undefined;
     global.window = { __dsAnatomyMap: {} };

--- a/plugins/actian-design-system/tests/renderers/ds-token-binding.test.js
+++ b/plugins/actian-design-system/tests/renderers/ds-token-binding.test.js
@@ -3,20 +3,53 @@
 var { describe, it } = require("node:test");
 var assert = require("node:assert");
 var path = require("path");
-var { bindTokens } = require(path.resolve(__dirname, "..", "..", "scripts", "renderers", "ds-token-binding.js"));
+var { bindTokens } = require(
+  path.resolve(
+    __dirname,
+    "..",
+    "..",
+    "scripts",
+    "renderers",
+    "ds-token-binding.js",
+  ),
+);
 
 describe("ds-token-binding", function () {
   it("maps variant axes to state classes", function () {
-    var r = bindTokens("button", { variants: { State: "Disabled", Emphasis: "Filled" } });
+    var r = bindTokens("button", {
+      variants: { State: "Disabled", Emphasis: "Filled" },
+    });
     assert.ok(r.classes.indexOf("ds--state-disabled") !== -1);
     assert.ok(r.classes.indexOf("ds--emphasis-filled") !== -1);
   });
   it("maps guideline domains.tokens bindings to cssVars", function () {
-    var r = bindTokens("button", { tokenBindings: [{ token: "--zen-color-action-primary", context: "background" }] });
-    assert.strictEqual(r.cssVars["background"], "var(--zen-color-action-primary)");
+    var r = bindTokens("button", {
+      tokenBindings: [
+        { token: "--zen-color-action-primary", context: "background" },
+      ],
+    });
+    assert.strictEqual(
+      r.cssVars["background"],
+      "var(--zen-color-action-primary)",
+    );
   });
   it("returns neutral on no data; never throws", function () {
-    assert.deepStrictEqual(bindTokens("x", undefined), { classes: [], cssVars: {} });
+    assert.deepStrictEqual(bindTokens("x", undefined), {
+      classes: [],
+      cssVars: {},
+    });
     assert.deepStrictEqual(bindTokens("x", {}), { classes: [], cssVars: {} });
+  });
+  it("skips bindings with descriptive (non-CSS-property) contexts", function () {
+    var r = bindTokens("card", {
+      tokenBindings: [{ token: "spacing-md", context: "Card padding" }],
+    });
+    assert.deepStrictEqual(r.cssVars, {});
+  });
+  it("prefixes bare token with --zen- when context is a real CSS property", function () {
+    var r = bindTokens("x", {
+      tokenBindings: [{ token: "color-bg-default", context: "background" }],
+    });
+    assert.strictEqual(r.cssVars["background"], "var(--zen-color-bg-default)");
   });
 });

--- a/plugins/actian-design-system/tests/renderers/ds-token-binding.test.js
+++ b/plugins/actian-design-system/tests/renderers/ds-token-binding.test.js
@@ -1,0 +1,22 @@
+#!/usr/bin/env node
+"use strict";
+var { describe, it } = require("node:test");
+var assert = require("node:assert");
+var path = require("path");
+var { bindTokens } = require(path.resolve(__dirname, "..", "..", "scripts", "renderers", "ds-token-binding.js"));
+
+describe("ds-token-binding", function () {
+  it("maps variant axes to state classes", function () {
+    var r = bindTokens("button", { variants: { State: "Disabled", Emphasis: "Filled" } });
+    assert.ok(r.classes.indexOf("ds--state-disabled") !== -1);
+    assert.ok(r.classes.indexOf("ds--emphasis-filled") !== -1);
+  });
+  it("maps guideline domains.tokens bindings to cssVars", function () {
+    var r = bindTokens("button", { tokenBindings: [{ token: "--zen-color-action-primary", context: "background" }] });
+    assert.strictEqual(r.cssVars["background"], "var(--zen-color-action-primary)");
+  });
+  it("returns neutral on no data; never throws", function () {
+    assert.deepStrictEqual(bindTokens("x", undefined), { classes: [], cssVars: {} });
+    assert.deepStrictEqual(bindTokens("x", {}), { classes: [], cssVars: {} });
+  });
+});

--- a/plugins/actian-design-system/tests/validation/validate-ds-nodes.test.js
+++ b/plugins/actian-design-system/tests/validation/validate-ds-nodes.test.js
@@ -3,8 +3,8 @@
 
 // Task 3: DS-node validation tests
 // Covers unknown-ds-slug (hard error) + ds-slug-unbuilt (warning) + known-built (clean).
-// Warning-tier slug used: "tooltip" — present in the vendored dskit registry,
-// not in BUILT_SLUGS (ds-html-map.js switch has no "tooltip" case).
+// Warning-tier slug used: "avatar" — present in the vendored dskit registry,
+// not in BUILT_SLUGS (ds-html-map.js switch has no "avatar" case).
 
 var { describe, it } = require("node:test");
 var assert = require("node:assert");
@@ -60,7 +60,11 @@ describe("validate-ds-nodes: unknown-ds-slug", function () {
     var errs = result.findings.filter(function (f) {
       return f.kind === "unknown-ds-slug";
     });
-    assert.strictEqual(errs.length, 1, "expected exactly one unknown-ds-slug finding");
+    assert.strictEqual(
+      errs.length,
+      1,
+      "expected exactly one unknown-ds-slug finding",
+    );
     assert.strictEqual(errs[0].severity, "error");
   });
 
@@ -93,35 +97,49 @@ describe("validate-ds-nodes: unknown-ds-slug", function () {
 
 // ---------------------------------------------------------------------------
 // Test 2: authorable-but-unbuilt dsSlug → WARNING (not an error)
-// Slug: "tooltip" — confirmed in vendored dskit.json, not in BUILT_SLUGS.
+// Slug: "avatar" — confirmed in vendored dskit.json, not in BUILT_SLUGS.
+// (Was "tooltip" until Hi-Fi Slice 1 Task 4 promoted tooltip to a built leaf;
+//  swapped to a still-unbuilt registry slug to keep covering the warning tier.)
 // ---------------------------------------------------------------------------
-describe("validate-ds-nodes: ds-slug-unbuilt (tooltip)", function () {
-  it("flags tooltip with kind=ds-slug-unbuilt, severity=warning", function () {
-    var data = flowWith(dsNode("tooltip"));
+describe("validate-ds-nodes: ds-slug-unbuilt (avatar)", function () {
+  it("flags avatar with kind=ds-slug-unbuilt, severity=warning", function () {
+    var data = flowWith(dsNode("avatar"));
     var result = validate.validate(data, QUIET);
     var warns = result.findings.filter(function (f) {
       return f.kind === "ds-slug-unbuilt";
     });
-    assert.strictEqual(warns.length, 1, "expected exactly one ds-slug-unbuilt finding for tooltip");
+    assert.strictEqual(
+      warns.length,
+      1,
+      "expected exactly one ds-slug-unbuilt finding for avatar",
+    );
     assert.strictEqual(warns[0].severity, "warning");
   });
 
-  it("tooltip does NOT produce an error finding", function () {
-    var data = flowWith(dsNode("tooltip"));
+  it("avatar does NOT produce an error finding", function () {
+    var data = flowWith(dsNode("avatar"));
     var result = validate.validate(data, QUIET);
     var errs = result.findings.filter(function (f) {
       return f.severity === "error" && f.kind !== "missing-justification";
     });
-    assert.strictEqual(errs.length, 0, "tooltip is in registry so must not produce any error");
+    assert.strictEqual(
+      errs.length,
+      0,
+      "avatar is in registry so must not produce any error",
+    );
   });
 
-  it("tooltip does NOT trigger unknown-component", function () {
-    var data = flowWith(dsNode("tooltip"));
+  it("avatar does NOT trigger unknown-component", function () {
+    var data = flowWith(dsNode("avatar"));
     var result = validate.validate(data, QUIET);
     var unknownComp = result.findings.filter(function (f) {
       return f.kind === "unknown-component";
     });
-    assert.strictEqual(unknownComp.length, 0, "DS nodes without ref must not trigger unknown-component");
+    assert.strictEqual(
+      unknownComp.length,
+      0,
+      "DS nodes without ref must not trigger unknown-component",
+    );
   });
 });
 
@@ -135,7 +153,11 @@ describe("validate-ds-nodes: built dsSlug clean (button)", function () {
     var dsFindings = result.findings.filter(function (f) {
       return f.kind === "unknown-ds-slug" || f.kind === "ds-slug-unbuilt";
     });
-    assert.strictEqual(dsFindings.length, 0, "built slug must produce zero ds-node findings");
+    assert.strictEqual(
+      dsFindings.length,
+      0,
+      "built slug must produce zero ds-node findings",
+    );
   });
 
   it("button dsSlug produces no error findings at all", function () {
@@ -144,7 +166,11 @@ describe("validate-ds-nodes: built dsSlug clean (button)", function () {
     var errs = result.findings.filter(function (f) {
       return f.severity === "error";
     });
-    assert.strictEqual(errs.length, 0, "clean built DS node must produce no errors");
+    assert.strictEqual(
+      errs.length,
+      0,
+      "clean built DS node must produce no errors",
+    );
   });
 });
 
@@ -154,23 +180,41 @@ describe("validate-ds-nodes: built dsSlug clean (button)", function () {
 describe("validate-ds-nodes: no ref → no FM ref checks fire", function () {
   it("library:ds node without ref field does not trigger unknown-component", function () {
     // Explicit: node has library:"ds" but no ref property at all
-    var node = { type: "INSTANCE", library: "ds", dsSlug: "button", props: { Label: "Go" } };
+    var node = {
+      type: "INSTANCE",
+      library: "ds",
+      dsSlug: "button",
+      props: { Label: "Go" },
+    };
     assert.strictEqual(node.ref, undefined, "fixture must have no ref");
     var data = flowWith(node);
     var result = validate.validate(data, QUIET);
     var unknownComp = result.findings.filter(function (f) {
       return f.kind === "unknown-component";
     });
-    assert.strictEqual(unknownComp.length, 0, "no ref on DS node must not trigger unknown-component");
+    assert.strictEqual(
+      unknownComp.length,
+      0,
+      "no ref on DS node must not trigger unknown-component",
+    );
   });
 
   it("library:ds node without ref does not trigger missing-required-override", function () {
-    var node = { type: "INSTANCE", library: "ds", dsSlug: "button", props: { Label: "Go" } };
+    var node = {
+      type: "INSTANCE",
+      library: "ds",
+      dsSlug: "button",
+      props: { Label: "Go" },
+    };
     var data = flowWith(node);
     var result = validate.validate(data, QUIET);
     var overrideFindings = result.findings.filter(function (f) {
       return f.kind === "missing-required-override";
     });
-    assert.strictEqual(overrideFindings.length, 0, "no ref → no required-override check");
+    assert.strictEqual(
+      overrideFindings.length,
+      0,
+      "no ref → no required-override check",
+    );
   });
 });


### PR DESCRIPTION
## Slice 1 — anatomy-grounded hi-fi leaf expansion

Expands high-fidelity DS rendering beyond the hand-authored override leaves by interpreting a component's **vendored anatomy part-tree** into structural HTML at assemble-time, so non-override DS slugs render as real structure instead of gray chips in `generate-flow --hifi`.

### What's in the slice
- **Anatomy interpreter** (`anatomy-render.js`) — part-tree → structural HTML (Node, assemble-time).
- **Token/state binding seam** (`ds-token-binding.js`) — honest `--zen-`-bound CSS with a CSS-property guard (only emits a binding when there's a real token).
- **Dispatch** override → anatomy → graceful chip, with the 19 existing override leaves untouched.
- **8 new DS override leaves** (transform targets), tokens-only.
- **DS render coverage report** (`ds-coverage-report.js`) — coverage ratio is null-not-zero for specs missing quality data.
- **Widened fidelity gate** — report-only (still exits 0).

### Fix-forward after code review
A pre-merge review found the headline (the anatomy interpreter) was **inert in the canonical deliverable**. Three fixes landed, each driven test-first:

- **C2** — `collectDsSlugs` walked `screens[].frames`, but real flow-data uses `screens[].content`, so the map was always empty. Fixed the key and extracted `collectDsSlugs`/`buildDsAnatomyMap` into `ds-anatomy-map.js` (re-exported from `assemble-preview.js`). This also repaired the browser embed path, which shared the broken collector.
- **C1** — the canonical `--type flow-share` deliverable pre-renders screens **server-side in Node** (no `window`), and the flow-share path never embedded the map — so the dispatch could never fire. Added `ds-html-map.setAnatomyMap()` (the dispatch reads `window.__dsAnatomyMap || _serverAnatomyMap`); `assemble-flow-share.js` builds + injects the map around the render loop and resets it in a `finally`.
- **I1** — `anatomy-render` emits aria-hidden `.ds-anatomy__image`/`__vector` slots with no CSS (rendered 0×0). Added a `.ds-anatomy*` section to `ds-base.css` with token-bound size + neutral fill (100% `--zen-*`).

### Verification
- Full suite: **1729/1730** pass. The single failure is the known **local-only** `vendor-paths-resolve` false positive (gitignored `docs/superpowers/` files absent on CI → CI-clean); this branch touches no `vendor/`/`superpowers` files.
- End-to-end via the real CLI `--type flow-share` path: non-override slugs (`link`, `scroll-bar`) render as anatomy (no chips); the `button` override still renders its real leaf.
- New tests cover content-shaped slug collection, server-side dispatch + reset, the flow-share integration (anatomy vs chip markers), and the anatomy CSS (sized + token-filled + no hardcoded color).
- Version bumped to `2026.6.25`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
