### PR TITLE
fix(render): migrate off retired text-link-* tokens (knowledge #341)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,22 @@ are summarized at the release level.
 
 ## [Unreleased]
 
+## [2026.7.15] - 2026-07-05
+
+### Changed
+- **Migrated off the retired `--zen-color-text-link-*` tokens.** Knowledge #341
+  deletes the text-link family; `--zen-color-text-primary` is now the
+  interactive-text token (same resolved value, `#0f5fdc`). The five
+  `var(--zen-color-text-link-default)` call sites in `ds-base.css` (secondary
+  button, selected item, breadcrumb link, active tab, steward source link) and
+  the brief renderer's token-pill color now use
+  `var(--zen-color-text-primary)`; the contrast-lint pair and token-pill test
+  follow. In the three binding-gated chrome sections (page-header, breadcrumbs,
+  tabs), body text moved from the pre-rename `text-primary` to `text-default`
+  (black, matching the Figma measurement), and the binding-conformance gate
+  accepts old and new names during the vendor transition. Remaining body-text
+  `text-primary` call sites in other sections migrate in a follow-up.
+
 ## [2026.7.13] - 2026-07-05
 
 ### Added

--- a/plugins/actian-design-system/.claude-plugin/plugin.json
+++ b/plugins/actian-design-system/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "actian-design-system",
   "description": "Actian Design System toolkit — generate wireframe flows with prototype wiring, create component briefs, audit designs, compare flows, and build presentations. 8 skills (with tiered generation: recognized / adapted / improvised), 9 agents, 155 tokens (3 themes, 8 collections), WCAG 2.2 AA. DS knowledge vendored from volivarii/actian-ds-knowledge.",
-  "version": "2026.7.14",
+  "version": "2026.7.15",
   "author": {
     "name": "Actian UX Team"
   },

--- a/plugins/actian-design-system/CLAUDE.md
+++ b/plugins/actian-design-system/CLAUDE.md
@@ -120,7 +120,7 @@ Every output includes a generation card (first element) with: skill name, prompt
 
 ## Design System Rules
 
-- **Tokens:** `vendor/tokens/tokens.json` (source of truth). For HTML: bind to vendored `--zen-*` vars (brand primary = `var(--zen-color-primary-500)` = canonical `#0F5FDC`; links = `var(--zen-color-text-link-default)`), never hardcoded hex. *(There is no `--zen-color-theme-primary` in vendored tokens.)*
+- **Tokens:** `vendor/tokens/tokens.json` (source of truth). For HTML: bind to vendored `--zen-*` vars (brand primary = `var(--zen-color-primary-500)` = canonical `#0F5FDC`; links = `var(--zen-color-text-primary)`), never hardcoded hex. *(There is no `--zen-color-theme-primary` in vendored tokens.)*
 - **Content guidelines:** `vendor/content/dist/global.md` (cross-cutting voice/tone/word rules) + `vendor/content/dist/words-to-avoid.json` (structured avoid-word rules for tooling; `PATHS.content.wordsToAvoid`) + per-component `vendor/components/dist/guidelines/<slug>.json` `domains.content`
 - **Accessibility:** `vendor/accessibility/src/<slug>.md` (per-section) — WCAG 2.2 AA
 - **Never hardcode:** colors, fonts, spacing, radius, shadows, icons. Use tokens. FM outputs use `--fm-*` variables only.

--- a/plugins/actian-design-system/scripts/lint/lint-tokens.js
+++ b/plugins/actian-design-system/scripts/lint/lint-tokens.js
@@ -76,7 +76,6 @@ function themeValue(tokensJson, dotPath, theme) {
 var CONTRAST_PAIRS = [
   { fg: "color.text.primary", bg: "color.bg.default", min: 4.5 },
   { fg: "color.text.secondary", bg: "color.bg.default", min: 4.5 },
-  { fg: "color.text.link.default", bg: "color.bg.default", min: 4.5 },
   { fg: "color.text.error", bg: "color.bg.default", min: 4.5 },
 ];
 

--- a/plugins/actian-design-system/scripts/renderers/html-renderers/brief-renderer.css
+++ b/plugins/actian-design-system/scripts/renderers/html-renderers/brief-renderer.css
@@ -326,7 +326,7 @@ td code {
   padding: 2px 6px;
   border-radius: 3px;
   background: #f0f2fa;
-  color: var(--zen-color-text-link-default, #0f5fdc);
+  color: var(--zen-color-text-primary, #0f5fdc);
   font-family:
     "JetBrains Mono", ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
   font-size: 12px;

--- a/plugins/actian-design-system/scripts/renderers/html-renderers/ds-base.css
+++ b/plugins/actian-design-system/scripts/renderers/html-renderers/ds-base.css
@@ -4,9 +4,12 @@
  * side-nav). Geometry + token bindings
  * measured from the published Figma DS Kit (file l8biHxfarNi1I2RMvVxVOK, 2026-06-06).
  * Figma-var -> --zen-* alias notes: color-bg-primary->bg-emphasis,
- * color-text-default->text-primary, color-text-interactive->text-link-default,
- * color-border-primary->border-selected, size-icon-lg->size-lg,
- * font-letterspacing-N->letterspacing-wide-N. */
+ * color-text-interactive->text-primary (text-link-* retired, knowledge #341;
+ * text-primary = interactive text now), color-border-primary->border-selected,
+ * size-icon-lg->size-lg, font-letterspacing-N->letterspacing-wide-N.
+ * color-text-default->text-default in the chrome sections (page-header,
+ * breadcrumbs, tabs); older sections still bind it as text-primary from before
+ * the rename and migrate in a follow-up. */
 
 /* ============ Button ============ */
 .ds-button {
@@ -48,7 +51,7 @@
 }
 .ds-button--secondary {
   background: transparent;
-  color: var(--zen-color-text-link-default);
+  color: var(--zen-color-text-primary);
   border-color: var(--zen-border-selected);
 }
 .ds-button--secondary .ds-button__icon {
@@ -704,7 +707,7 @@
   background: var(
     --zen-color-bg-selected
   ); /* fallback: turquoise-50 not vendored */
-  color: var(--zen-color-text-link-default);
+  color: var(--zen-color-text-primary);
   display: flex;
   align-items: center;
   justify-content: center;
@@ -849,7 +852,7 @@
     --zen-font-lineheight-2xl
   ); /* 32 — heading leading, intentionally > size tier */
   letter-spacing: var(--zen-font-letterspacing-normal);
-  color: var(--zen-color-text-primary);
+  color: var(--zen-color-text-default);
 }
 .ds-page-header__desc {
   margin: 0;
@@ -877,14 +880,14 @@
   letter-spacing: var(--zen-font-letterspacing-wide-2); /* 0.2 */
 }
 .ds-breadcrumbs__crumb {
-  color: var(--zen-color-text-link-default);
+  color: var(--zen-color-text-primary);
   font-weight: var(--zen-font-weight-regular);
   text-decoration: none;
   cursor: pointer;
   white-space: nowrap;
 }
 .ds-breadcrumbs__crumb--current {
-  color: var(--zen-color-text-primary);
+  color: var(--zen-color-text-default);
   font-weight: var(--zen-font-weight-medium);
   cursor: default;
 }
@@ -893,7 +896,7 @@
   height: 16px;
   flex: 0 0 auto;
   display: inline-flex;
-  color: var(--zen-color-text-primary);
+  color: var(--zen-color-text-default);
 }
 .ds-breadcrumbs__sep svg {
   width: 100%;
@@ -920,7 +923,7 @@
   border: none;
   border-bottom: var(--zen-border-width-md) solid transparent;
   background: transparent;
-  color: var(--zen-color-text-primary);
+  color: var(--zen-color-text-default);
   font-family: inherit;
   font-size: var(--zen-font-size-md); /* 14 */
   line-height: var(--zen-font-lineheight-md); /* 20 */
@@ -934,7 +937,7 @@
   background: var(--zen-color-bg-selected);
 }
 .ds-tabs__tab.is-active {
-  color: var(--zen-color-text-link-default);
+  color: var(--zen-color-text-primary);
   font-weight: var(--zen-font-weight-semibold);
   border-bottom-color: var(--zen-border-selected);
 }
@@ -1195,7 +1198,7 @@
   gap: var(--zen-spacing-xs); /* 8px */
 }
 .ds-steward__source-link {
-  color: var(--zen-color-text-link-default);
+  color: var(--zen-color-text-primary);
   text-decoration: underline;
   cursor: pointer;
 }

--- a/plugins/actian-design-system/tests/lint/lint-tokens.test.js
+++ b/plugins/actian-design-system/tests/lint/lint-tokens.test.js
@@ -159,7 +159,6 @@ describe("countChecks", function () {
         text: {
           primary: { $type: "color", $value: "#000000" },
           secondary: { $type: "color", $value: "#222222" },
-          link: { default: { $type: "color", $value: "#0000FF" } },
           error: { $type: "color", $value: "#CC0000" },
         },
         bg: { default: { $type: "color", $value: "#FFFFFF" } },
@@ -167,8 +166,8 @@ describe("countChecks", function () {
     };
     var counts = lint.countChecks({ cssText: css, tokensJson: tokens });
     assert.strictEqual(counts.refsChecked, 2); // text + color-x, deduped
-    // 4 CONTRAST_PAIRS that resolve × 3 themes = 12 contrast checks
-    assert.strictEqual(counts.contrastChecks, 12);
+    // 3 CONTRAST_PAIRS that resolve × 3 themes = 9 contrast checks
+    assert.strictEqual(counts.contrastChecks, 9);
   });
 
   it("only counts contrast pairs whose tokens resolve", function () {

--- a/plugins/actian-design-system/tests/renderers/ds-token-bindings.test.js
+++ b/plugins/actian-design-system/tests/renderers/ds-token-bindings.test.js
@@ -32,6 +32,17 @@ var KNOWN_UNUSED = {
   tabs: new Set(["font-weight-medium"]), // we render the body-standard inactive weight
 };
 
+// Rename transition (knowledge #341): text-link-* retired, text-primary now
+// means interactive text, text-default is body text. Until the vendored
+// guideline docs refresh past that change, their bindings may still name a
+// pre-rename token while the CSS already uses the successor. A binding is
+// "used" if any listed name appears. Delete this map once the vendored
+// knowledge snapshot is newer than v0.34.71 and the suite is green without it.
+var RENAME_ACCEPT = {
+  "color-text-link-default": ["color-text-link-default", "color-text-primary"],
+  "color-text-primary": ["color-text-primary", "color-text-default"],
+};
+
 // Every --zen-* var DEFINED in tokens.css (the "resolves" universe).
 function definedZenVars() {
   var css = fs.readFileSync(PATHS.tokens.css, "utf8");
@@ -95,9 +106,14 @@ Object.keys(ROOT_CLASS).forEach(function (slug) {
             // Whitespace-tolerant: the repo's format-on-save (Prettier) can wrap a
             // long declaration inside `var( ... )`, so match `var(<ws>--zen-token<ws>)`
             // rather than the exact single-line substring.
-            var usedRe = new RegExp("var\\(\\s*--zen-" + b.token + "\\s*\\)");
+            var accepted = RENAME_ACCEPT[b.token] || [b.token];
+            var used = accepted.some(function (name) {
+              return new RegExp("var\\(\\s*--zen-" + name + "\\s*\\)").test(
+                section,
+              );
+            });
             assert.ok(
-              usedRe.test(section),
+              used,
               "binding token --zen-" +
                 b.token +
                 " (" +

--- a/plugins/actian-design-system/tests/renderers/preview-tokens-inlined.test.js
+++ b/plugins/actian-design-system/tests/renderers/preview-tokens-inlined.test.js
@@ -74,12 +74,12 @@ describe("preview-tokens-inlined", function () {
       );
     });
 
-    it("token-pill color is bound to var(--zen-color-text-link-default", function () {
+    it("token-pill color is bound to var(--zen-color-text-primary", function () {
       var r = run([BRIEF_FIXTURE, "--type", "brief"]);
       assert.strictEqual(r.status, 0, "exits cleanly");
       assert.ok(
-        r.html.includes("var(--zen-color-text-link-default"), // prefix match — the resolved value comes from vendored tokens
-        "brief HTML contains var(--zen-color-text-link-default for token-pill color",
+        r.html.includes("var(--zen-color-text-primary"), // prefix match — the resolved value comes from vendored tokens
+        "brief HTML contains var(--zen-color-text-primary for token-pill color",
       );
     });
   });


### PR DESCRIPTION
## Why

Knowledge [#341](https://github.com/volivarii/actian-ds-knowledge/pull/341) deliberately deletes the `--zen-color-text-link-{default,reverse,visited}` tokens: `--zen-color-text-primary` is the interactive-text token now (same resolved value, `#0f5fdc`), and `--zen-color-text-default` is body text. The plugin's render CSS used `var(--zen-color-text-link-default)` **without fallbacks** in five places, so once the nightly vendor snapshot (09:00 UTC) picks up a post-#341 knowledge tag (v0.34.72+; v0.34.73 is already cut), links and active states would silently lose their color.

**Merge before the next vendor refresh.**

## What

- `ds-base.css`: the five `var(--zen-color-text-link-default)` call sites (secondary button, selected item, breadcrumb link, active tab, steward source link) now use `var(--zen-color-text-primary)`. Zero visual change (same resolved hex).
- `brief-renderer.css`: token-pill color follows (fallback value unchanged).
- `lint-tokens.js`: the `color.text.link.default` contrast pair is dropped (the `color.text.primary` pair already checks the same value); `countChecks` fixture updated (3 pairs).
- Binding-gated chrome sections (page-header, breadcrumbs, tabs): body text migrates from the pre-rename `text-primary` (renders blue today) to `text-default` (black, matching the original Figma measurement). A `RENAME_ACCEPT` map in the conformance gate keeps it green on **both** the current vendored snapshot (v0.34.69, bindings still name `color-text-link-default`) and the post-#341 snapshot (bindings become `color-text-primary`/`color-text-default`). Delete the map once vendor > v0.34.71.
- `CLAUDE.md` authoring guidance + `preview-tokens-inlined` test follow.
- `plugin.json` 2026.7.14 -> 2026.7.15 (CalVer) + CHANGELOG entry.

## Discovered, deferred

`ds-base.css` has ~35 more body-text `var(--zen-color-text-primary)` call sites written under the OLD meaning (text-primary = black). Since the vendored value flipped to `#0f5fdc`, those have been rendering blue, mostly masked by the 1B inline appearance values which win over ds-base.css. They should migrate to `text-default` in a follow-up with Figma-grounded review per section (this PR only migrated the three conformance-gated chrome sections, where the new vendored bindings would otherwise go red).

## Verification

Full suite: 1878/1879 pass. The one failure (`vendor-paths-resolve`) also fails on clean `main` locally: it flags a gitignored local planning doc that CI never sees (known local-only noise pattern).

🤖 Generated with [Claude Code](https://claude.com/claude-code)