### PR TITLE
chore: gitignore in-plugin flows/ dogfood output

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,9 @@ settings.json
 /presentations/
 /prototypes/
 
+# Dogfood/preview output generated in-plugin (local artifacts, not source).
+/plugins/actian-design-system/flows/
+
 # Annotation files (browser preview artifacts)
 .annotations.json
 


### PR DESCRIPTION
## What
`plugins/actian-design-system/flows/` holds generated dogfood/preview output (HTML + JSON) — local artifacts, not source.

## Why
The existing `/flows/` ignore rule is anchored to the repo root (deliberately, per its comment, so it doesn't match nested `vendor/` dirs), so it never covered the nested plugin path. Generated dogfood output was showing up as untracked. This adds a targeted entry.

## Verification
- `git check-ignore plugins/actian-design-system/flows/` → ignored
- `git status` no longer surfaces the dogfood output
- Nothing tracked lives under that path, so no real source is hidden

Note: no version bump — non-functional housekeeping, no user-facing plugin change. If the version-bump gate flags it, admin-merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)