### PR TITLE
feat(render): variant-aware harvest render, slice 1 (tag-default token injection)

### DIFF
--- a/plugins/actian-design-system/.claude-plugin/plugin.json
+++ b/plugins/actian-design-system/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "actian-design-system",
   "description": "Actian Design System toolkit — generate wireframe flows with prototype wiring, create component briefs, audit designs, compare flows, and build presentations. 8 skills (with tiered generation: recognized / adapted / improvised), 9 agents, 155 tokens (3 themes, 8 collections), WCAG 2.2 AA. DS knowledge vendored from volivarii/actian-ds-knowledge.",
-  "version": "2026.7.7",
+  "version": "2026.7.8",
   "author": {
     "name": "Actian UX Team"
   },

--- a/plugins/actian-design-system/scripts/renderers/anatomy-render.js
+++ b/plugins/actian-design-system/scripts/renderers/anatomy-render.js
@@ -45,7 +45,8 @@ function loadAnatomy(slug, loader) {
 function loadTokenBindings(slug, loader) {
   if (typeof loader === "function") return loader(slug);
   try {
-    var p = PATHS.components.tokenBindings && PATHS.components.tokenBindings[slug];
+    var p =
+      PATHS.components.tokenBindings && PATHS.components.tokenBindings[slug];
     if (typeof p !== "string") return null;
     var doc = JSON.parse(fs.readFileSync(p, "utf8"));
     return (doc && doc.byNodeId) || null;
@@ -86,18 +87,66 @@ function flexStyle(layout) {
 // schema-validated upstream, but the loader is injectable).
 var PROP_RE = /^[a-z][a-z-]*$/;
 var TOKEN_RE = /^--[a-zA-Z0-9-]+$/;
-function tokenDecls(node, byNodeId) {
-  if (!byNodeId || !node.id) return [];
-  var list = byNodeId[node.id];
+// Pick one binding for a property group given a target variant.
+// Precedence: scoped match > variantDefaults-scoped > unscoped > last.
+function pickBinding(cands, targetVariant, variantDefaults) {
+  var unscoped = null,
+    matched = null,
+    defaulted = null;
+  for (var i = 0; i < cands.length; i++) {
+    var b = cands[i];
+    var v = b.variant;
+    if (!v || !v.prop || !Array.isArray(v.values)) {
+      if (!unscoped) unscoped = b;
+      continue;
+    }
+    var target = targetVariant ? targetVariant[v.prop] : undefined;
+    if (target != null && v.values.indexOf(target) !== -1 && !matched)
+      matched = b;
+    var dv = variantDefaults ? variantDefaults[v.prop] : undefined;
+    if (dv != null && v.values.indexOf(dv) !== -1 && !defaulted) defaulted = b;
+  }
+  return matched || defaulted || unscoped || cands[cands.length - 1];
+}
+
+// Resolve the inline token declarations for one node's binding list.
+// No targetVariant -> emit every valid binding in order (current behavior).
+// With a targetVariant -> emit one decl per property via pickBinding.
+function resolveTokenDecls(list, targetVariant, variantDefaults) {
   if (!Array.isArray(list)) return [];
+  var valid = list.filter(function (b) {
+    return (
+      b &&
+      typeof b === "object" &&
+      PROP_RE.test(String(b.property || "")) &&
+      TOKEN_RE.test(String(b.token || ""))
+    );
+  });
+  if (!targetVariant) {
+    return valid.map(function (b) {
+      return b.property + ":var(" + b.token + ")";
+    });
+  }
+  var byProp = {},
+    order = [];
+  valid.forEach(function (b) {
+    if (!Object.prototype.hasOwnProperty.call(byProp, b.property)) {
+      byProp[b.property] = [];
+      order.push(b.property);
+    }
+    byProp[b.property].push(b);
+  });
   var decls = [];
-  list.forEach(function (b) {
-    if (!b || typeof b !== "object") return;
-    if (!PROP_RE.test(String(b.property || ""))) return;
-    if (!TOKEN_RE.test(String(b.token || ""))) return;
-    decls.push(b.property + ":var(" + b.token + ")");
+  order.forEach(function (prop) {
+    var chosen = pickBinding(byProp[prop], targetVariant, variantDefaults);
+    if (chosen) decls.push(prop + ":var(" + chosen.token + ")");
   });
   return decls;
+}
+
+function tokenDecls(node, byNodeId, targetVariant, variantDefaults) {
+  if (!byNodeId || !node.id) return [];
+  return resolveTokenDecls(byNodeId[node.id], targetVariant, variantDefaults);
 }
 function renderNode(node, byNodeId) {
   if (!node || typeof node !== "object") return "";
@@ -107,12 +156,20 @@ function renderNode(node, byNodeId) {
   if (kind === "text") {
     var textStyle = decls.length ? ' style="' + esc(decls.join(";")) + '"' : "";
     return (
-      '<span class="' + cls + '"' + textStyle + ">" + esc(node.text || "") + "</span>"
+      '<span class="' +
+      cls +
+      '"' +
+      textStyle +
+      ">" +
+      esc(node.text || "") +
+      "</span>"
     );
   }
   if (kind === "image" || kind === "vector") {
     var leafStyle = decls.length ? ' style="' + esc(decls.join(";")) + '"' : "";
-    return '<div class="' + cls + '"' + leafStyle + ' aria-hidden="true"></div>';
+    return (
+      '<div class="' + cls + '"' + leafStyle + ' aria-hidden="true"></div>'
+    );
   }
   var kids = Array.isArray(node.children)
     ? node.children
@@ -156,4 +213,5 @@ module.exports = {
   loadAnatomy: loadAnatomy,
   loadTokenBindings: loadTokenBindings,
   flexStyle: flexStyle,
+  resolveTokenDecls: resolveTokenDecls,
 };

--- a/plugins/actian-design-system/scripts/renderers/anatomy-render.js
+++ b/plugins/actian-design-system/scripts/renderers/anatomy-render.js
@@ -49,7 +49,11 @@ function loadTokenBindings(slug, loader) {
       PATHS.components.tokenBindings && PATHS.components.tokenBindings[slug];
     if (typeof p !== "string") return null;
     var doc = JSON.parse(fs.readFileSync(p, "utf8"));
-    return (doc && doc.byNodeId) || null;
+    if (!doc || typeof doc !== "object" || !doc.byNodeId) return null;
+    return {
+      byNodeId: doc.byNodeId,
+      variantDefaults: doc.variantDefaults || null,
+    };
   } catch (e) {
     return null;
   }
@@ -148,11 +152,11 @@ function tokenDecls(node, byNodeId, targetVariant, variantDefaults) {
   if (!byNodeId || !node.id) return [];
   return resolveTokenDecls(byNodeId[node.id], targetVariant, variantDefaults);
 }
-function renderNode(node, byNodeId) {
+function renderNode(node, byNodeId, targetVariant, variantDefaults) {
   if (!node || typeof node !== "object") return "";
   var kind = node.kind,
     cls = "ds-anatomy__" + (kind || "node");
-  var decls = tokenDecls(node, byNodeId);
+  var decls = tokenDecls(node, byNodeId, targetVariant, variantDefaults);
   if (kind === "text") {
     var textStyle = decls.length ? ' style="' + esc(decls.join(";")) + '"' : "";
     return (
@@ -174,7 +178,7 @@ function renderNode(node, byNodeId) {
   var kids = Array.isArray(node.children)
     ? node.children
         .map(function (c) {
-          return renderNode(c, byNodeId);
+          return renderNode(c, byNodeId, targetVariant, variantDefaults);
         })
         .join("")
     : "";
@@ -197,14 +201,16 @@ function renderAnatomy(dsSlug, opts) {
       ? data.quality.ratio
       : 0;
   if (ratio < minRatio) return null;
-  var byNodeId = loadTokenBindings(dsSlug, opts.bindingsLoader);
+  var bindings = loadTokenBindings(dsSlug, opts.bindingsLoader);
+  var byNodeId = bindings ? bindings.byNodeId : null;
+  var variantDefaults = bindings ? bindings.variantDefaults : null;
   return (
     '<div class="ds-anatomy ds-anatomy--' +
     esc(dsSlug) +
     '" data-ds-slug="' +
     esc(dsSlug) +
     '">' +
-    renderNode(data.root, byNodeId) +
+    renderNode(data.root, byNodeId, opts.variant || null, variantDefaults) +
     "</div>"
   );
 }

--- a/plugins/actian-design-system/scripts/renderers/anatomy-render.js
+++ b/plugins/actian-design-system/scripts/renderers/anatomy-render.js
@@ -38,7 +38,8 @@ function loadAnatomy(slug, loader) {
     return null;
   }
 }
-// byNodeId map from the vendored sidecar, or null when the slug has none.
+// Returns the sidecar { byNodeId, variantDefaults } from the vendored sidecar,
+// or null when the slug has none.
 // Sidecars are registered as per-slug manifest entries
 // (components.tokenBindings.<slug>), so the PATHS node is a plain
 // slug → absolute-path object — no byKey collection (yet).

--- a/plugins/actian-design-system/scripts/renderers/anatomy-render.js
+++ b/plugins/actian-design-system/scripts/renderers/anatomy-render.js
@@ -215,10 +215,35 @@ function renderAnatomy(dsSlug, opts) {
     "</div>"
   );
 }
+// Resolve the anatomy ROOT node's variant token declarations to an inline CSS
+// style string, for token-injection into a hand-authored template. Returns ""
+// when there is no anatomy, quality is below minRatio, there is no sidecar, or
+// the root has no resolvable bindings.
+function resolveRootTokenStyle(dsSlug, opts) {
+  opts = opts || {};
+  var minRatio = typeof opts.minRatio === "number" ? opts.minRatio : 0.6;
+  var data = loadAnatomy(dsSlug, opts.loader);
+  if (!data || !data.root || typeof data.root !== "object") return "";
+  var ratio =
+    data.quality && typeof data.quality.ratio === "number"
+      ? data.quality.ratio
+      : 0;
+  if (ratio < minRatio) return "";
+  var bindings = loadTokenBindings(dsSlug, opts.bindingsLoader);
+  if (!bindings || !bindings.byNodeId) return "";
+  var decls = resolveTokenDecls(
+    bindings.byNodeId[data.root.id],
+    opts.variant || null,
+    bindings.variantDefaults || null,
+  );
+  return decls.join(";");
+}
+
 module.exports = {
   renderAnatomy: renderAnatomy,
   loadAnatomy: loadAnatomy,
   loadTokenBindings: loadTokenBindings,
   flexStyle: flexStyle,
   resolveTokenDecls: resolveTokenDecls,
+  resolveRootTokenStyle: resolveRootTokenStyle,
 };

--- a/plugins/actian-design-system/scripts/renderers/assemble-flow-share.js
+++ b/plugins/actian-design-system/scripts/renderers/assemble-flow-share.js
@@ -62,6 +62,7 @@ function assembleFlowShare(data) {
   var anatomyHelpers = require("./ds-anatomy-map.js");
   var anatomyMap = anatomyHelpers.buildDsAnatomyMap(
     anatomyHelpers.collectDsSlugs(data),
+    { data: data },
   );
 
   // Assets (fail loudly if missing — same contract as readFileChecked).

--- a/plugins/actian-design-system/scripts/renderers/assemble-flow-share.js
+++ b/plugins/actian-design-system/scripts/renderers/assemble-flow-share.js
@@ -62,8 +62,12 @@ function assembleFlowShare(data) {
   var anatomyHelpers = require("./ds-anatomy-map.js");
   var anatomyMap = anatomyHelpers.buildDsAnatomyMap(
     anatomyHelpers.collectDsSlugs(data),
-    { data: data },
   );
+  // Token-injection tier (slice 1: tag-default): { anatomyVariantKey ->
+  // inline-style-string } for delegated slugs, so their hand-authored
+  // templates render with the harvested variant-correct token instead of
+  // being replaced by anatomy HTML.
+  var variantStyleMap = anatomyHelpers.buildDsVariantStyleMap(data);
 
   // Assets (fail loudly if missing — same contract as readFileChecked).
   var wrapper = readFileChecked(WRAPPER_PATH);
@@ -93,6 +97,7 @@ function assembleFlowShare(data) {
   var screensHtml = "";
   var navArray = [];
   dsHtmlMap.setAnatomyMap(anatomyMap);
+  dsHtmlMap.setVariantStyleMap(variantStyleMap);
   try {
     for (var s = 0; s < screens.length; s++) {
       var id = s + 1;
@@ -120,6 +125,7 @@ function assembleFlowShare(data) {
   } finally {
     // Reset module-level state so it never leaks into a later assembly.
     dsHtmlMap.setAnatomyMap(null);
+    dsHtmlMap.setVariantStyleMap(null);
   }
   // navJson sits inside a double-quoted HTML attribute (x-data="{ screens: … }").
   // esc (not escapeJsonForScript) is required: a bare " in a screen name would

--- a/plugins/actian-design-system/scripts/renderers/ds-anatomy-map.js
+++ b/plugins/actian-design-system/scripts/renderers/ds-anatomy-map.js
@@ -25,21 +25,18 @@ var {
 var parseVariant = require("./html-renderers/ds-html-map.js").parseVariant;
 
 /**
- * Collect every unique dsSlug from a flow data tree (screens → content → nodes).
- * Returns a deduplicated array of slug strings.
+ * Shared recursive tree-walk over a flow data tree (screens → content →
+ * nodes), invoking visitFn(node) for every node encountered (pre-order,
+ * children before nodes). Both collectors below differ only in what their
+ * visitor does with each node.
  */
-function collectDsSlugs(data) {
-  var seen = {};
-  var slugs = [];
+function walkDsContent(data, visitFn) {
   function walk(nodes) {
     if (!Array.isArray(nodes)) return;
     for (var i = 0; i < nodes.length; i++) {
       var n = nodes[i];
       if (!n || typeof n !== "object") continue;
-      if (typeof n.dsSlug === "string" && n.dsSlug && !seen[n.dsSlug]) {
-        seen[n.dsSlug] = true;
-        slugs.push(n.dsSlug);
-      }
+      visitFn(n);
       if (Array.isArray(n.children)) walk(n.children);
       if (Array.isArray(n.nodes)) walk(n.nodes);
     }
@@ -48,6 +45,21 @@ function collectDsSlugs(data) {
   for (var s = 0; s < screens.length; s++) {
     walk((screens[s] && screens[s].content) || []);
   }
+}
+
+/**
+ * Collect every unique dsSlug from a flow data tree (screens → content → nodes).
+ * Returns a deduplicated array of slug strings.
+ */
+function collectDsSlugs(data) {
+  var seen = {};
+  var slugs = [];
+  walkDsContent(data, function (n) {
+    if (typeof n.dsSlug === "string" && n.dsSlug && !seen[n.dsSlug]) {
+      seen[n.dsSlug] = true;
+      slugs.push(n.dsSlug);
+    }
+  });
   return slugs;
 }
 
@@ -61,26 +73,16 @@ function collectDsSlugs(data) {
 function collectDsSlugVariants(data) {
   var seen = {};
   var pairs = [];
-  function walk(nodes) {
-    if (!Array.isArray(nodes)) return;
-    for (var i = 0; i < nodes.length; i++) {
-      var n = nodes[i];
-      if (!n || typeof n !== "object") continue;
-      if (typeof n.dsSlug === "string" && isDelegated(n.dsSlug)) {
-        var variant = parseVariant(n.variant || "");
-        var key = anatomyVariantKey(n.dsSlug, variant);
-        if (!seen[key]) {
-          seen[key] = true;
-          pairs.push({ slug: n.dsSlug, variant: variant });
-        }
+  walkDsContent(data, function (n) {
+    if (typeof n.dsSlug === "string" && isDelegated(n.dsSlug)) {
+      var variant = parseVariant(n.variant || "");
+      var key = anatomyVariantKey(n.dsSlug, variant);
+      if (!seen[key]) {
+        seen[key] = true;
+        pairs.push({ slug: n.dsSlug, variant: variant });
       }
-      if (Array.isArray(n.children)) walk(n.children);
-      if (Array.isArray(n.nodes)) walk(n.nodes);
     }
-  }
-  var screens = (data && data.screens) || [];
-  for (var s = 0; s < screens.length; s++)
-    walk((screens[s] && screens[s].content) || []);
+  });
   return pairs;
 }
 

--- a/plugins/actian-design-system/scripts/renderers/ds-anatomy-map.js
+++ b/plugins/actian-design-system/scripts/renderers/ds-anatomy-map.js
@@ -18,6 +18,11 @@
  */
 
 var renderAnatomy = require("./anatomy-render").renderAnatomy;
+var {
+  isDelegated,
+  anatomyVariantKey,
+} = require("./html-renderers/anatomy-variant-key.js");
+var parseVariant = require("./html-renderers/ds-html-map.js").parseVariant;
 
 /**
  * Collect every unique dsSlug from a flow data tree (screens → content → nodes).
@@ -47,15 +52,51 @@ function collectDsSlugs(data) {
 }
 
 /**
+ * Collect every unique {slug, variant} pair for DELEGATED dsSlugs (see
+ * isDelegated in anatomy-variant-key.js) from a flow data tree (screens →
+ * content → nodes). variant is the PARSED object (via ds-html-map's
+ * parseVariant), deduped by the same composite key anatomyVariantKey
+ * produces, so callers render each distinct pair exactly once.
+ */
+function collectDsSlugVariants(data) {
+  var seen = {};
+  var pairs = [];
+  function walk(nodes) {
+    if (!Array.isArray(nodes)) return;
+    for (var i = 0; i < nodes.length; i++) {
+      var n = nodes[i];
+      if (!n || typeof n !== "object") continue;
+      if (typeof n.dsSlug === "string" && isDelegated(n.dsSlug)) {
+        var variant = parseVariant(n.variant || "");
+        var key = anatomyVariantKey(n.dsSlug, variant);
+        if (!seen[key]) {
+          seen[key] = true;
+          pairs.push({ slug: n.dsSlug, variant: variant });
+        }
+      }
+      if (Array.isArray(n.children)) walk(n.children);
+      if (Array.isArray(n.nodes)) walk(n.nodes);
+    }
+  }
+  var screens = (data && data.screens) || [];
+  for (var s = 0; s < screens.length; s++)
+    walk((screens[s] && screens[s].content) || []);
+  return pairs;
+}
+
+/**
  * Build the anatomy map { slug → htmlString } for all non-override DS slugs.
  *
  * @param {string[]} slugs - candidate slug list (typically from collectDsSlugs)
  * @param {object}   opts
  *   opts.builtSlugs          - override list (default: BUILT_SLUGS from ds-html-map.js)
  *   opts.anatomyLoader       - injectable loader(slug) for anatomy JSON (default: fs read)
- *   opts.tokenBindingsLoader - injectable loader(slug) → sidecar byNodeId map
- *                              { nodeId: [{property, token, grade}] } (default:
- *                              fs read of the vendored token-bindings sidecar)
+ *   opts.tokenBindingsLoader - injectable loader(slug) → the sidecar doc
+ *                              { byNodeId: { nodeId: [...] }, variantDefaults }
+ *                              (default: fs read of the vendored token-bindings sidecar)
+ *   opts.data                - optional flow data tree; when present, delegated
+ *                              slugs (see isDelegated) are additionally rendered
+ *                              per-variant and keyed via anatomyVariantKey
  * @returns {{ [slug: string]: string }}
  */
 function buildDsAnatomyMap(slugs, opts) {
@@ -81,10 +122,25 @@ function buildDsAnatomyMap(slugs, opts) {
     // Drop nulls (quality too low, missing root, or no anatomy file)
     if (html) map[slug] = html;
   }
+
+  if (opts.data) {
+    var delegated = collectDsSlugVariants(opts.data);
+    for (var d = 0; d < delegated.length; d++) {
+      var pair = delegated[d];
+      var dhtml = renderAnatomy(pair.slug, {
+        loader: opts.anatomyLoader,
+        bindingsLoader: opts.tokenBindingsLoader,
+        variant: pair.variant,
+      });
+      if (dhtml) map[anatomyVariantKey(pair.slug, pair.variant)] = dhtml;
+    }
+  }
+
   return map;
 }
 
 module.exports = {
   collectDsSlugs: collectDsSlugs,
+  collectDsSlugVariants: collectDsSlugVariants,
   buildDsAnatomyMap: buildDsAnatomyMap,
 };

--- a/plugins/actian-design-system/scripts/renderers/ds-anatomy-map.js
+++ b/plugins/actian-design-system/scripts/renderers/ds-anatomy-map.js
@@ -17,7 +17,9 @@
  * the render-grade facts live in components/dist/token-bindings/.
  */
 
-var renderAnatomy = require("./anatomy-render").renderAnatomy;
+var anatomyRender = require("./anatomy-render");
+var renderAnatomy = anatomyRender.renderAnatomy;
+var resolveRootTokenStyle = anatomyRender.resolveRootTokenStyle;
 var {
   isDelegated,
   anatomyVariantKey,
@@ -96,9 +98,6 @@ function collectDsSlugVariants(data) {
  *   opts.tokenBindingsLoader - injectable loader(slug) → the sidecar doc
  *                              { byNodeId: { nodeId: [...] }, variantDefaults }
  *                              (default: fs read of the vendored token-bindings sidecar)
- *   opts.data                - optional flow data tree; when present, delegated
- *                              slugs (see isDelegated) are additionally rendered
- *                              per-variant and keyed via anatomyVariantKey
  * @returns {{ [slug: string]: string }}
  */
 function buildDsAnatomyMap(slugs, opts) {
@@ -125,19 +124,25 @@ function buildDsAnatomyMap(slugs, opts) {
     if (html) map[slug] = html;
   }
 
-  if (opts.data) {
-    var delegated = collectDsSlugVariants(opts.data);
-    for (var d = 0; d < delegated.length; d++) {
-      var pair = delegated[d];
-      var dhtml = renderAnatomy(pair.slug, {
-        loader: opts.anatomyLoader,
-        bindingsLoader: opts.tokenBindingsLoader,
-        variant: pair.variant,
-      });
-      if (dhtml) map[anatomyVariantKey(pair.slug, pair.variant)] = dhtml;
-    }
-  }
+  return map;
+}
 
+// Build { anatomyVariantKey(slug, variant) -> inline-style-string } for the
+// delegated slugs used in the flow, for token-injection into hand-authored
+// templates. Entries with no resolvable root style are omitted.
+function buildDsVariantStyleMap(data, opts) {
+  opts = opts || {};
+  var map = {};
+  var pairs = collectDsSlugVariants(data);
+  for (var i = 0; i < pairs.length; i++) {
+    var pair = pairs[i];
+    var style = resolveRootTokenStyle(pair.slug, {
+      variant: pair.variant,
+      loader: opts.anatomyLoader,
+      bindingsLoader: opts.tokenBindingsLoader,
+    });
+    if (style) map[anatomyVariantKey(pair.slug, pair.variant)] = style;
+  }
   return map;
 }
 
@@ -145,4 +150,5 @@ module.exports = {
   collectDsSlugs: collectDsSlugs,
   collectDsSlugVariants: collectDsSlugVariants,
   buildDsAnatomyMap: buildDsAnatomyMap,
+  buildDsVariantStyleMap: buildDsVariantStyleMap,
 };

--- a/plugins/actian-design-system/scripts/renderers/html-renderers/anatomy-variant-key.js
+++ b/plugins/actian-design-system/scripts/renderers/html-renderers/anatomy-variant-key.js
@@ -4,10 +4,10 @@
 // composite key for a delegated slug + variant. No requires (leaf module).
 "use strict";
 
-// Slice 1 delegates the tag family to the variant-aware anatomy render.
+// Slice 1 delegates ONLY tag-default to variant-aware token-injection.
 // Widening later = broadening this predicate; no other change needed.
 function isDelegated(slug) {
-  return typeof slug === "string" && slug.indexOf("tag-") === 0;
+  return slug === "tag-default";
 }
 
 // slug + a deterministic, sorted encoding of the variant object.
@@ -18,8 +18,12 @@ function anatomyVariantKey(slug, variant) {
   var keys = Object.keys(variant).sort();
   if (!keys.length) return slug;
   var parts = [];
-  for (var i = 0; i < keys.length; i++) parts.push(keys[i] + "=" + variant[keys[i]]);
+  for (var i = 0; i < keys.length; i++)
+    parts.push(keys[i] + "=" + variant[keys[i]]);
   return slug + "|" + parts.join(",");
 }
 
-module.exports = { isDelegated: isDelegated, anatomyVariantKey: anatomyVariantKey };
+module.exports = {
+  isDelegated: isDelegated,
+  anatomyVariantKey: anatomyVariantKey,
+};

--- a/plugins/actian-design-system/scripts/renderers/html-renderers/anatomy-variant-key.js
+++ b/plugins/actian-design-system/scripts/renderers/html-renderers/anatomy-variant-key.js
@@ -1,0 +1,25 @@
+// scripts/renderers/html-renderers/anatomy-variant-key.js
+// Pure helpers shared by the assemble-time anatomy builder (ds-anatomy-map.js)
+// and the fs-free interpreter (ds-html-map.js) so both compute the SAME
+// composite key for a delegated slug + variant. No requires (leaf module).
+"use strict";
+
+// Slice 1 delegates the tag family to the variant-aware anatomy render.
+// Widening later = broadening this predicate; no other change needed.
+function isDelegated(slug) {
+  return typeof slug === "string" && slug.indexOf("tag-") === 0;
+}
+
+// slug + a deterministic, sorted encoding of the variant object.
+// Both call sites pass the SAME node's variant, so the keys match without
+// either side needing the sidecar's variantDefaults.
+function anatomyVariantKey(slug, variant) {
+  if (!variant || typeof variant !== "object") return slug;
+  var keys = Object.keys(variant).sort();
+  if (!keys.length) return slug;
+  var parts = [];
+  for (var i = 0; i < keys.length; i++) parts.push(keys[i] + "=" + variant[keys[i]]);
+  return slug + "|" + parts.join(",");
+}
+
+module.exports = { isDelegated: isDelegated, anatomyVariantKey: anatomyVariantKey };

--- a/plugins/actian-design-system/scripts/renderers/html-renderers/ds-html-map.js
+++ b/plugins/actian-design-system/scripts/renderers/html-renderers/ds-html-map.js
@@ -45,6 +45,34 @@
       return p || {};
     };
 
+  // Composite-key delegation helpers (Task 3: isDelegated/anatomyVariantKey).
+  // Same guard-with-inline-fallback shape as fm above: this module runs in
+  // BOTH Node (require works) and the browser deliverable (require may be
+  // absent), so the fallback bodies are verbatim mirrors of
+  // anatomy-variant-key.js kept here for the browser-without-require case.
+  // Do NOT delete them as dead code — they are the only implementation when
+  // `require` is unavailable.
+  var anatomyKey =
+    (typeof require !== "undefined" && require("./anatomy-variant-key.js")) ||
+    {};
+  var isDelegated =
+    anatomyKey.isDelegated ||
+    function (slug) {
+      return typeof slug === "string" && slug.indexOf("tag-") === 0;
+    };
+  var anatomyVariantKey =
+    anatomyKey.anatomyVariantKey ||
+    function (slug, variant) {
+      if (!variant || typeof variant !== "object") return slug;
+      var keys = Object.keys(variant).sort();
+      if (!keys.length) return slug;
+      var parts = [];
+      for (var i = 0; i < keys.length; i++) {
+        parts.push(keys[i] + "=" + variant[keys[i]]);
+      }
+      return slug + "|" + parts.join(",");
+    };
+
   // Icon geometry: browser global (injected by the assembler) or the vendored
   // read-surface in Node. Geometry-only { slug: {viewBox, body} }.
   var dsIcons =
@@ -179,6 +207,18 @@
     try {
       var v = parseVariant(node.variant || "");
       var props = normalizeProps(node.props);
+
+      // Delegated slugs (slice 1: tag-*) render via the variant-aware anatomy
+      // map when a composite-keyed entry exists; else fall through to the switch.
+      if (isDelegated(slug)) {
+        var _m =
+          (typeof window !== "undefined" && window.__dsAnatomyMap) ||
+          _serverAnatomyMap ||
+          {};
+        var _k = anatomyVariantKey(slug, v);
+        if (_m[_k]) return _m[_k];
+      }
+
       switch (slug) {
         case "button": {
           // Button taxonomy is Intent×Emphasis as of knowledge v0.34.x. Map the

--- a/plugins/actian-design-system/scripts/renderers/html-renderers/ds-html-map.js
+++ b/plugins/actian-design-system/scripts/renderers/html-renderers/ds-html-map.js
@@ -45,21 +45,16 @@
       return p || {};
     };
 
-  // Composite-key delegation helpers (Task 3: isDelegated/anatomyVariantKey).
-  // Same guard-with-inline-fallback shape as fm above: this module runs in
-  // BOTH Node (require works) and the browser deliverable (require may be
-  // absent), so the fallback bodies are verbatim mirrors of
-  // anatomy-variant-key.js kept here for the browser-without-require case.
-  // Do NOT delete them as dead code — they are the only implementation when
+  // Composite-key helper (anatomyVariantKey) used by the tag-default
+  // token-injection case below. Same guard-with-inline-fallback shape as fm
+  // above: this module runs in BOTH Node (require works) and the browser
+  // deliverable (require may be absent), so the fallback body is a verbatim
+  // mirror of anatomy-variant-key.js kept here for the browser-without-require
+  // case. Do NOT delete it as dead code — it is the only implementation when
   // `require` is unavailable.
   var anatomyKey =
     (typeof require !== "undefined" && require("./anatomy-variant-key.js")) ||
     {};
-  var isDelegated =
-    anatomyKey.isDelegated ||
-    function (slug) {
-      return typeof slug === "string" && slug.indexOf("tag-") === 0;
-    };
   var anatomyVariantKey =
     anatomyKey.anatomyVariantKey ||
     function (slug, variant) {
@@ -178,6 +173,23 @@
     _serverAnatomyMap = map && typeof map === "object" ? map : null;
   }
 
+  // Variant-style map for token-injection into delegated hand-authored
+  // templates (slice 1: tag-default). Same two supply paths as the anatomy
+  // map above: window.__dsVariantStyles (browser) or setVariantStyleMap()
+  // (server-side Node render).
+  var _serverVariantStyleMap = null;
+
+  /**
+   * setVariantStyleMap(map) — supply the assemble-time variant-style map for
+   * server-side rendering. Pass a plain object
+   * { anatomyVariantKey(slug, variant) → inline-style-string }, or
+   * null/undefined to clear it (callers MUST reset after a render so state
+   * never leaks).
+   */
+  function setVariantStyleMap(map) {
+    _serverVariantStyleMap = map && typeof map === "object" ? map : null;
+  }
+
   /**
    * renderDSComponent(node)
    * node = { type: 'INSTANCE', library: 'ds', dsSlug: 'button', variant: '...', props: {...}, name: '...' }
@@ -207,17 +219,6 @@
     try {
       var v = parseVariant(node.variant || "");
       var props = normalizeProps(node.props);
-
-      // Delegated slugs (slice 1: tag-*) render via the variant-aware anatomy
-      // map when a composite-keyed entry exists; else fall through to the switch.
-      if (isDelegated(slug)) {
-        var _m =
-          (typeof window !== "undefined" && window.__dsAnatomyMap) ||
-          _serverAnatomyMap ||
-          {};
-        var _k = anatomyVariantKey(slug, v);
-        if (_m[_k]) return _m[_k];
-      }
 
       switch (slug) {
         case "button": {
@@ -376,9 +377,11 @@
         }
 
         case "tag-default": {
-          // Color variant axis exists in the kit (Default, Gray, Pink, …) but
-          // this slice renders the Default palette for every Color; the
-          // per-Color hue palette (<hue>/25 bg + <hue>/50 border) is deferred.
+          // Token-injection (not anatomy replacement): the hand-authored
+          // .ds-tag template (label + icon) stays intact; the harvested
+          // per-Color root token style is injected as an inline style attr so
+          // variant colors render correctly WITHOUT dropping the instance
+          // label. See resolveRootTokenStyle / buildDsVariantStyleMap.
           var tagCls = "ds-tag";
           var tagIcon = "";
           if (props["Leading icon show"]) {
@@ -388,10 +391,20 @@
               renderIcon("directory") +
               "</span>";
           }
+          var _styleMap =
+            (typeof window !== "undefined" && window.__dsVariantStyles) ||
+            _serverVariantStyleMap ||
+            {};
+          var _tagStyle = _styleMap[anatomyVariantKey("tag-default", v)] || "";
+          var _tagStyleAttr = _tagStyle
+            ? ' style="' + esc(_tagStyle) + '"'
+            : "";
           return (
             '<span class="' +
             tagCls +
-            '">' +
+            '"' +
+            _tagStyleAttr +
+            ">" +
             tagIcon +
             esc(props.Label || "") +
             "</span>"
@@ -1732,6 +1745,7 @@
 
   exports.renderDSComponent = renderDSComponent;
   exports.setAnatomyMap = setAnatomyMap;
+  exports.setVariantStyleMap = setVariantStyleMap;
   exports.renderIcon = renderIcon;
   exports.esc = esc;
   exports.parseVariant = parseVariant;

--- a/plugins/actian-design-system/tests/integration/flow-share-variant-tag-deliverable.test.js
+++ b/plugins/actian-design-system/tests/integration/flow-share-variant-tag-deliverable.test.js
@@ -52,21 +52,12 @@ function scopedBgToken(colorValue) {
   return candidates[0];
 }
 
-test("flow-share deliverable: Color=Pink and Color=Default tags render distinct harvested tokens", () => {
+test("flow-share deliverable: tag-default keeps its instance label AND injects its distinct harvested variant token", () => {
   const pink = scopedBgToken("Pink");
   const def = scopedBgToken("Default");
   assert.ok(
-    pink,
-    "sidecar has a Pink-scoped background-color binding (fixture precondition)",
-  );
-  assert.ok(
-    def,
-    "sidecar has a Default-scoped background-color binding (fixture precondition)",
-  );
-  assert.notStrictEqual(
-    pink,
-    def,
-    "Pink and Default must resolve to DISTINCT tokens, or this test cannot detect a composite-key collision",
+    pink && def && pink !== def,
+    "sidecar has distinct Pink/Default background tokens (precondition)",
   );
 
   const flow = {
@@ -80,14 +71,14 @@ test("flow-share deliverable: Color=Pink and Color=Default tags render distinct 
             library: "ds",
             dsSlug: "tag-default",
             variant: "Color=Pink",
-            props: { Label: "Pink" },
+            props: { Label: "Customer Orders" },
           },
           {
             type: "INSTANCE",
             library: "ds",
             dsSlug: "tag-default",
             variant: "Color=Default",
-            props: { Label: "Default" },
+            props: { Label: "Draft Items" },
           },
         ],
       },
@@ -98,12 +89,23 @@ test("flow-share deliverable: Color=Pink and Color=Default tags render distinct 
   const html = assemble.assembleFlowShare(flow);
 
   assert.ok(
+    html.includes("Customer Orders"),
+    "Pink tag keeps its instance label",
+  );
+  assert.ok(
+    html.includes("Draft Items"),
+    "Default tag keeps its instance label",
+  );
+  assert.ok(
+    html.includes('class="ds-tag"'),
+    "renders the hand-authored ds-tag span, not anatomy divs",
+  );
+  assert.ok(
     html.includes("background-color:var(" + pink + ")"),
-    "the Pink tag emitted its harvested Pink background token",
+    "Pink tag injected its harvested token",
   );
   assert.ok(
     html.includes("background-color:var(" + def + ")"),
-    "the Default tag emitted its harvested Default background token (a composite-key " +
-      "collision between the two nodes would drop one of the two distinct tokens)",
+    "Default tag injected its distinct harvested token",
   );
 });

--- a/plugins/actian-design-system/tests/integration/flow-share-variant-tag-deliverable.test.js
+++ b/plugins/actian-design-system/tests/integration/flow-share-variant-tag-deliverable.test.js
@@ -1,0 +1,44 @@
+const { test } = require("node:test");
+const assert = require("node:assert");
+const path = require("path");
+const fs = require("fs");
+
+const SIDE = path.resolve(
+  __dirname, "..", "..", "vendor", "components", "dist", "token-bindings", "tag-default.json"
+);
+const assemble = require("../../scripts/renderers/assemble-flow-share.js");
+
+// Pull the real Pink-scoped background token from the vendored sidecar.
+function pinkBgToken() {
+  const doc = JSON.parse(fs.readFileSync(SIDE, "utf8"));
+  for (const nid of Object.keys(doc.byNodeId)) {
+    for (const b of doc.byNodeId[nid]) {
+      if (b.property === "background-color" && b.variant && b.variant.prop === "Color" &&
+          Array.isArray(b.variant.values) && b.variant.values.indexOf("Pink") !== -1) {
+        return b.token;
+      }
+    }
+  }
+  return null;
+}
+
+test("flow-share deliverable: a Color=Pink tag renders its harvested Pink token", () => {
+  const token = pinkBgToken();
+  assert.ok(token, "sidecar has a Pink-scoped background-color binding (fixture precondition)");
+
+  const flow = {
+    meta: { library: "ds" },
+    screens: [
+      { name: "S1", content: [
+        { type: "INSTANCE", library: "ds", dsSlug: "tag-default", variant: "Color=Pink", props: { Label: "Pink" } },
+        { type: "INSTANCE", library: "ds", dsSlug: "tag-default", variant: "Color=Default", props: { Label: "Default" } },
+      ] },
+    ],
+  };
+
+  // assemble-flow-share.js exports { assembleFlowShare(data) } -> full HTML string.
+  const html = assemble.assembleFlowShare(flow);
+
+  assert.ok(html.includes("background-color:var(" + token + ")"),
+    "the Pink tag emitted its harvested Pink background token");
+});

--- a/plugins/actian-design-system/tests/integration/flow-share-variant-tag-deliverable.test.js
+++ b/plugins/actian-design-system/tests/integration/flow-share-variant-tag-deliverable.test.js
@@ -4,41 +4,106 @@ const path = require("path");
 const fs = require("fs");
 
 const SIDE = path.resolve(
-  __dirname, "..", "..", "vendor", "components", "dist", "token-bindings", "tag-default.json"
+  __dirname,
+  "..",
+  "..",
+  "vendor",
+  "components",
+  "dist",
+  "token-bindings",
+  "tag-default.json",
 );
 const assemble = require("../../scripts/renderers/assemble-flow-share.js");
 
-// Pull the real Pink-scoped background token from the vendored sidecar.
-function pinkBgToken() {
+// Pull the real background-color token from the vendored sidecar whose
+// binding is scoped to variant.prop === "Color" and whose variant.values
+// includes colorValue (e.g. "Pink", "Default"). Fails loudly (rather than
+// silently returning the first match) unless there is EXACTLY ONE such
+// candidate — a zero or multi-match sidecar would let this test pass while
+// a composite-key collision quietly rendered the wrong token.
+function scopedBgToken(colorValue) {
   const doc = JSON.parse(fs.readFileSync(SIDE, "utf8"));
+  const candidates = [];
   for (const nid of Object.keys(doc.byNodeId)) {
     for (const b of doc.byNodeId[nid]) {
-      if (b.property === "background-color" && b.variant && b.variant.prop === "Color" &&
-          Array.isArray(b.variant.values) && b.variant.values.indexOf("Pink") !== -1) {
-        return b.token;
+      if (
+        b.property === "background-color" &&
+        b.variant &&
+        b.variant.prop === "Color" &&
+        Array.isArray(b.variant.values) &&
+        b.variant.values.indexOf(colorValue) !== -1
+      ) {
+        candidates.push(b.token);
       }
     }
   }
-  return null;
+  assert.strictEqual(
+    candidates.length,
+    1,
+    "expected exactly one Color=" +
+      colorValue +
+      "-scoped background-color binding in " +
+      "tag-default.json, found " +
+      candidates.length +
+      " (" +
+      JSON.stringify(candidates) +
+      ")",
+  );
+  return candidates[0];
 }
 
-test("flow-share deliverable: a Color=Pink tag renders its harvested Pink token", () => {
-  const token = pinkBgToken();
-  assert.ok(token, "sidecar has a Pink-scoped background-color binding (fixture precondition)");
+test("flow-share deliverable: Color=Pink and Color=Default tags render distinct harvested tokens", () => {
+  const pink = scopedBgToken("Pink");
+  const def = scopedBgToken("Default");
+  assert.ok(
+    pink,
+    "sidecar has a Pink-scoped background-color binding (fixture precondition)",
+  );
+  assert.ok(
+    def,
+    "sidecar has a Default-scoped background-color binding (fixture precondition)",
+  );
+  assert.notStrictEqual(
+    pink,
+    def,
+    "Pink and Default must resolve to DISTINCT tokens, or this test cannot detect a composite-key collision",
+  );
 
   const flow = {
     meta: { library: "ds" },
     screens: [
-      { name: "S1", content: [
-        { type: "INSTANCE", library: "ds", dsSlug: "tag-default", variant: "Color=Pink", props: { Label: "Pink" } },
-        { type: "INSTANCE", library: "ds", dsSlug: "tag-default", variant: "Color=Default", props: { Label: "Default" } },
-      ] },
+      {
+        name: "S1",
+        content: [
+          {
+            type: "INSTANCE",
+            library: "ds",
+            dsSlug: "tag-default",
+            variant: "Color=Pink",
+            props: { Label: "Pink" },
+          },
+          {
+            type: "INSTANCE",
+            library: "ds",
+            dsSlug: "tag-default",
+            variant: "Color=Default",
+            props: { Label: "Default" },
+          },
+        ],
+      },
     ],
   };
 
   // assemble-flow-share.js exports { assembleFlowShare(data) } -> full HTML string.
   const html = assemble.assembleFlowShare(flow);
 
-  assert.ok(html.includes("background-color:var(" + token + ")"),
-    "the Pink tag emitted its harvested Pink background token");
+  assert.ok(
+    html.includes("background-color:var(" + pink + ")"),
+    "the Pink tag emitted its harvested Pink background token",
+  );
+  assert.ok(
+    html.includes("background-color:var(" + def + ")"),
+    "the Default tag emitted its harvested Default background token (a composite-key " +
+      "collision between the two nodes would drop one of the two distinct tokens)",
+  );
 });

--- a/plugins/actian-design-system/tests/renderers/anatomy-render.test.js
+++ b/plugins/actian-design-system/tests/renderers/anatomy-render.test.js
@@ -364,3 +364,43 @@ test("renderAnatomy: without opts.variant, output is unchanged (all decls)", () 
     "emits both (current behavior)",
   );
 });
+
+test("resolveRootTokenStyle: returns the root node's variant-resolved decls string", () => {
+  const anatomy = {
+    quality: { ratio: 1 },
+    root: { id: "r", kind: "container" },
+  };
+  const bindings = {
+    variantDefaults: { Color: "Default" },
+    byNodeId: {
+      r: [
+        {
+          property: "background-color",
+          token: "--zen-pink",
+          variant: { prop: "Color", values: ["Pink"] },
+        },
+        {
+          property: "background-color",
+          token: "--zen-default",
+          variant: { prop: "Color", values: ["Default"] },
+        },
+      ],
+    },
+  };
+  const style = ar.resolveRootTokenStyle("tag-default", {
+    variant: { Color: "Pink" },
+    loader: () => anatomy,
+    bindingsLoader: () => bindings,
+  });
+  assert.strictEqual(style, "background-color:var(--zen-pink)");
+});
+test("resolveRootTokenStyle: returns '' when anatomy quality is below minRatio", () => {
+  const anatomy = { quality: { ratio: 0.1 }, root: { id: "r" } };
+  assert.strictEqual(
+    ar.resolveRootTokenStyle("x", {
+      loader: () => anatomy,
+      bindingsLoader: () => ({ byNodeId: {} }),
+    }),
+    "",
+  );
+});

--- a/plugins/actian-design-system/tests/renderers/anatomy-render.test.js
+++ b/plugins/actian-design-system/tests/renderers/anatomy-render.test.js
@@ -1,9 +1,9 @@
 #!/usr/bin/env node
 "use strict";
-var { describe, it } = require("node:test");
+var { describe, it, test } = require("node:test");
 var assert = require("node:assert");
 var path = require("path");
-var { renderAnatomy } = require(
+var ar = require(
   path.resolve(
     __dirname,
     "..",
@@ -13,6 +13,7 @@ var { renderAnatomy } = require(
     "anatomy-render.js",
   ),
 );
+var { renderAnatomy } = ar;
 
 var GOOD = {
   slug: "x",
@@ -203,4 +204,92 @@ describe("anatomy-render", function () {
       "text span should have no style attribute without bindings",
     );
   });
+});
+
+test("resolveTokenDecls: no target variant returns all valid decls in order", () => {
+  const list = [
+    {
+      property: "background-color",
+      token: "--zen-a",
+      variant: { prop: "Color", values: ["Default"] },
+    },
+    {
+      property: "background-color",
+      token: "--zen-b",
+      variant: { prop: "Color", values: ["Pink"] },
+    },
+  ];
+  assert.deepStrictEqual(ar.resolveTokenDecls(list, null, null), [
+    "background-color:var(--zen-a)",
+    "background-color:var(--zen-b)",
+  ]);
+});
+
+test("resolveTokenDecls: target variant picks the scoped match, one per property", () => {
+  const list = [
+    {
+      property: "background-color",
+      token: "--zen-default",
+      variant: { prop: "Color", values: ["Default"] },
+    },
+    {
+      property: "background-color",
+      token: "--zen-pink",
+      variant: { prop: "Color", values: ["Pink"] },
+    },
+    {
+      property: "border-color",
+      token: "--zen-border-pink",
+      variant: { prop: "Color", values: ["Pink"] },
+    },
+  ];
+  assert.deepStrictEqual(
+    ar.resolveTokenDecls(list, { Color: "Pink" }, { Color: "Default" }),
+    ["background-color:var(--zen-pink)", "border-color:var(--zen-border-pink)"],
+  );
+});
+
+test("resolveTokenDecls: unknown target value falls back to variantDefaults binding", () => {
+  const list = [
+    {
+      property: "background-color",
+      token: "--zen-default",
+      variant: { prop: "Color", values: ["Default"] },
+    },
+    {
+      property: "background-color",
+      token: "--zen-pink",
+      variant: { prop: "Color", values: ["Pink"] },
+    },
+  ];
+  assert.deepStrictEqual(
+    ar.resolveTokenDecls(list, { Color: "Nonexistent" }, { Color: "Default" }),
+    ["background-color:var(--zen-default)"],
+  );
+});
+
+test("resolveTokenDecls: unscoped binding is always kept under a target variant", () => {
+  const list = [
+    { property: "padding", token: "--zen-spacing-sm" },
+    {
+      property: "background-color",
+      token: "--zen-pink",
+      variant: { prop: "Color", values: ["Pink"] },
+    },
+  ];
+  assert.deepStrictEqual(
+    ar.resolveTokenDecls(list, { Color: "Pink" }, { Color: "Default" }),
+    ["padding:var(--zen-spacing-sm)", "background-color:var(--zen-pink)"],
+  );
+});
+
+test("resolveTokenDecls: invalid property/token entries are dropped", () => {
+  const list = [
+    { property: "content!", token: "--zen-x" }, // property not in PROP_RE
+    { property: "padding", token: "red" }, // token not in TOKEN_RE
+    { property: "padding", token: "--zen-spacing-sm" },
+  ];
+  assert.deepStrictEqual(ar.resolveTokenDecls(list, null, null), [
+    "padding:var(--zen-spacing-sm)",
+  ]);
 });

--- a/plugins/actian-design-system/tests/renderers/anatomy-render.test.js
+++ b/plugins/actian-design-system/tests/renderers/anatomy-render.test.js
@@ -126,7 +126,7 @@ describe("anatomy-render", function () {
     var html = renderAnatomy("x", {
       loader: loader,
       bindingsLoader: function () {
-        return BINDINGS;
+        return { byNodeId: BINDINGS };
       },
     });
     assert.ok(
@@ -145,7 +145,7 @@ describe("anatomy-render", function () {
     var html = renderAnatomy("x", {
       loader: loader,
       bindingsLoader: function () {
-        return BINDINGS;
+        return { byNodeId: BINDINGS };
       },
     });
     var span = html.match(/<span[^>]*>/);
@@ -160,7 +160,7 @@ describe("anatomy-render", function () {
     var html = renderAnatomy("x", {
       loader: loader,
       bindingsLoader: function () {
-        return BINDINGS;
+        return { byNodeId: BINDINGS };
       },
     });
     var instance = html.match(/<div class="ds-anatomy__instance"[^>]*>/);
@@ -175,11 +175,13 @@ describe("anatomy-render", function () {
       loader: loader,
       bindingsLoader: function () {
         return {
-          "1:1": [
-            { property: "background;evil", token: "--zen-color-bg-default" },
-            { property: "color", token: "red" },
-            { property: "color", token: "--zen-color-text-default" },
-          ],
+          byNodeId: {
+            "1:1": [
+              { property: "background;evil", token: "--zen-color-bg-default" },
+              { property: "color", token: "red" },
+              { property: "color", token: "--zen-color-text-default" },
+            ],
+          },
         };
       },
     });
@@ -292,4 +294,73 @@ test("resolveTokenDecls: invalid property/token entries are dropped", () => {
   assert.deepStrictEqual(ar.resolveTokenDecls(list, null, null), [
     "padding:var(--zen-spacing-sm)",
   ]);
+});
+
+test("renderAnatomy: opts.variant selects the scoped token in the output", () => {
+  const anatomy = {
+    quality: { ratio: 1 },
+    root: { id: "n1", kind: "container", layout: {}, children: [] },
+  };
+  const bindings = {
+    variantDefaults: { Color: "Default" },
+    byNodeId: {
+      n1: [
+        {
+          property: "background-color",
+          token: "--zen-default",
+          variant: { prop: "Color", values: ["Default"] },
+        },
+        {
+          property: "background-color",
+          token: "--zen-pink",
+          variant: { prop: "Color", values: ["Pink"] },
+        },
+      ],
+    },
+  };
+  const html = ar.renderAnatomy("tag-default", {
+    loader: () => anatomy,
+    bindingsLoader: () => bindings,
+    variant: { Color: "Pink" },
+  });
+  assert.ok(
+    html.includes("background-color:var(--zen-pink)"),
+    "renders the Pink token",
+  );
+  assert.ok(
+    !html.includes("--zen-default"),
+    "does not also emit the Default token",
+  );
+});
+
+test("renderAnatomy: without opts.variant, output is unchanged (all decls)", () => {
+  const anatomy = {
+    quality: { ratio: 1 },
+    root: { id: "n1", kind: "container", layout: {}, children: [] },
+  };
+  const bindings = {
+    variantDefaults: { Color: "Default" },
+    byNodeId: {
+      n1: [
+        {
+          property: "background-color",
+          token: "--zen-default",
+          variant: { prop: "Color", values: ["Default"] },
+        },
+        {
+          property: "background-color",
+          token: "--zen-pink",
+          variant: { prop: "Color", values: ["Pink"] },
+        },
+      ],
+    },
+  };
+  const html = ar.renderAnatomy("tag-default", {
+    loader: () => anatomy,
+    bindingsLoader: () => bindings,
+  });
+  assert.ok(
+    html.includes("--zen-default") && html.includes("--zen-pink"),
+    "emits both (current behavior)",
+  );
 });

--- a/plugins/actian-design-system/tests/renderers/anatomy-variant-key.test.js
+++ b/plugins/actian-design-system/tests/renderers/anatomy-variant-key.test.js
@@ -1,12 +1,18 @@
 const { test } = require("node:test");
 const assert = require("node:assert");
-const { anatomyVariantKey, isDelegated } = require("../../scripts/renderers/html-renderers/anatomy-variant-key.js");
+const {
+  anatomyVariantKey,
+  isDelegated,
+} = require("../../scripts/renderers/html-renderers/anatomy-variant-key.js");
 
 test("anatomyVariantKey: sorts props deterministically", () => {
-  assert.strictEqual(anatomyVariantKey("tag-default", { Color: "Pink" }), "tag-default|Color=Pink");
+  assert.strictEqual(
+    anatomyVariantKey("tag-default", { Color: "Pink" }),
+    "tag-default|Color=Pink",
+  );
   assert.strictEqual(
     anatomyVariantKey("x", { B: "2", A: "1" }),
-    anatomyVariantKey("x", { A: "1", B: "2" })
+    anatomyVariantKey("x", { A: "1", B: "2" }),
   );
   assert.strictEqual(anatomyVariantKey("x", { A: "1", B: "2" }), "x|A=1,B=2");
 });
@@ -16,9 +22,9 @@ test("anatomyVariantKey: empty/absent variant returns the bare slug", () => {
   assert.strictEqual(anatomyVariantKey("tag-default", null), "tag-default");
 });
 
-test("isDelegated: only tag-* is delegated in slice 1", () => {
+test("isDelegated: only tag-default is delegated in slice 1", () => {
   assert.strictEqual(isDelegated("tag-default"), true);
-  assert.strictEqual(isDelegated("tag-status"), true);
+  assert.strictEqual(isDelegated("tag-status"), false);
   assert.strictEqual(isDelegated("button"), false);
   assert.strictEqual(isDelegated(null), false);
 });

--- a/plugins/actian-design-system/tests/renderers/anatomy-variant-key.test.js
+++ b/plugins/actian-design-system/tests/renderers/anatomy-variant-key.test.js
@@ -1,0 +1,24 @@
+const { test } = require("node:test");
+const assert = require("node:assert");
+const { anatomyVariantKey, isDelegated } = require("../../scripts/renderers/html-renderers/anatomy-variant-key.js");
+
+test("anatomyVariantKey: sorts props deterministically", () => {
+  assert.strictEqual(anatomyVariantKey("tag-default", { Color: "Pink" }), "tag-default|Color=Pink");
+  assert.strictEqual(
+    anatomyVariantKey("x", { B: "2", A: "1" }),
+    anatomyVariantKey("x", { A: "1", B: "2" })
+  );
+  assert.strictEqual(anatomyVariantKey("x", { A: "1", B: "2" }), "x|A=1,B=2");
+});
+
+test("anatomyVariantKey: empty/absent variant returns the bare slug", () => {
+  assert.strictEqual(anatomyVariantKey("tag-default", {}), "tag-default");
+  assert.strictEqual(anatomyVariantKey("tag-default", null), "tag-default");
+});
+
+test("isDelegated: only tag-* is delegated in slice 1", () => {
+  assert.strictEqual(isDelegated("tag-default"), true);
+  assert.strictEqual(isDelegated("tag-status"), true);
+  assert.strictEqual(isDelegated("button"), false);
+  assert.strictEqual(isDelegated(null), false);
+});

--- a/plugins/actian-design-system/tests/renderers/ds-anatomy-map.test.js
+++ b/plugins/actian-design-system/tests/renderers/ds-anatomy-map.test.js
@@ -4,7 +4,7 @@
 // Verifies: collectDsSlugs (content-shaped traversal), buildDsAnatomyMap
 // (override exclusion, anatomy+binding integration, null-anatomy exclusion).
 
-var { describe, it } = require("node:test");
+var { describe, it, test } = require("node:test");
 var assert = require("node:assert");
 
 var {
@@ -179,4 +179,70 @@ describe("buildDsAnatomyMap", function () {
       "spinner included when not in custom builtSlugs",
     );
   });
+});
+
+var anatomyMapMod = require("../../scripts/renderers/ds-anatomy-map.js");
+
+test("collectDsSlugVariants: emits distinct {slug, variant} for delegated nodes", () => {
+  const data = {
+    screens: [
+      {
+        content: [
+          { dsSlug: "tag-default", variant: "Color=Pink" },
+          { dsSlug: "tag-default", variant: "Color=Pink" }, // dup -> collapses
+          { dsSlug: "tag-default", variant: "Color=Gray" },
+          { dsSlug: "button", variant: "Type=Primary" }, // not delegated -> ignored here
+        ],
+      },
+    ],
+  };
+  const pairs = anatomyMapMod.collectDsSlugVariants(data);
+  const keys = pairs
+    .map((p) => p.slug + "|" + JSON.stringify(p.variant))
+    .sort();
+  assert.deepStrictEqual(keys, [
+    'tag-default|{"Color":"Gray"}',
+    'tag-default|{"Color":"Pink"}',
+  ]);
+});
+
+test("buildDsAnatomyMap: keys delegated slugs by composite variant key", () => {
+  const anatomy = {
+    quality: { ratio: 1 },
+    root: { id: "n1", kind: "container", layout: {}, children: [] },
+  };
+  const bindings = {
+    variantDefaults: { Color: "Default" },
+    byNodeId: {
+      n1: [
+        {
+          property: "background-color",
+          token: "--zen-pink",
+          variant: { prop: "Color", values: ["Pink"] },
+        },
+        {
+          property: "background-color",
+          token: "--zen-default",
+          variant: { prop: "Color", values: ["Default"] },
+        },
+      ],
+    },
+  };
+  const data = {
+    screens: [{ content: [{ dsSlug: "tag-default", variant: "Color=Pink" }] }],
+  };
+  const map = anatomyMapMod.buildDsAnatomyMap([], {
+    data: data,
+    anatomyLoader: () => anatomy,
+    tokenBindingsLoader: () => bindings,
+  });
+  assert.ok(map["tag-default|Color=Pink"], "has the composite-keyed entry");
+  assert.ok(
+    map["tag-default|Color=Pink"].includes("--zen-pink"),
+    "rendered the Pink token",
+  );
+  assert.ok(
+    !map["tag-default"],
+    "delegated slug is NOT under the bare slug key",
+  );
 });

--- a/plugins/actian-design-system/tests/renderers/ds-anatomy-map.test.js
+++ b/plugins/actian-design-system/tests/renderers/ds-anatomy-map.test.js
@@ -101,20 +101,22 @@ describe("buildDsAnatomyMap", function () {
     var tokenBindingsLoader = function (slug) {
       if (slug === "spinner")
         return {
-          "9:1": [
-            {
-              property: "background-color",
-              token: "--zen-color-primary-500",
-              grade: "semantic",
-            },
-          ],
-          "9:2": [
-            {
-              property: "color",
-              token: "--zen-color-text-default",
-              grade: "semantic",
-            },
-          ],
+          byNodeId: {
+            "9:1": [
+              {
+                property: "background-color",
+                token: "--zen-color-primary-500",
+                grade: "semantic",
+              },
+            ],
+            "9:2": [
+              {
+                property: "color",
+                token: "--zen-color-text-default",
+                grade: "semantic",
+              },
+            ],
+          },
         };
       return null;
     };

--- a/plugins/actian-design-system/tests/renderers/ds-anatomy-map.test.js
+++ b/plugins/actian-design-system/tests/renderers/ds-anatomy-map.test.js
@@ -206,15 +206,12 @@ test("collectDsSlugVariants: emits distinct {slug, variant} for delegated nodes"
   ]);
 });
 
-test("buildDsAnatomyMap: keys delegated slugs by composite variant key", () => {
-  const anatomy = {
-    quality: { ratio: 1 },
-    root: { id: "n1", kind: "container", layout: {}, children: [] },
-  };
+test("buildDsVariantStyleMap: keys tag-default by composite key with the root variant style", () => {
+  const anatomy = { quality: { ratio: 1 }, root: { id: "r" } };
   const bindings = {
     variantDefaults: { Color: "Default" },
     byNodeId: {
-      n1: [
+      r: [
         {
           property: "background-color",
           token: "--zen-pink",
@@ -231,18 +228,12 @@ test("buildDsAnatomyMap: keys delegated slugs by composite variant key", () => {
   const data = {
     screens: [{ content: [{ dsSlug: "tag-default", variant: "Color=Pink" }] }],
   };
-  const map = anatomyMapMod.buildDsAnatomyMap([], {
-    data: data,
+  const map = anatomyMapMod.buildDsVariantStyleMap(data, {
     anatomyLoader: () => anatomy,
     tokenBindingsLoader: () => bindings,
   });
-  assert.ok(map["tag-default|Color=Pink"], "has the composite-keyed entry");
-  assert.ok(
-    map["tag-default|Color=Pink"].includes("--zen-pink"),
-    "rendered the Pink token",
-  );
-  assert.ok(
-    !map["tag-default"],
-    "delegated slug is NOT under the bare slug key",
+  assert.strictEqual(
+    map["tag-default|Color=Pink"],
+    "background-color:var(--zen-pink)",
   );
 });

--- a/plugins/actian-design-system/tests/renderers/ds-html-map.test.js
+++ b/plugins/actian-design-system/tests/renderers/ds-html-map.test.js
@@ -2971,3 +2971,45 @@ describe("ds-html-map: A1 hostile-prop robustness", function () {
     );
   });
 });
+
+// ---------------------------------------------------------------------------
+// Task 5: composite-key delegation lookup — delegated slugs (tag-*) render
+// via the variant-aware anatomy map when a composite-keyed entry exists;
+// a miss falls through to the hand-authored switch case unchanged.
+describe("ds-html-map: delegated composite-key lookup (Task 5)", function () {
+  it("delegated slug returns the composite-keyed anatomy HTML", function () {
+    ds.setAnatomyMap({
+      "tag-default|Color=Pink": '<div class="ds-anatomy">PINK</div>',
+    });
+    try {
+      var html = render({
+        dsSlug: "tag-default",
+        variant: "Color=Pink",
+        props: {},
+      });
+      assert.ok(html.includes("PINK"), "used the composite-keyed anatomy HTML");
+    } finally {
+      ds.setAnatomyMap(null);
+    }
+  });
+
+  it("delegated slug with no matching key falls back to the tag switch case", function () {
+    ds.setAnatomyMap({
+      "tag-default|Color=Nonexistent": "<div>X</div>",
+    });
+    try {
+      var html = render({
+        dsSlug: "tag-default",
+        variant: "Color=Pink",
+        props: { Label: "Hi" },
+      });
+      assert.ok(
+        html.includes("ds-tag"),
+        "fell through to the hand-authored tag case",
+      );
+      assert.ok(html.includes("Hi"), "rendered the label");
+    } finally {
+      ds.setAnatomyMap(null);
+    }
+  });
+});

--- a/plugins/actian-design-system/tests/renderers/ds-html-map.test.js
+++ b/plugins/actian-design-system/tests/renderers/ds-html-map.test.js
@@ -2973,43 +2973,42 @@ describe("ds-html-map: A1 hostile-prop robustness", function () {
 });
 
 // ---------------------------------------------------------------------------
-// Task 5: composite-key delegation lookup — delegated slugs (tag-*) render
-// via the variant-aware anatomy map when a composite-keyed entry exists;
-// a miss falls through to the hand-authored switch case unchanged.
-describe("ds-html-map: delegated composite-key lookup (Task 5)", function () {
-  it("delegated slug returns the composite-keyed anatomy HTML", function () {
-    ds.setAnatomyMap({
-      "tag-default|Color=Pink": '<div class="ds-anatomy">PINK</div>',
+// Token-injection pivot: tag-default keeps the hand-authored .ds-tag template
+// (label + icon) and INJECTS the harvested variant token style as an inline
+// style attr, instead of being replaced by anatomy HTML.
+describe("ds-html-map: tag-default variant-style token injection", function () {
+  it("renderDSComponent: tag-default injects the variant style onto the ds-tag span, keeping the label", function () {
+    ds.setVariantStyleMap({
+      "tag-default|Color=Pink": "background-color:var(--zen-pink)",
     });
     try {
       var html = render({
         dsSlug: "tag-default",
         variant: "Color=Pink",
-        props: {},
+        props: { Label: "Customer Orders" },
       });
-      assert.ok(html.includes("PINK"), "used the composite-keyed anatomy HTML");
+      assert.ok(html.includes('class="ds-tag"'), "hand-authored ds-tag span");
+      assert.ok(html.includes("Customer Orders"), "label preserved");
+      assert.ok(
+        html.includes("background-color:var(--zen-pink)"),
+        "variant style injected",
+      );
     } finally {
-      ds.setAnatomyMap(null);
+      ds.setVariantStyleMap(null);
     }
   });
 
-  it("delegated slug with no matching key falls back to the tag switch case", function () {
-    ds.setAnatomyMap({
-      "tag-default|Color=Nonexistent": "<div>X</div>",
+  it("renderDSComponent: tag-default with no style-map entry renders the plain ds-tag (no style attr)", function () {
+    ds.setVariantStyleMap(null);
+    var html = render({
+      dsSlug: "tag-default",
+      variant: "Color=Pink",
+      props: { Label: "Hi" },
     });
-    try {
-      var html = render({
-        dsSlug: "tag-default",
-        variant: "Color=Pink",
-        props: { Label: "Hi" },
-      });
-      assert.ok(
-        html.includes("ds-tag"),
-        "fell through to the hand-authored tag case",
-      );
-      assert.ok(html.includes("Hi"), "rendered the label");
-    } finally {
-      ds.setAnatomyMap(null);
-    }
+    assert.ok(
+      html.includes('class="ds-tag"') && html.includes("Hi"),
+      "plain ds-tag with label",
+    );
+    assert.ok(!html.includes(" style="), "no injected style when map is empty");
   });
 });


### PR DESCRIPTION
## Summary

Slice 1 of the variant-aware harvest render: a `tag-default` instance in a flow-share deliverable now renders its **harvested variant tokens** (the `Color` palette) while keeping its instance content. A `Color=Pink` tag shows the Pink palette instead of the default one, and still shows its real `Label`.

This closes the gap the `ds-html-map` `tag-default` case flagged as deferred ("renders the Default palette for every Color").

## How it works

- A pure **variant-aware resolver** (`resolveTokenDecls`) selects one harvested token per CSS property for a target variant (scoped-match, else `variantDefaults`, else unscoped, else last). The no-variant path is byte-identical to the previous behavior, so existing anatomy renders are unchanged.
- At assemble time, `buildDsVariantStyleMap` resolves each delegated tag's anatomy **root** node bindings to an inline style string, keyed by `anatomyVariantKey(slug, variant)`.
- `ds-html-map`'s hand-authored `tag-default` case **injects** that style onto its `<span class="ds-tag">`, preserving the label, icon, and structure. `ds-html-map` stays fs-free; the style map is pre-computed in Node and injected (`setVariantStyleMap`).

Slice 1 delegates **`tag-default` only** (via `isDelegated`); the mechanism generalizes by widening that one predicate, with no per-component code. No harvest schema change, no new dependencies.

## Why token-injection (and not anatomy-replacement)

The first build routed tags through the anatomy render. An adversarial review caught a HIGH regression: the anatomy tree is a static Figma capture with the default text `"Label"` baked in, so a tag with `props.Label:"Customer Orders"` rendered `>Label<` and `tag-interactive` lost its affordances. The anatomy render carries tokens but not instance content. The pivot keeps the crafted template and injects only the tokens, which preserves content and interactivity while getting variant-correct colors.

## Proof

Deliverable test (`flow-share-variant-tag-deliverable.test.js`) runs the real `assembleFlowShare` path over the real vendored `tag-default` sidecar and asserts: both instance labels survive, the output uses `<span class="ds-tag">` (not anatomy divs), and the Pink and Default tags carry **distinct** harvested background tokens (derived from the sidecar, so it survives a palette re-sync). Full suite 1836/1837; the single failure is the pre-existing `vendor-paths-resolve` check (stale refs in gitignored `docs/superpowers/` planning docs, absent on CI).

## Follow-ups (disclosed, non-blocking)

1. The abandoned anatomy approach left `renderAnatomy`'s `opts.variant`/`targetVariant` threading now unused in production (variant resolution flows `resolveRootTokenStyle -> resolveTokenDecls`). Harmless and test-covered; remove in a follow-up.
2. `resolveRootTokenStyle` injects all harvested root tokens (sizing and spacing, not only color), so the pill's dimensions shift to harvested values. This is intended (harvest as the token source of truth), but run the visual dogfood fidelity gate before lifting the `tag-default` slug guard to widen.
3. The `assemble-preview` strip renderer is not wired for variant styles (the flow-share deliverable is the slice-1 surface); it degrades to the default palette with the label preserved.
