### PR TITLE
hifi(a1): degraded-slug HTML leaf overrides (8 leaves; override 27→35, degraded 12→4)

### DIFF
--- a/plugins/actian-design-system/.claude-plugin/plugin.json
+++ b/plugins/actian-design-system/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "actian-design-system",
   "description": "Actian Design System toolkit — generate wireframe flows with prototype wiring, create component briefs, audit designs, compare flows, and build presentations. 8 skills (with tiered generation: recognized / adapted / improvised), 9 agents, 155 tokens (3 themes, 8 collections), WCAG 2.2 AA. DS knowledge vendored from volivarii/actian-ds-knowledge.",
-  "version": "2026.6.30",
+  "version": "2026.7.0",
   "author": {
     "name": "Actian UX Team"
   },

--- a/plugins/actian-design-system/scripts/quality/quality-gates-cli.js
+++ b/plugins/actian-design-system/scripts/quality/quality-gates-cli.js
@@ -33,6 +33,16 @@ var PILOT = [
   "dropdown-select-default",
   "progress-bar-small",
   "tag-interactive",
+  // Hi-Fi A1 (narrow) degraded-slug override leaves — same rationale as Slice 1
+  // (real switch-case, render server-side in Node, no window.__dsAnatomyMap).
+  "popover",
+  "account-dropdown",
+  "app-switcher-dropdown",
+  "segmented-control",
+  "toolbar",
+  "sticky-footer",
+  "loader",
+  "calendar",
 ];
 var DIFF_DIR = path.join(
   __dirname,

--- a/plugins/actian-design-system/scripts/renderers/html-renderers/ds-base.css
+++ b/plugins/actian-design-system/scripts/renderers/html-renderers/ds-base.css
@@ -1921,7 +1921,7 @@
 .ds-account-menu__header {
   display: flex;
   flex-direction: column;
-  gap: 2px; /* raw px: tight identity stack */
+  gap: var(--zen-spacing-3xs);
   padding: var(--zen-spacing-xs) var(--zen-spacing-sm);
   border-bottom: 1px solid var(--zen-border-default);
   margin-bottom: var(--zen-spacing-2xs);
@@ -2083,6 +2083,9 @@
   border-radius: var(--zen-border-radius-sm);
   font-family: var(--zen-font-family-text);
   box-sizing: border-box;
+}
+.ds-toolbar--horizontal {
+  flex-direction: row;
 }
 .ds-toolbar--vertical {
   flex-direction: column;

--- a/plugins/actian-design-system/scripts/renderers/html-renderers/ds-base.css
+++ b/plugins/actian-design-system/scripts/renderers/html-renderers/ds-base.css
@@ -1838,3 +1838,193 @@
   min-width: var(--zen-size-lg);
   min-height: var(--zen-size-lg);
 }
+
+/* ===================================================================== */
+/* Hi-Fi A1 (narrow) — degraded-slug leaf overrides. Batch 1: overlays.  */
+/* ===================================================================== */
+
+/* ============ Popover (floating card overlay) ============ */
+/* Registry axis: Type = Interaction guide | Advanced search; prop Show info icon. */
+.ds-popover {
+  position: relative;
+  display: inline-flex;
+  flex-direction: column;
+  gap: var(--zen-spacing-2xs);
+  max-width: 320px; /* raw px: popover card width */
+  padding: var(--zen-spacing-sm) var(--zen-spacing-md);
+  background: var(--zen-color-bg-default);
+  border: 1px solid var(--zen-border-default);
+  border-radius: var(--zen-border-radius-md);
+  box-shadow: var(--zen-shadow-lg);
+  font-family: var(--zen-font-family-text);
+  box-sizing: border-box;
+}
+.ds-popover--advanced-search {
+  max-width: 400px; /* raw px: wider advanced-search variant */
+}
+.ds-popover__header {
+  display: flex;
+  align-items: center;
+  gap: var(--zen-spacing-2xs);
+}
+.ds-popover__info {
+  width: 16px; /* raw px: info icon box */
+  height: 16px;
+  flex: 0 0 auto;
+  display: inline-flex;
+  color: var(--zen-color-icon-primary);
+}
+.ds-popover__info svg {
+  width: 100%;
+  height: 100%;
+  display: block;
+}
+.ds-popover__title {
+  font-size: var(--zen-font-size-md);
+  font-weight: var(--zen-font-weight-medium);
+  line-height: var(--zen-font-lineheight-md);
+  letter-spacing: var(--zen-font-letterspacing-wide-2);
+  color: var(--zen-color-text-primary);
+}
+.ds-popover__body {
+  font-size: var(--zen-font-size-sm);
+  line-height: var(--zen-font-lineheight-sm);
+  letter-spacing: var(--zen-font-letterspacing-wide-3);
+  color: var(--zen-color-text-secondary);
+}
+.ds-popover__arrow {
+  position: absolute;
+  left: var(--zen-spacing-md);
+  bottom: -5px; /* raw px: caret tip offset */
+  width: 10px; /* raw px: caret geometry */
+  height: 10px;
+  background: var(--zen-color-bg-default);
+  border-left: 1px solid var(--zen-border-default);
+  border-bottom: 1px solid var(--zen-border-default);
+  transform: rotate(-45deg);
+}
+
+/* ============ Account menu (identity + item overlay) ============ */
+/* Single-import; nested help-bubble / arrow-down / exit baked into the component. */
+.ds-account-menu {
+  display: flex;
+  flex-direction: column;
+  min-width: 240px; /* raw px: menu overlay width */
+  padding: var(--zen-spacing-2xs);
+  background: var(--zen-color-bg-default);
+  border: 1px solid var(--zen-border-default);
+  border-radius: var(--zen-border-radius-md);
+  box-shadow: var(--zen-shadow-lg);
+  font-family: var(--zen-font-family-text);
+  box-sizing: border-box;
+}
+.ds-account-menu__header {
+  display: flex;
+  flex-direction: column;
+  gap: 2px; /* raw px: tight identity stack */
+  padding: var(--zen-spacing-xs) var(--zen-spacing-sm);
+  border-bottom: 1px solid var(--zen-border-default);
+  margin-bottom: var(--zen-spacing-2xs);
+}
+.ds-account-menu__name {
+  font-size: var(--zen-font-size-md);
+  font-weight: var(--zen-font-weight-medium);
+  line-height: var(--zen-font-lineheight-md);
+  letter-spacing: var(--zen-font-letterspacing-wide-2);
+  color: var(--zen-color-text-primary);
+}
+.ds-account-menu__email {
+  font-size: var(--zen-font-size-sm);
+  line-height: var(--zen-font-lineheight-sm);
+  letter-spacing: var(--zen-font-letterspacing-wide-3);
+  color: var(--zen-color-text-secondary);
+}
+.ds-account-menu__items {
+  display: flex;
+  flex-direction: column;
+}
+.ds-account-menu__item {
+  display: flex;
+  align-items: center;
+  gap: var(--zen-spacing-xs);
+  padding: var(--zen-spacing-xs) var(--zen-spacing-sm);
+  border-radius: var(--zen-border-radius-xs);
+  color: var(--zen-color-text-secondary);
+  font-size: var(--zen-font-size-md);
+  line-height: var(--zen-font-lineheight-md);
+  letter-spacing: var(--zen-font-letterspacing-wide-2);
+}
+.ds-account-menu__icon {
+  width: 20px; /* raw px: item icon box */
+  height: 20px;
+  flex: 0 0 auto;
+  display: inline-flex;
+  color: var(--zen-color-icon-default);
+}
+.ds-account-menu__icon svg {
+  width: 100%;
+  height: 100%;
+  display: block;
+}
+
+/* ============ App switcher (product grid + settings overlay) ============ */
+/* Single-import; nested settings / arrow-down baked into the component. */
+.ds-app-switcher {
+  display: flex;
+  flex-direction: column;
+  min-width: 280px; /* raw px: switcher overlay width */
+  padding: var(--zen-spacing-2xs);
+  background: var(--zen-color-bg-default);
+  border: 1px solid var(--zen-border-default);
+  border-radius: var(--zen-border-radius-md);
+  box-shadow: var(--zen-shadow-lg);
+  font-family: var(--zen-font-family-text);
+  box-sizing: border-box;
+}
+.ds-app-switcher__apps {
+  display: flex;
+  flex-direction: column;
+}
+.ds-app-switcher__app {
+  display: flex;
+  align-items: center;
+  gap: var(--zen-spacing-xs);
+  padding: var(--zen-spacing-xs) var(--zen-spacing-sm);
+  border-radius: var(--zen-border-radius-xs);
+  color: var(--zen-color-text-secondary);
+  font-size: var(--zen-font-size-md);
+  line-height: var(--zen-font-lineheight-md);
+  letter-spacing: var(--zen-font-letterspacing-wide-2);
+}
+.ds-app-switcher__tile {
+  width: 24px; /* raw px: product tile */
+  height: 24px;
+  flex: 0 0 auto;
+  background: var(--zen-color-bg-subtle);
+  border-radius: var(--zen-border-radius-sm);
+}
+.ds-app-switcher__settings {
+  display: flex;
+  align-items: center;
+  gap: var(--zen-spacing-xs);
+  padding: var(--zen-spacing-xs) var(--zen-spacing-sm);
+  margin-top: var(--zen-spacing-2xs);
+  border-top: 1px solid var(--zen-border-default);
+  border-radius: var(--zen-border-radius-xs);
+  color: var(--zen-color-text-secondary);
+  font-size: var(--zen-font-size-md);
+  line-height: var(--zen-font-lineheight-md);
+  letter-spacing: var(--zen-font-letterspacing-wide-2);
+}
+.ds-app-switcher__icon {
+  width: 20px; /* raw px: settings icon box */
+  height: 20px;
+  flex: 0 0 auto;
+  display: inline-flex;
+  color: var(--zen-color-icon-default);
+}
+.ds-app-switcher__icon svg {
+  width: 100%;
+  height: 100%;
+  display: block;
+}

--- a/plugins/actian-design-system/scripts/renderers/html-renderers/ds-base.css
+++ b/plugins/actian-design-system/scripts/renderers/html-renderers/ds-base.css
@@ -2277,7 +2277,9 @@
 .ds-calendar__day.is-selected,
 .ds-calendar__day.is-range-start,
 .ds-calendar__day.is-range-end {
-  background: var(--zen-color-bg-primary);
+  /* Brand fill: bg-emphasis is the canonical Figma color-bg-primary alias this
+     file standardizes on (see header note + .ds-button--primary), not bg-primary. */
+  background: var(--zen-color-bg-emphasis);
   color: var(--zen-color-text-reverse);
   font-weight: var(--zen-font-weight-medium);
 }

--- a/plugins/actian-design-system/scripts/renderers/html-renderers/ds-base.css
+++ b/plugins/actian-design-system/scripts/renderers/html-renderers/ds-base.css
@@ -2028,3 +2028,116 @@
   height: 100%;
   display: block;
 }
+
+/* ===================================================================== */
+/* Hi-Fi A1 (narrow) — degraded-slug leaf overrides. Batch 2: controls.  */
+/* ===================================================================== */
+
+/* ============ Segmented control (mutually-exclusive toggle) ============ */
+/* Registry axis: Type = Default. */
+.ds-segmented {
+  display: inline-flex;
+  align-items: stretch;
+  padding: var(--zen-spacing-3xs);
+  gap: var(--zen-spacing-3xs);
+  background: var(--zen-color-bg-subtle);
+  border: 1px solid var(--zen-border-default);
+  border-radius: var(--zen-border-radius-sm);
+  font-family: var(--zen-font-family-text);
+  box-sizing: border-box;
+}
+.ds-segmented__item {
+  display: inline-flex;
+  align-items: center;
+  padding: var(--zen-spacing-2xs) var(--zen-spacing-sm);
+  border-radius: var(--zen-border-radius-xs);
+  font-size: var(--zen-font-size-sm);
+  font-weight: var(--zen-font-weight-medium);
+  line-height: var(--zen-font-lineheight-sm);
+  letter-spacing: var(--zen-font-letterspacing-wide-3);
+  color: var(--zen-color-text-secondary);
+}
+.ds-segmented__item.is-active {
+  background: var(--zen-color-bg-default);
+  color: var(--zen-color-text-primary);
+  box-shadow: var(--zen-shadow-sm);
+}
+
+/* ============ Toolbar (action bar) ============ */
+/* Registry axes: Type = Single | Combined | Group; Orientation = H | V. */
+.ds-toolbar {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--zen-spacing-sm);
+  padding: var(--zen-spacing-2xs) var(--zen-spacing-xs);
+  background: var(--zen-color-bg-default);
+  border: 1px solid var(--zen-border-default);
+  border-radius: var(--zen-border-radius-sm);
+  font-family: var(--zen-font-family-text);
+  box-sizing: border-box;
+}
+.ds-toolbar--vertical {
+  flex-direction: column;
+  align-items: stretch;
+}
+.ds-toolbar__group {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--zen-spacing-2xs);
+}
+.ds-toolbar--vertical .ds-toolbar__group {
+  flex-direction: column;
+}
+.ds-toolbar__btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 32px; /* raw px: icon button box */
+  height: 32px;
+  padding: 0;
+  background: transparent;
+  border: none;
+  border-radius: var(--zen-border-radius-xs);
+  color: var(--zen-color-icon-default);
+  cursor: pointer;
+}
+.ds-toolbar__btn svg {
+  width: 20px; /* raw px: glyph box */
+  height: 20px;
+  display: block;
+}
+.ds-toolbar__scale {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--zen-spacing-2xs);
+  padding-left: var(--zen-spacing-xs);
+  border-left: 1px solid var(--zen-border-default);
+}
+.ds-toolbar__scale-value {
+  font-size: var(--zen-font-size-sm);
+  line-height: var(--zen-font-lineheight-sm);
+  letter-spacing: var(--zen-font-letterspacing-wide-3);
+  color: var(--zen-color-text-secondary);
+  min-width: 40px; /* raw px: stable percent column */
+  text-align: center;
+}
+
+/* ============ Sticky footer (persistent action bar) ============ */
+/* Registry axis: Property 1 = Default. Reuses .ds-button leaves. */
+.ds-sticky-footer {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  width: 100%;
+  padding: var(--zen-spacing-sm) var(--zen-spacing-lg);
+  background: var(--zen-color-bg-default);
+  border-top: 1px solid var(--zen-border-default);
+  box-shadow: var(--zen-shadow-md);
+  font-family: var(--zen-font-family-text);
+  box-sizing: border-box;
+}
+.ds-sticky-footer__actions {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--zen-spacing-sm);
+}

--- a/plugins/actian-design-system/scripts/renderers/html-renderers/ds-base.css
+++ b/plugins/actian-design-system/scripts/renderers/html-renderers/ds-base.css
@@ -1966,6 +1966,10 @@
   height: 100%;
   display: block;
 }
+.ds-account-menu__label {
+  flex: 1 1 auto;
+  min-width: 0;
+}
 
 /* ============ App switcher (product grid + settings overlay) ============ */
 /* Single-import; nested settings / arrow-down baked into the component. */
@@ -2027,6 +2031,10 @@
   width: 100%;
   height: 100%;
   display: block;
+}
+.ds-app-switcher__label {
+  flex: 1 1 auto;
+  min-width: 0;
 }
 
 /* ===================================================================== */
@@ -2140,4 +2148,141 @@
   display: inline-flex;
   align-items: center;
   gap: var(--zen-spacing-sm);
+}
+
+/* ===================================================================== */
+/* Hi-Fi A1 (narrow) — degraded-slug leaf overrides. Batch 3: feedback.  */
+/* ===================================================================== */
+
+/* ============ Loader (indeterminate activity spinner) ============ */
+.ds-loader {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--zen-spacing-xs);
+  font-family: var(--zen-font-family-text);
+}
+.ds-loader__spinner {
+  width: 24px; /* raw px: spinner box */
+  height: 24px;
+  flex: 0 0 auto;
+  border: 2px solid var(--zen-color-bg-muted); /* raw px: ring weight */
+  border-top-color: var(--zen-color-icon-primary);
+  border-radius: var(--zen-border-radius-full);
+  animation: ds-spin 800ms linear infinite;
+}
+.ds-loader__label {
+  font-size: var(--zen-font-size-sm);
+  line-height: var(--zen-font-lineheight-sm);
+  letter-spacing: var(--zen-font-letterspacing-wide-3);
+  color: var(--zen-color-text-secondary);
+}
+@keyframes ds-spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+@media (prefers-reduced-motion: reduce) {
+  .ds-loader__spinner {
+    animation: none;
+  }
+}
+
+/* ============ Calendar (static month grid) ============ */
+/* Registry axes: Type = Single date select | … ; Selection = Single | Range | Year. */
+.ds-calendar {
+  display: inline-flex;
+  flex-direction: column;
+  gap: var(--zen-spacing-xs);
+  width: 280px; /* raw px: month grid width */
+  padding: var(--zen-spacing-sm);
+  background: var(--zen-color-bg-default);
+  border: 1px solid var(--zen-border-default);
+  border-radius: var(--zen-border-radius-md);
+  box-shadow: var(--zen-shadow-md);
+  font-family: var(--zen-font-family-text);
+  box-sizing: border-box;
+}
+.ds-calendar__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--zen-spacing-xs);
+}
+.ds-calendar__month {
+  font-size: var(--zen-font-size-md);
+  font-weight: var(--zen-font-weight-medium);
+  line-height: var(--zen-font-lineheight-md);
+  letter-spacing: var(--zen-font-letterspacing-wide-2);
+  color: var(--zen-color-text-primary);
+}
+.ds-calendar__nav {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 28px; /* raw px: nav button box */
+  height: 28px;
+  padding: 0;
+  background: transparent;
+  border: none;
+  border-radius: var(--zen-border-radius-xs);
+  color: var(--zen-color-icon-default);
+  cursor: pointer;
+}
+.ds-calendar__nav svg {
+  width: 16px; /* raw px: chevron box */
+  height: 16px;
+  display: block;
+}
+.ds-calendar__weekdays,
+.ds-calendar__grid {
+  display: grid;
+  grid-template-columns: repeat(7, 1fr);
+  gap: var(--zen-spacing-3xs);
+}
+.ds-calendar__weekday {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  height: 28px; /* raw px: weekday header row */
+  font-size: var(--zen-font-size-sm);
+  font-weight: var(--zen-font-weight-medium);
+  color: var(--zen-color-text-tertiary);
+}
+.ds-calendar__day {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  height: 32px; /* raw px: day cell */
+  padding: 0;
+  background: transparent;
+  border: none;
+  border-radius: var(--zen-border-radius-xs);
+  font-size: var(--zen-font-size-sm);
+  line-height: var(--zen-font-lineheight-sm);
+  color: var(--zen-color-text-secondary);
+  cursor: pointer;
+}
+.ds-calendar__day.is-blank {
+  visibility: hidden;
+}
+/* Band first, so the endpoints (which also carry is-range) win the strong fill below. */
+.ds-calendar__day.is-range {
+  background: var(--zen-color-bg-selected);
+  color: var(--zen-color-text-primary);
+  border-radius: 0;
+}
+.ds-calendar__day.is-selected,
+.ds-calendar__day.is-range-start,
+.ds-calendar__day.is-range-end {
+  background: var(--zen-color-bg-primary);
+  color: var(--zen-color-text-reverse);
+  font-weight: var(--zen-font-weight-medium);
+}
+.ds-calendar__day.is-range-start {
+  border-top-left-radius: var(--zen-border-radius-xs);
+  border-bottom-left-radius: var(--zen-border-radius-xs);
+}
+.ds-calendar__day.is-range-end {
+  border-top-right-radius: var(--zen-border-radius-xs);
+  border-bottom-right-radius: var(--zen-border-radius-xs);
 }

--- a/plugins/actian-design-system/scripts/renderers/html-renderers/ds-html-map.js
+++ b/plugins/actian-design-system/scripts/renderers/html-renderers/ds-html-map.js
@@ -1427,6 +1427,100 @@
           );
         }
 
+        // ---- Hi-Fi A1 (narrow) — degraded-slug overrides. Batch 2: controls ----
+
+        case "segmented-control": {
+          // Registry axis: Type = Default (no content props). Render a segmented
+          // toggle from Segments/Items (comma list; Active picks the selected
+          // segment, else the first). role=tablist for assistive tech.
+          var segItems = parseItems(
+            props.Segments || props.Items,
+            "Option A,Option B",
+          );
+          var segActive = resolveActive(segItems, props.Active);
+          var segList = segItems
+            .map(function (label) {
+              var on = label === segActive;
+              return (
+                '<span class="ds-segmented__item' +
+                (on ? " is-active" : "") +
+                '" role="tab" aria-selected="' +
+                (on ? "true" : "false") +
+                '">' +
+                esc(label) +
+                "</span>"
+              );
+            })
+            .join("");
+          return (
+            '<div class="ds-segmented" role="tablist">' + segList + "</div>"
+          );
+        }
+
+        case "toolbar": {
+          // Registry axes: Type = Single | Combined | Group; Orientation =
+          // Horizontal | Vertical; prop "Show View scale". Representative action
+          // bar (no content props) — a group of icon buttons + an optional
+          // zoom/view-scale control. role=toolbar.
+          var tbVertical = v.Orientation === "Vertical";
+          var tbCls = "ds-toolbar";
+          tbCls += tbVertical
+            ? " ds-toolbar--vertical"
+            : " ds-toolbar--horizontal";
+          function tbBtn(iconSlug, label) {
+            return (
+              '<button class="ds-toolbar__btn" type="button" aria-label="' +
+              esc(label) +
+              '">' +
+              renderIcon(iconSlug) +
+              "</button>"
+            );
+          }
+          var tbGroup =
+            '<div class="ds-toolbar__group">' +
+            tbBtn("filter", "Filter") +
+            tbBtn("chevron-sort", "Sort") +
+            tbBtn("view", "View") +
+            tbBtn("more", "More") +
+            "</div>";
+          var tbScale = props["Show View scale"]
+            ? '<div class="ds-toolbar__scale">' +
+              tbBtn("zoom-out", "Zoom out") +
+              '<span class="ds-toolbar__scale-value">100%</span>' +
+              tbBtn("zoom-in", "Zoom in") +
+              "</div>"
+            : "";
+          return (
+            '<div class="' +
+            tbCls +
+            '" role="toolbar">' +
+            tbGroup +
+            tbScale +
+            "</div>"
+          );
+        }
+
+        case "sticky-footer": {
+          // Registry axis: Property 1 = Default (no content props). Persistent
+          // bottom action bar; right-aligned DS buttons (reuses .ds-button) —
+          // defaults Cancel (secondary) + Save (primary); Primary/Secondary
+          // props override the labels.
+          var sfPrimary = esc(props.Primary || "Save");
+          var sfSecondary = esc(props.Secondary || "Cancel");
+          return (
+            '<div class="ds-sticky-footer">' +
+            '<div class="ds-sticky-footer__actions">' +
+            '<button class="ds-button ds-button--secondary">' +
+            sfSecondary +
+            "</button>" +
+            '<button class="ds-button ds-button--primary">' +
+            sfPrimary +
+            "</button>" +
+            "</div>" +
+            "</div>"
+          );
+        }
+
         default: {
           // Anatomy dispatch: if an assemble-time anatomy map was supplied,
           // look up the pre-rendered HTML. Browser deliverables embed it on
@@ -1483,6 +1577,10 @@
     "popover",
     "account-dropdown",
     "app-switcher-dropdown",
+    // Hi-Fi A1 (narrow) — degraded-slug overrides. Batch 2: controls.
+    "segmented-control",
+    "toolbar",
+    "sticky-footer",
   ];
 
   exports.renderDSComponent = renderDSComponent;

--- a/plugins/actian-design-system/scripts/renderers/html-renderers/ds-html-map.js
+++ b/plugins/actian-design-system/scripts/renderers/html-renderers/ds-html-map.js
@@ -1441,9 +1441,13 @@
           var segList = segItems
             .map(function (label) {
               var on = label === segActive;
+              // Compute the class into a variable (never inline a ternary inside
+              // the class attribute literal — the css-staleness extractor scans
+              // raw source and mis-parses an inline ternary there).
+              var segCls = "ds-segmented__item" + (on ? " is-active" : "");
               return (
-                '<span class="ds-segmented__item' +
-                (on ? " is-active" : "") +
+                '<span class="' +
+                segCls +
                 '" role="tab" aria-selected="' +
                 (on ? "true" : "false") +
                 '">' +
@@ -1521,6 +1525,84 @@
           );
         }
 
+        // ---- Hi-Fi A1 (narrow) — degraded-slug overrides. Batch 3: feedback + date ----
+
+        case "loader": {
+          // Registry axis: Percent (auto-named variants). "loader" is the
+          // indeterminate activity spinner (determinate progress is the
+          // progress-bar-small leaf). Optional visible Label; role=status +
+          // aria-live for assistive tech.
+          var ldLabel = props.Label
+            ? '<span class="ds-loader__label">' + esc(props.Label) + "</span>"
+            : "";
+          return (
+            '<div class="ds-loader" role="status" aria-live="polite" aria-label="' +
+            esc(props.Label || "Loading") +
+            '">' +
+            '<span class="ds-loader__spinner" aria-hidden="true"></span>' +
+            ldLabel +
+            "</div>"
+          );
+        }
+
+        case "calendar": {
+          // Registry axes: Type = Single date select | Date | Month | Single;
+          // Selection = Single | Range | Year. A static month grid
+          // (DETERMINISTIC — no Date()): header (month/year + prev/next nav) +
+          // weekday row + day cells. Range renders a start→end band; else a
+          // single selected day. Month label is overridable via props.Month.
+          var calRange = v.Selection === "Range";
+          var calMonth = esc(props.Month || "June 2026");
+          var calWeek = ["S", "M", "T", "W", "T", "F", "S"]
+            .map(function (d) {
+              return (
+                '<span class="ds-calendar__weekday" aria-hidden="true">' +
+                d +
+                "</span>"
+              );
+            })
+            .join("");
+          // Static month layout: 2 leading blanks, then days 1..30.
+          var calCells = [
+            '<span class="ds-calendar__day is-blank" aria-hidden="true"></span>',
+            '<span class="ds-calendar__day is-blank" aria-hidden="true"></span>',
+          ];
+          for (var cd = 1; cd <= 30; cd++) {
+            var cdCls = "ds-calendar__day";
+            if (calRange) {
+              if (cd >= 12 && cd <= 16) cdCls += " is-range";
+              if (cd === 12) cdCls += " is-range-start";
+              if (cd === 16) cdCls += " is-range-end";
+            } else if (cd === 15) {
+              cdCls += " is-selected";
+            }
+            calCells.push(
+              '<button class="' + cdCls + '" type="button">' + cd + "</button>",
+            );
+          }
+          return (
+            '<div class="ds-calendar">' +
+            '<div class="ds-calendar__header">' +
+            '<button class="ds-calendar__nav" type="button" aria-label="Previous month">' +
+            renderIcon("chevron-left") +
+            "</button>" +
+            '<span class="ds-calendar__month">' +
+            calMonth +
+            "</span>" +
+            '<button class="ds-calendar__nav" type="button" aria-label="Next month">' +
+            renderIcon("chevron-left", { rotate: 180 }) +
+            "</button>" +
+            "</div>" +
+            '<div class="ds-calendar__weekdays">' +
+            calWeek +
+            "</div>" +
+            '<div class="ds-calendar__grid" role="grid">' +
+            calCells.join("") +
+            "</div>" +
+            "</div>"
+          );
+        }
+
         default: {
           // Anatomy dispatch: if an assemble-time anatomy map was supplied,
           // look up the pre-rendered HTML. Browser deliverables embed it on
@@ -1581,6 +1663,9 @@
     "segmented-control",
     "toolbar",
     "sticky-footer",
+    // Hi-Fi A1 (narrow) — degraded-slug overrides. Batch 3: feedback + date.
+    "loader",
+    "calendar",
   ];
 
   exports.renderDSComponent = renderDSComponent;

--- a/plugins/actian-design-system/scripts/renderers/html-renderers/ds-html-map.js
+++ b/plugins/actian-design-system/scripts/renderers/html-renderers/ds-html-map.js
@@ -1569,15 +1569,26 @@
           ];
           for (var cd = 1; cd <= 30; cd++) {
             var cdCls = "ds-calendar__day";
+            var cdSel = false; // selected → aria-pressed (non-visual selection state)
             if (calRange) {
-              if (cd >= 12 && cd <= 16) cdCls += " is-range";
+              if (cd >= 12 && cd <= 16) {
+                cdCls += " is-range";
+                cdSel = true;
+              }
               if (cd === 12) cdCls += " is-range-start";
               if (cd === 16) cdCls += " is-range-end";
             } else if (cd === 15) {
               cdCls += " is-selected";
+              cdSel = true;
             }
             calCells.push(
-              '<button class="' + cdCls + '" type="button">' + cd + "</button>",
+              '<button class="' +
+                cdCls +
+                '" type="button"' +
+                (cdSel ? ' aria-pressed="true"' : "") +
+                ">" +
+                cd +
+                "</button>",
             );
           }
           return (
@@ -1596,7 +1607,11 @@
             '<div class="ds-calendar__weekdays">' +
             calWeek +
             "</div>" +
-            '<div class="ds-calendar__grid" role="grid">' +
+            // No role="grid": a real grid requires row/gridcell descendants,
+            // which this static month strip does not provide; claiming the role
+            // without them is invalid ARIA (axe aria-required-children). Left as
+            // a styled group of day buttons; selection carried via aria-pressed.
+            '<div class="ds-calendar__grid">' +
             calCells.join("") +
             "</div>" +
             "</div>"

--- a/plugins/actian-design-system/scripts/renderers/html-renderers/ds-html-map.js
+++ b/plugins/actian-design-system/scripts/renderers/html-renderers/ds-html-map.js
@@ -1312,6 +1312,121 @@
           );
         }
 
+        // ---- Hi-Fi A1 (narrow) — degraded-slug overrides. Batch 1: overlays ----
+
+        case "popover": {
+          // Registry axis: Type = Interaction guide | Advanced search; prop
+          // "Show info icon". A floating card: optional info icon + title +
+          // body + arrow. role=dialog for assistive tech.
+          var poAdvanced = v.Type === "Advanced search";
+          var poCls =
+            "ds-popover" + (poAdvanced ? " ds-popover--advanced-search" : "");
+          var poInfo = props["Show info icon"]
+            ? '<span class="ds-popover__info" aria-hidden="true">' +
+              renderIcon("help-circle") +
+              "</span>"
+            : "";
+          var poTitle = props.Title
+            ? '<span class="ds-popover__title">' + esc(props.Title) + "</span>"
+            : "";
+          var poBody = props.Body
+            ? '<span class="ds-popover__body">' + esc(props.Body) + "</span>"
+            : "";
+          return (
+            '<div class="' +
+            poCls +
+            '" role="dialog" aria-label="' +
+            esc(props.Title || "Popover") +
+            '">' +
+            '<div class="ds-popover__header">' +
+            poInfo +
+            poTitle +
+            "</div>" +
+            poBody +
+            '<span class="ds-popover__arrow" aria-hidden="true"></span>' +
+            "</div>"
+          );
+        }
+
+        case "account-dropdown": {
+          // No registry variants/props (single-import; nested help-bubble /
+          // arrow-down / exit baked into the Figma component). Render an account
+          // menu overlay: identity header + default items (Items prop overrides).
+          var acName = esc(props.Name || "Account user");
+          var acEmail = props.Email
+            ? '<span class="ds-account-menu__email">' +
+              esc(props.Email) +
+              "</span>"
+            : "";
+          var acIcons = {
+            "account settings": "settings",
+            help: "help-bubble",
+            "sign out": "exit",
+          };
+          var acList = parseItems(props.Items, "Account settings,Help,Sign out")
+            .map(function (label) {
+              var ico = acIcons[label.toLowerCase()];
+              var g = ico
+                ? '<span class="ds-account-menu__icon" aria-hidden="true">' +
+                  renderIcon(ico) +
+                  "</span>"
+                : "";
+              return (
+                '<span class="ds-account-menu__item" role="menuitem">' +
+                g +
+                '<span class="ds-account-menu__label">' +
+                esc(label) +
+                "</span></span>"
+              );
+            })
+            .join("");
+          return (
+            '<div class="ds-account-menu" role="menu" aria-label="Account">' +
+            '<div class="ds-account-menu__header">' +
+            '<span class="ds-account-menu__name">' +
+            acName +
+            "</span>" +
+            acEmail +
+            "</div>" +
+            '<div class="ds-account-menu__items">' +
+            acList +
+            "</div>" +
+            "</div>"
+          );
+        }
+
+        case "app-switcher-dropdown": {
+          // No registry variants/props (single-import; nested settings /
+          // arrow-down baked in). Render an app-switcher menu overlay: an app
+          // list + a settings row (Items prop overrides the app list).
+          var asList = parseItems(
+            props.Items,
+            "Data Studio,Data Catalog,Data Integration",
+          )
+            .map(function (label) {
+              return (
+                '<span class="ds-app-switcher__app" role="menuitem">' +
+                '<span class="ds-app-switcher__tile" aria-hidden="true"></span>' +
+                '<span class="ds-app-switcher__label">' +
+                esc(label) +
+                "</span></span>"
+              );
+            })
+            .join("");
+          return (
+            '<div class="ds-app-switcher" role="menu" aria-label="Switch app">' +
+            '<div class="ds-app-switcher__apps">' +
+            asList +
+            "</div>" +
+            '<span class="ds-app-switcher__settings" role="menuitem">' +
+            '<span class="ds-app-switcher__icon" aria-hidden="true">' +
+            renderIcon("settings") +
+            "</span>" +
+            '<span class="ds-app-switcher__label">Settings</span></span>' +
+            "</div>"
+          );
+        }
+
         default: {
           // Anatomy dispatch: if an assemble-time anatomy map was supplied,
           // look up the pre-rendered HTML. Browser deliverables embed it on
@@ -1364,6 +1479,10 @@
     "dropdown-select-default",
     "progress-bar-small",
     "tag-interactive",
+    // Hi-Fi A1 (narrow) — degraded-slug overrides. Batch 1: overlays.
+    "popover",
+    "account-dropdown",
+    "app-switcher-dropdown",
   ];
 
   exports.renderDSComponent = renderDSComponent;

--- a/plugins/actian-design-system/scripts/renderers/html-renderers/ds-html-map.js
+++ b/plugins/actian-design-system/scripts/renderers/html-renderers/ds-html-map.js
@@ -1321,11 +1321,15 @@
           var poAdvanced = v.Type === "Advanced search";
           var poCls =
             "ds-popover" + (poAdvanced ? " ds-popover--advanced-search" : "");
-          var poInfo = props["Show info icon"]
-            ? '<span class="ds-popover__info" aria-hidden="true">' +
-              renderIcon("help-circle") +
-              "</span>"
-            : "";
+          // "Show info icon" is a default-TRUE registry boolean → shown unless
+          // explicitly false (the file's default-true convention, cf. radio /
+          // toggle / tag-interactive: `props[x] !== false`).
+          var poInfo =
+            props["Show info icon"] !== false
+              ? '<span class="ds-popover__info" aria-hidden="true">' +
+                renderIcon("help-circle") +
+                "</span>"
+              : "";
           var poTitle = props.Title
             ? '<span class="ds-popover__title">' + esc(props.Title) + "</span>"
             : "";
@@ -1487,13 +1491,16 @@
             tbBtn("view", "View") +
             tbBtn("more", "More") +
             "</div>";
-          var tbScale = props["Show View scale"]
-            ? '<div class="ds-toolbar__scale">' +
-              tbBtn("zoom-out", "Zoom out") +
-              '<span class="ds-toolbar__scale-value">100%</span>' +
-              tbBtn("zoom-in", "Zoom in") +
-              "</div>"
-            : "";
+          // "Show View scale" is a default-TRUE registry boolean → shown unless
+          // explicitly false (the file's default-true convention).
+          var tbScale =
+            props["Show View scale"] !== false
+              ? '<div class="ds-toolbar__scale">' +
+                tbBtn("zoom-out", "Zoom out") +
+                '<span class="ds-toolbar__scale-value">100%</span>' +
+                tbBtn("zoom-in", "Zoom in") +
+                "</div>"
+              : "";
           return (
             '<div class="' +
             tbCls +

--- a/plugins/actian-design-system/tests/integration/flow-share-a1-overrides.test.js
+++ b/plugins/actian-design-system/tests/integration/flow-share-a1-overrides.test.js
@@ -1,0 +1,60 @@
+"use strict";
+
+// flow-share-a1-overrides.test.js — DELIVERABLE-level proof for the Hi-Fi A1
+// degraded-slug leaf overrides. The canonical generate-flow deliverable is the
+// server-side flow-share render (Node, no window). A leaf can pass every unit
+// test yet be inert in this path (Slice-1 durable lesson), so we assert each
+// override's signature class appears in assembleFlowShare output — and that the
+// slug does NOT fall back to a chip (data-slug) or anatomy (data-ds-slug).
+//
+// Markers (non-substring, per Slice-1): override = a distinct ds-* class;
+// chip = data-slug="<slug>"; anatomy = data-ds-slug="<slug>".
+// Repo style: node:test + node:assert.
+
+var { describe, it } = require("node:test");
+var assert = require("node:assert");
+var {
+  assembleFlowShare,
+} = require("../../scripts/renderers/assemble-flow-share.js");
+
+// slug → override signature class. Grown per batch as overrides land.
+var A1_OVERRIDES = [
+  { slug: "popover", cls: "ds-popover" },
+  { slug: "account-dropdown", cls: "ds-account-menu" },
+  { slug: "app-switcher-dropdown", cls: "ds-app-switcher" },
+];
+
+function fixture(slug) {
+  return {
+    meta: { library: "ds", app: "Test App", feature: "A1 overrides" },
+    screens: [
+      {
+        name: "Screen 1",
+        library: "ds",
+        content: [{ type: "INSTANCE", library: "ds", dsSlug: slug, props: {} }],
+      },
+    ],
+  };
+}
+
+describe("flow-share: A1 override slugs render as leaves, not chips/anatomy", function () {
+  A1_OVERRIDES.forEach(function (t) {
+    it(t.slug + " → " + t.cls + " in the canonical flow-share output", function () {
+      var html = assembleFlowShare(fixture(t.slug));
+      assert.ok(
+        html.indexOf(t.cls) !== -1,
+        t.slug + " must render its override class " + t.cls,
+      );
+      assert.strictEqual(
+        html.indexOf('data-slug="' + t.slug + '"'),
+        -1,
+        t.slug + " must NOT fall back to a chip (data-slug)",
+      );
+      assert.strictEqual(
+        html.indexOf('data-ds-slug="' + t.slug + '"'),
+        -1,
+        t.slug + " must NOT fall back to anatomy (data-ds-slug)",
+      );
+    });
+  });
+});

--- a/plugins/actian-design-system/tests/integration/flow-share-a1-overrides.test.js
+++ b/plugins/actian-design-system/tests/integration/flow-share-a1-overrides.test.js
@@ -25,6 +25,8 @@ var A1_OVERRIDES = [
   { slug: "segmented-control", cls: "ds-segmented" },
   { slug: "toolbar", cls: "ds-toolbar" },
   { slug: "sticky-footer", cls: "ds-sticky-footer" },
+  { slug: "loader", cls: "ds-loader" },
+  { slug: "calendar", cls: "ds-calendar" },
 ];
 
 function fixture(slug) {

--- a/plugins/actian-design-system/tests/integration/flow-share-a1-overrides.test.js
+++ b/plugins/actian-design-system/tests/integration/flow-share-a1-overrides.test.js
@@ -22,6 +22,9 @@ var A1_OVERRIDES = [
   { slug: "popover", cls: "ds-popover" },
   { slug: "account-dropdown", cls: "ds-account-menu" },
   { slug: "app-switcher-dropdown", cls: "ds-app-switcher" },
+  { slug: "segmented-control", cls: "ds-segmented" },
+  { slug: "toolbar", cls: "ds-toolbar" },
+  { slug: "sticky-footer", cls: "ds-sticky-footer" },
 ];
 
 function fixture(slug) {
@@ -39,22 +42,25 @@ function fixture(slug) {
 
 describe("flow-share: A1 override slugs render as leaves, not chips/anatomy", function () {
   A1_OVERRIDES.forEach(function (t) {
-    it(t.slug + " → " + t.cls + " in the canonical flow-share output", function () {
-      var html = assembleFlowShare(fixture(t.slug));
-      assert.ok(
-        html.indexOf(t.cls) !== -1,
-        t.slug + " must render its override class " + t.cls,
-      );
-      assert.strictEqual(
-        html.indexOf('data-slug="' + t.slug + '"'),
-        -1,
-        t.slug + " must NOT fall back to a chip (data-slug)",
-      );
-      assert.strictEqual(
-        html.indexOf('data-ds-slug="' + t.slug + '"'),
-        -1,
-        t.slug + " must NOT fall back to anatomy (data-ds-slug)",
-      );
-    });
+    it(
+      t.slug + " → " + t.cls + " in the canonical flow-share output",
+      function () {
+        var html = assembleFlowShare(fixture(t.slug));
+        assert.ok(
+          html.indexOf(t.cls) !== -1,
+          t.slug + " must render its override class " + t.cls,
+        );
+        assert.strictEqual(
+          html.indexOf('data-slug="' + t.slug + '"'),
+          -1,
+          t.slug + " must NOT fall back to a chip (data-slug)",
+        );
+        assert.strictEqual(
+          html.indexOf('data-ds-slug="' + t.slug + '"'),
+          -1,
+          t.slug + " must NOT fall back to anatomy (data-ds-slug)",
+        );
+      },
+    );
   });
 });

--- a/plugins/actian-design-system/tests/integration/flow-share-a1-overrides.test.js
+++ b/plugins/actian-design-system/tests/integration/flow-share-a1-overrides.test.js
@@ -48,9 +48,14 @@ describe("flow-share: A1 override slugs render as leaves, not chips/anatomy", fu
       t.slug + " → " + t.cls + " in the canonical flow-share output",
       function () {
         var html = assembleFlowShare(fixture(t.slug));
+        // Assert the class-ATTRIBUTE form, not the bare class name: the full
+        // ds-base.css is inlined into the deliverable, so `indexOf("ds-popover")`
+        // matches the `.ds-popover {` CSS rule even when NO node rendered (a
+        // vacuous check — the inert-deliverable trap). `class="ds-popover` only
+        // appears in emitted markup, so this proves the override actually fired.
         assert.ok(
-          html.indexOf(t.cls) !== -1,
-          t.slug + " must render its override class " + t.cls,
+          html.indexOf('class="' + t.cls) !== -1,
+          t.slug + ' must render its override (class="' + t.cls + '")',
         );
         assert.strictEqual(
           html.indexOf('data-slug="' + t.slug + '"'),

--- a/plugins/actian-design-system/tests/renderers/ds-html-map.test.js
+++ b/plugins/actian-design-system/tests/renderers/ds-html-map.test.js
@@ -2698,6 +2698,21 @@ describe("ds-html-map: app-switcher-dropdown (A1)", function () {
     assert.ok(html.indexOf("Settings") !== -1, "settings row");
     assert.ok(html.indexOf('role="menu"') !== -1, "menu semantics");
   });
+
+  it("falls back to a default app list when no Items given", function () {
+    var html = render({
+      type: "INSTANCE",
+      library: "ds",
+      dsSlug: "app-switcher-dropdown",
+      props: {},
+    });
+    assert.ok(
+      html.indexOf("ds-app-switcher__app") !== -1,
+      "default apps rendered",
+    );
+    assert.ok(html.indexOf("Data Studio") !== -1, "default app label");
+    assert.ok(html.indexOf("Settings") !== -1, "settings row present");
+  });
 });
 
 // ---------------------------------------------------------------------------
@@ -2841,6 +2856,14 @@ describe("ds-html-map: calendar (A1)", function () {
     assert.ok(html.indexOf("is-selected") !== -1, "a selected day");
     assert.ok(html.indexOf(">15</button>") !== -1, "renders day cells");
     assert.ok(html.indexOf("ds-icon") !== -1, "nav chevrons");
+    assert.ok(
+      html.indexOf('aria-pressed="true"') !== -1,
+      "selected day carries non-visual selection state",
+    );
+    assert.ok(
+      html.indexOf('role="grid"') === -1,
+      "no invalid role=grid (lacks row/gridcell descendants)",
+    );
   });
 
   it("Selection=Range renders a start→end band", function () {

--- a/plugins/actian-design-system/tests/renderers/ds-html-map.test.js
+++ b/plugins/actian-design-system/tests/renderers/ds-html-map.test.js
@@ -2622,7 +2622,7 @@ describe("ds-html-map: popover (A1)", function () {
     assert.ok(html.indexOf("ds-icon") !== -1, "info icon glyph shown");
   });
 
-  it("Type=Advanced search adds the modifier; info icon off by default", function () {
+  it("Type=Advanced search adds the modifier; info icon shown by default (registry default-true)", function () {
     var html = render({
       type: "INSTANCE",
       library: "ds",
@@ -2635,8 +2635,21 @@ describe("ds-html-map: popover (A1)", function () {
       "advanced-search modifier",
     );
     assert.ok(
+      html.indexOf("ds-popover__info") !== -1,
+      "info icon shown by default (Show info icon defaults true in the registry)",
+    );
+  });
+
+  it('hides the info icon only when "Show info icon" is explicitly false', function () {
+    var html = render({
+      type: "INSTANCE",
+      library: "ds",
+      dsSlug: "popover",
+      props: { Title: "Filters", "Show info icon": false },
+    });
+    assert.ok(
       html.indexOf("ds-popover__info") === -1,
-      "no info icon by default",
+      "explicit false hides the info icon",
     );
   });
 
@@ -2766,7 +2779,7 @@ describe("ds-html-map: toolbar (A1)", function () {
     assert.ok(html.indexOf("ds-icon") !== -1, "action icons present");
   });
 
-  it("Orientation=Vertical adds the modifier; no scale by default", function () {
+  it("Orientation=Vertical adds the modifier; scale shown by default (registry default-true)", function () {
     var html = render({
       type: "INSTANCE",
       library: "ds",
@@ -2775,7 +2788,23 @@ describe("ds-html-map: toolbar (A1)", function () {
       props: {},
     });
     assert.ok(html.indexOf("ds-toolbar--vertical") !== -1, "vertical modifier");
-    assert.ok(html.indexOf("ds-toolbar__scale") === -1, "no scale by default");
+    assert.ok(
+      html.indexOf("ds-toolbar__scale") !== -1,
+      "view scale shown by default (Show View scale defaults true in the registry)",
+    );
+  });
+
+  it('hides the view scale only when "Show View scale" is explicitly false', function () {
+    var html = render({
+      type: "INSTANCE",
+      library: "ds",
+      dsSlug: "toolbar",
+      props: { "Show View scale": false },
+    });
+    assert.ok(
+      html.indexOf("ds-toolbar__scale") === -1,
+      "explicit false hides the view scale",
+    );
   });
 });
 
@@ -2887,5 +2916,58 @@ describe("ds-html-map: calendar (A1)", function () {
       props: { Month: "March 2027" },
     });
     assert.ok(html.indexOf("March 2027") !== -1, "custom month label");
+  });
+});
+
+// Never-throws + no silent chip-degradation on hostile (object/array-shaped)
+// flow-data props — for the A1 slugs that lack a dedicated hostile-prop test
+// (popover + loader already have theirs above). esc()/String() coercion must
+// keep these rendering their real leaf, not degrading to a chip.
+describe("ds-html-map: A1 hostile-prop robustness", function () {
+  var HOSTILE = {
+    Title: { x: 1 },
+    Body: [1, 2],
+    Items: { a: 1 },
+    Name: [1],
+    Email: {},
+    Label: [1],
+    Active: {},
+    Primary: {},
+    Secondary: [1],
+    Month: {},
+    Segments: { s: 1 },
+  };
+  [
+    { slug: "account-dropdown", cls: "ds-account-menu" },
+    { slug: "app-switcher-dropdown", cls: "ds-app-switcher" },
+    { slug: "segmented-control", cls: "ds-segmented" },
+    { slug: "toolbar", cls: "ds-toolbar" },
+    { slug: "sticky-footer", cls: "ds-sticky-footer" },
+    { slug: "calendar", cls: "ds-calendar" },
+  ].forEach(function (t) {
+    it(
+      t.slug + " renders its leaf (no throw, no chip) on hostile props",
+      function () {
+        var html = render({
+          type: "INSTANCE",
+          library: "ds",
+          dsSlug: t.slug,
+          variant: "Selection=Range,Orientation=Vertical",
+          props: HOSTILE,
+        });
+        assert.ok(
+          typeof html === "string" && html.length > 0,
+          "returns a string",
+        );
+        assert.ok(
+          html.indexOf(t.cls) !== -1,
+          t.slug + " still renders its leaf",
+        );
+        assert.ok(
+          html.indexOf("ds-component") === -1,
+          t.slug + " did not silently chip-degrade",
+        );
+      },
+    );
   });
 });

--- a/plugins/actian-design-system/tests/renderers/ds-html-map.test.js
+++ b/plugins/actian-design-system/tests/renderers/ds-html-map.test.js
@@ -2793,3 +2793,76 @@ describe("ds-html-map: sticky-footer (A1)", function () {
     assert.ok(html.indexOf("Cancel") !== -1, "default secondary");
   });
 });
+
+// ---------------------------------------------------------------------------
+// Hi-Fi A1 (narrow) — degraded-slug leaf overrides. Batch 3: feedback + date.
+// ---------------------------------------------------------------------------
+
+describe("ds-html-map: loader (A1)", function () {
+  it("renders a spinner — not a chip — with status role + optional label", function () {
+    var html = render({
+      type: "INSTANCE",
+      library: "ds",
+      dsSlug: "loader",
+      props: { Label: "Fetching results" },
+    });
+    assert.ok(html.indexOf("ds-loader") !== -1, "loader leaf class");
+    assert.ok(html.indexOf("ds-component") === -1, "loader not a chip");
+    assert.ok(html.indexOf("ds-loader__spinner") !== -1, "spinner element");
+    assert.ok(html.indexOf('role="status"') !== -1, "status role");
+    assert.ok(html.indexOf("Fetching results") !== -1, "label text");
+  });
+
+  it("renders without a label and never throws", function () {
+    var html = render({
+      type: "INSTANCE",
+      library: "ds",
+      dsSlug: "loader",
+      props: {},
+    });
+    assert.ok(html.indexOf("ds-loader__spinner") !== -1, "spinner still shown");
+    assert.ok(typeof html === "string", "returns a string");
+  });
+});
+
+describe("ds-html-map: calendar (A1)", function () {
+  it("renders a month grid — not a chip — with header, weekdays, selected day", function () {
+    var html = render({
+      type: "INSTANCE",
+      library: "ds",
+      dsSlug: "calendar",
+      variant: "Selection=Single",
+      props: {},
+    });
+    assert.ok(html.indexOf("ds-calendar") !== -1, "calendar leaf class");
+    assert.ok(html.indexOf("ds-component") === -1, "calendar not a chip");
+    assert.ok(html.indexOf("ds-calendar__month") !== -1, "month header");
+    assert.ok(html.indexOf("ds-calendar__weekdays") !== -1, "weekday row");
+    assert.ok(html.indexOf("is-selected") !== -1, "a selected day");
+    assert.ok(html.indexOf(">15</button>") !== -1, "renders day cells");
+    assert.ok(html.indexOf("ds-icon") !== -1, "nav chevrons");
+  });
+
+  it("Selection=Range renders a start→end band", function () {
+    var html = render({
+      type: "INSTANCE",
+      library: "ds",
+      dsSlug: "calendar",
+      variant: "Selection=Range",
+      props: {},
+    });
+    assert.ok(html.indexOf("is-range-start") !== -1, "range start");
+    assert.ok(html.indexOf("is-range-end") !== -1, "range end");
+    assert.ok(html.indexOf("is-selected") === -1, "no single-select in range");
+  });
+
+  it("uses a provided Month label deterministically", function () {
+    var html = render({
+      type: "INSTANCE",
+      library: "ds",
+      dsSlug: "calendar",
+      props: { Month: "March 2027" },
+    });
+    assert.ok(html.indexOf("March 2027") !== -1, "custom month label");
+  });
+});

--- a/plugins/actian-design-system/tests/renderers/ds-html-map.test.js
+++ b/plugins/actian-design-system/tests/renderers/ds-html-map.test.js
@@ -2699,3 +2699,97 @@ describe("ds-html-map: app-switcher-dropdown (A1)", function () {
     assert.ok(html.indexOf('role="menu"') !== -1, "menu semantics");
   });
 });
+
+// ---------------------------------------------------------------------------
+// Hi-Fi A1 (narrow) — degraded-slug leaf overrides. Batch 2: controls.
+// ---------------------------------------------------------------------------
+
+describe("ds-html-map: segmented-control (A1)", function () {
+  it("renders a segmented control — not a chip — with items + active", function () {
+    var html = render({
+      type: "INSTANCE",
+      library: "ds",
+      dsSlug: "segmented-control",
+      props: { Items: "List, Grid, Board", Active: "Grid" },
+    });
+    assert.ok(html.indexOf("ds-segmented") !== -1, "segmented leaf class");
+    assert.ok(html.indexOf("ds-component") === -1, "segmented not a chip");
+    assert.ok(html.indexOf("List") !== -1, "item 1");
+    assert.ok(html.indexOf("Board") !== -1, "item 3");
+    assert.ok(html.indexOf('role="tablist"') !== -1, "tablist semantics");
+    assert.ok(
+      /Grid<\/span>/.test(html) && html.indexOf("is-active") !== -1,
+      "active item flagged",
+    );
+  });
+
+  it("defaults to two options with the first active", function () {
+    var html = render({
+      type: "INSTANCE",
+      library: "ds",
+      dsSlug: "segmented-control",
+      props: {},
+    });
+    assert.ok(html.indexOf("is-active") !== -1, "an item is active by default");
+    assert.ok(html.indexOf('aria-selected="true"') !== -1, "aria-selected set");
+  });
+});
+
+describe("ds-html-map: toolbar (A1)", function () {
+  it("renders a toolbar — not a chip — with action buttons + view scale", function () {
+    var html = render({
+      type: "INSTANCE",
+      library: "ds",
+      dsSlug: "toolbar",
+      variant: "Type=Combined,Orientation=Horizontal",
+      props: { "Show View scale": true },
+    });
+    assert.ok(html.indexOf("ds-toolbar") !== -1, "toolbar leaf class");
+    assert.ok(html.indexOf("ds-component") === -1, "toolbar not a chip");
+    assert.ok(html.indexOf('role="toolbar"') !== -1, "toolbar semantics");
+    assert.ok(html.indexOf("ds-toolbar__scale") !== -1, "view scale shown");
+    assert.ok(html.indexOf("ds-icon") !== -1, "action icons present");
+  });
+
+  it("Orientation=Vertical adds the modifier; no scale by default", function () {
+    var html = render({
+      type: "INSTANCE",
+      library: "ds",
+      dsSlug: "toolbar",
+      variant: "Orientation=Vertical",
+      props: {},
+    });
+    assert.ok(html.indexOf("ds-toolbar--vertical") !== -1, "vertical modifier");
+    assert.ok(html.indexOf("ds-toolbar__scale") === -1, "no scale by default");
+  });
+});
+
+describe("ds-html-map: sticky-footer (A1)", function () {
+  it("renders a sticky footer — not a chip — with DS action buttons", function () {
+    var html = render({
+      type: "INSTANCE",
+      library: "ds",
+      dsSlug: "sticky-footer",
+      props: { Primary: "Publish", Secondary: "Discard" },
+    });
+    assert.ok(html.indexOf("ds-sticky-footer") !== -1, "sticky-footer class");
+    assert.ok(html.indexOf("ds-component") === -1, "sticky-footer not a chip");
+    assert.ok(html.indexOf("Publish") !== -1, "primary action label");
+    assert.ok(html.indexOf("Discard") !== -1, "secondary action label");
+    assert.ok(
+      html.indexOf("ds-button--primary") !== -1,
+      "reuses the DS button primary class",
+    );
+  });
+
+  it("defaults to Cancel + Save", function () {
+    var html = render({
+      type: "INSTANCE",
+      library: "ds",
+      dsSlug: "sticky-footer",
+      props: {},
+    });
+    assert.ok(html.indexOf("Save") !== -1, "default primary");
+    assert.ok(html.indexOf("Cancel") !== -1, "default secondary");
+  });
+});

--- a/plugins/actian-design-system/tests/renderers/ds-html-map.test.js
+++ b/plugins/actian-design-system/tests/renderers/ds-html-map.test.js
@@ -2597,3 +2597,105 @@ describe("ds-html-map: dispatch override → anatomy → chip", function () {
     );
   });
 });
+
+// ---------------------------------------------------------------------------
+// Hi-Fi A1 (narrow) — degraded-slug leaf overrides. Batch 1: overlays.
+// ---------------------------------------------------------------------------
+
+describe("ds-html-map: popover (A1)", function () {
+  it("renders a popover card — not a chip — with title + body + info icon", function () {
+    var html = render({
+      type: "INSTANCE",
+      library: "ds",
+      dsSlug: "popover",
+      variant: "Type=Interaction guide",
+      props: {
+        Title: "Quick tip",
+        Body: "Do this next",
+        "Show info icon": true,
+      },
+    });
+    assert.ok(html.indexOf("ds-popover") !== -1, "popover built leaf class");
+    assert.ok(html.indexOf("ds-component") === -1, "popover not a chip");
+    assert.ok(html.indexOf("Quick tip") !== -1, "title text");
+    assert.ok(html.indexOf("Do this next") !== -1, "body text");
+    assert.ok(html.indexOf("ds-icon") !== -1, "info icon glyph shown");
+  });
+
+  it("Type=Advanced search adds the modifier; info icon off by default", function () {
+    var html = render({
+      type: "INSTANCE",
+      library: "ds",
+      dsSlug: "popover",
+      variant: "Type=Advanced search",
+      props: { Title: "Filters" },
+    });
+    assert.ok(
+      html.indexOf("ds-popover--advanced-search") !== -1,
+      "advanced-search modifier",
+    );
+    assert.ok(
+      html.indexOf("ds-popover__info") === -1,
+      "no info icon by default",
+    );
+  });
+
+  it("hostile prop shape does not throw", function () {
+    var html = render({
+      type: "INSTANCE",
+      library: "ds",
+      dsSlug: "popover",
+      props: { Title: { bad: 1 }, Body: [1, 2] },
+    });
+    assert.ok(typeof html === "string", "returns a string, never throws");
+  });
+});
+
+describe("ds-html-map: account-dropdown (A1)", function () {
+  it("renders an account menu — not a chip — with identity + default items", function () {
+    var html = render({
+      type: "INSTANCE",
+      library: "ds",
+      dsSlug: "account-dropdown",
+      props: { Name: "Ada Lovelace", Email: "ada@example.com" },
+    });
+    assert.ok(
+      html.indexOf("ds-account-menu") !== -1,
+      "account-menu leaf class",
+    );
+    assert.ok(html.indexOf("ds-component") === -1, "account-menu not a chip");
+    assert.ok(html.indexOf("Ada Lovelace") !== -1, "name text");
+    assert.ok(html.indexOf("ada@example.com") !== -1, "email text");
+    assert.ok(html.indexOf("Sign out") !== -1, "default sign-out item");
+    assert.ok(html.indexOf('role="menu"') !== -1, "menu semantics");
+  });
+
+  it("accepts a custom Items list", function () {
+    var html = render({
+      type: "INSTANCE",
+      library: "ds",
+      dsSlug: "account-dropdown",
+      props: { Items: "Profile, Preferences, Log out" },
+    });
+    assert.ok(html.indexOf("Preferences") !== -1, "custom item rendered");
+  });
+});
+
+describe("ds-html-map: app-switcher-dropdown (A1)", function () {
+  it("renders an app switcher menu — not a chip — with apps + settings", function () {
+    var html = render({
+      type: "INSTANCE",
+      library: "ds",
+      dsSlug: "app-switcher-dropdown",
+      props: { Items: "Data Studio, Catalog" },
+    });
+    assert.ok(
+      html.indexOf("ds-app-switcher") !== -1,
+      "app-switcher leaf class",
+    );
+    assert.ok(html.indexOf("ds-component") === -1, "app-switcher not a chip");
+    assert.ok(html.indexOf("Data Studio") !== -1, "app item text");
+    assert.ok(html.indexOf("Settings") !== -1, "settings row");
+    assert.ok(html.indexOf('role="menu"') !== -1, "menu semantics");
+  });
+});


### PR DESCRIPTION
## What

A1-narrow of the Skills x Knowledge x Hifi-Direct program (Axis A, HTML leaf coverage). Lifts the 8 highest-value **degraded** DS slugs from the degraded anatomy floor to hand-authored, token-bound HTML leaf overrides, the same mechanism behind the existing 27 overrides.

A3 (#207) made the Figma tier high-fidelity (real DS Kit instances for all 69 slugs). That left the HTML tier as the binding constraint on the program's "consistent HTML and Figma output" goal, with 12 slugs still rendering from the degraded anatomy floor (health < 0.6). This closes 8 of them.

**Coverage: override 27 to 35, degraded 12 to 4.** The 4 remaining degraded slugs are the deferred Tier-B niche data-catalog viz fragments (glossary hierarchy diagram, lineage node/line, loader-with-logo), which are a different rendering model and rarely appear in flows.

Plugin version: `2026.6.30` to `2026.7.0` (new month).

## The 8 leaves

| Slug | Category | Prior health |
|---|---|---|
| popover | Overlays | 0.46 |
| account-dropdown | Navigation | 0.38 |
| app-switcher-dropdown | Navigation | 0.33 |
| segmented-control | control | 0.50 |
| toolbar | Data Display | 0.50 |
| sticky-footer | Action | 0.40 |
| loader | Feedback | 0.50 |
| calendar | Form input | 0.24 |

Each override = a `renderDSComponent` switch case (token-bound `ds-<slug>` HTML, never-throws, `renderIcon` for glyphs) + a `BUILT_SLUGS` entry (lockstep-gated) + a `--zen-*`-bound CSS block in `ds-base.css` + unit tests + a deliverable-level `assembleFlowShare` proof. Built TDD, RED to GREEN per batch. Determinism enforced (no `Date()`; the calendar renders a static month).

## Review

Two rounds. A whole-branch pass caught and fixed the inert-deliverable trap in the proof itself (the full `ds-base.css` is inlined into flow-share output, so `indexOf("ds-popover")` matched the CSS rule even for an unrendered node; the assertion now checks the `class="ds-popover"` attribute form) plus an invalid `role="grid"` on the calendar (a grid role needs row/gridcell children; selection now rides `aria-pressed`).

A second independent full review (3 fresh read-only reviewers: correctness/a11y, CSS/tokens/conventions, cross-file/downstream) returned CLEAN and surfaced 7 findings, all triaged in `3b32981d`:

- **popover `Show info icon` and toolbar `Show View scale`** are registry `BOOLEAN default:true`, but were read with a bare-truthy check, so an unset prop hid them (under-rendering the component default). Now `props[x] !== false`, matching the file's default-true convention. Tests flipped, explicit-false paths added.
- **calendar strong-fill** `--zen-color-bg-primary` to `--zen-color-bg-emphasis` (the canonical Figma `color-bg-primary` alias this file and `.ds-button--primary` standardize on; same color across all 3 themes today, but theme-robust).
- **quality-gate `PILOT` list**: added the 8 leaves (Slice-1 override leaves were already in it; leaving these out silently skipped the structural fidelity gate). See the cost note below.
- **hostile-prop robustness tests** for the 6 A1 slugs that lacked them (never-throw, no silent chip-degradation).

## Two deliberate deferrals for your call

Both are design/a11y judgment calls the branch scopes to the planned Phase 1d axe gate rather than this slice:

1. **loader ignores its `Percent` variant axis.** It renders an indeterminate spinner (activity indicator). The registry axis is `Percent` (["99%","10%","Percent3"]), which suggests a determinate ring, but the axis values are auto-generated and murky, and an indeterminate spinner is a valid loader. Honoring `Percent` (determinate ring) would be a fidelity improvement if that is what the real DS loader is. Want me to make it determinate?
2. **popover `role="dialog"`** over-claims for a non-modal hint card (`role="tooltip"` or a labelled region is more accurate for the "Interaction guide" variant). Kept as-is to match the existing overlay leaves; a systematic role pass belongs to the axe gate.

## Cost note

Adding the 8 leaves to the quality-gate `PILOT` roughly +90s to the chrome-gated `quality-gates-cli.test.js` (222s for 19 slugs, up from ~130s). It passes and is report-only. If CI time matters, trim `PILOT` back.

## Testing

Full suite **1806 / 1807**. The single failure is the known `vendor-paths-resolve` LOCAL-ONLY false positive (it flags a gitignored local plan file's prose; invisible to CI). Coverage report confirms override 35 / degraded 4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
