### PR TITLE
feat(render): per-variant icon glyphs (consumer half) + authoring-table regen with drift gate (W3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,31 @@ are summarized at the release level.
 
 ## [Unreleased]
 
+## [2026.7.17] - 2026-07-05
+
+### Added
+- **Per-variant icon glyphs (consumer half).** The appearance renderer now
+  honors the `slug` field on anatomy variant deltas (knowledge #354): when a
+  variant swaps the component an instance references (a per-status tag icon),
+  the matching delta's slug wins over the node's base slug, so a Success tag
+  renders its own check glyph instead of Fail's x-circle. Total-tolerant in
+  either landing order: without slug deltas in the vendored data, rendering is
+  byte-identical to today; a swapped slug missing from the icon set renders
+  the neutral placeholder, never the wrong glyph. Closes the F2 known
+  limitation once the knowledge capture lands and vendors.
+
+### Fixed
+- **`ds-components-authoring.md` vocabulary table regenerated and gated.** The
+  hand-maintained table had drifted badly (16 built slugs still marked as chip
+  fallbacks, the retired `input` slug listed as the text field, `text-input`
+  missing, stale variant axes), mis-steering hi-fi screen generation. The
+  table is now generated from the vendored registry + `BUILT_SLUGS`
+  (`node scripts/renderers/render-authoring-table.js`, statuses:
+  BUILT / appearance / chip per the real render tiers, verbatim registry axis
+  names), a sync gate test fails on any future drift, and the text-field
+  authoring section moved to `text-input` with an explicit
+  never-author-`input` note.
+
 ## [2026.7.16] - 2026-07-05
 
 ### Fixed

--- a/plugins/actian-design-system/.claude-plugin/plugin.json
+++ b/plugins/actian-design-system/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "actian-design-system",
   "description": "Actian Design System toolkit — generate wireframe flows with prototype wiring, create component briefs, audit designs, compare flows, and build presentations. 8 skills (with tiered generation: recognized / adapted / improvised), 9 agents, 155 tokens (3 themes, 8 collections), WCAG 2.2 AA. DS knowledge vendored from volivarii/actian-ds-knowledge.",
-  "version": "2026.7.16",
+  "version": "2026.7.17",
   "author": {
     "name": "Actian UX Team"
   },

--- a/plugins/actian-design-system/references/generate-flow/ds-components-authoring.md
+++ b/plugins/actian-design-system/references/generate-flow/ds-components-authoring.md
@@ -10,75 +10,75 @@ The table below covers the 69 authorable slugs (registry `section:"Components"`)
 
 | Slug | Name | Status | Variant axes |
 |---|---|---|---|
-| `account-dropdown` | Account dropdown | chip | — |
-| `alert-banner` | Alert-banner | **BUILT** | Type / Orientation |
-| `app-switcher-dropdown` | App switcher dropdown | chip | — |
-| `avatar` | Avatar | chip | State / Type |
-| `badge` | Badge | **BUILT** | Type |
-| `bar-graph` | Bar graph | chip | — |
+| `account-dropdown` | Account dropdown | **BUILT** | — |
+| `alert-banner` | ✍️ Alert-banner | **BUILT** | Type / Orientation' |
+| `app-switcher-dropdown` | App switcher dropdown | **BUILT** | — |
+| `avatar` | Avatar | appearance | State / Type |
+| `badge` | ✍️ Badge | **BUILT** | Type |
+| `bar-graph` | ⛔️ Bar graph | appearance | Property 1 |
 | `breadcrumbs` | Breadcrumbs | **BUILT** | Type |
-| `button` | Button | **BUILT** | Type / Size / State |
-| `calendar` | Calendar | chip | Type / Selection |
-| `card-for-grouped-content` | Card for grouped content | chip | — |
+| `button` | Button | **BUILT** | Intent / Emphasis / Size / State |
+| `calendar` | Calendar | **BUILT** | Type / Selection |
+| `card-for-grouped-content` | Card for grouped content | appearance | Property 1 |
 | `card-for-items` | Card for items | **BUILT** | Type / State |
-| `card-for-perimeter` | Card for perimeter | chip | — |
-| `chat-with-ai-steward` | Chat with AI Steward | **BUILT** | State (Default / Generating) |
+| `card-for-perimeter` | Card for perimeter | appearance | Property 1 |
+| `chat-with-ai-steward` | Chat with AI Steward | **BUILT** | size / history |
 | `checkbox-with-label` | Checkbox with label | **BUILT** | Selected / State |
-| `collapse-accordion` | Collapse-accordion | chip | State |
-| `confirmation` | Confirmation | chip | Size |
-| `digram-item-types` | Diagram, Item types | chip | Item type / Size |
-| `digram-topic` | Diagram, Topic | chip | Type |
-| `drawer-side-panel` | Drawer, side panel | chip | App |
-| `dropdown-select-default` | Dropdown, Select, default | chip | Type / State |
+| `collapse-accordion` | ✍️ Collapse-accordion | appearance | State |
+| `confirmation` | Confirmation | appearance | Size |
+| `digram-item-types` | Digram, Item types | appearance | — |
+| `digram-topic` | Digram, Topic | appearance | Type |
+| `drawer-side-panel` | Drawer, side panel | appearance | App |
+| `dropdown-select-default` | Dropdown, Select, default | **BUILT** | Type / State |
 | `empty-state` | Empty state | **BUILT** | Size |
-| `error-state` | Error state | chip | Size |
+| `error-state` | Error state | appearance | Size |
 | `global-header` | Global header | **BUILT** | App type / Breakpoints |
 | `glossary-item-hierarchy-diagram` | Glossary item hierarchy diagram | chip | Type |
-| `identification-key` | Identification key | chip | — |
-| `input` | Input | **BUILT** | States |
-| `input-date` | Input, date | chip | Type / States |
+| `identification-key` | Identification key | appearance | Property 1 |
+| `input-date` | Input, date | **BUILT** | Type / States |
+| `line-graph` | ⛔️ Line graph | appearance | Property 1 |
 | `lineage-connecting-line` | Lineage connecting line | chip | Direction / State |
-| `lineage-grouped-node` | Lineage grouped node | chip | State / Type |
+| `lineage-grouped-node` | Lineage grouped node | appearance | State / Type |
 | `lineage-individual-node` | Lineage individual node | chip | Type / State / Fields |
-| `line-graph` | Line graph | chip | — |
-| `link` | Link | chip | State |
-| `loader` | Loader | chip | Percent |
+| `link` | Link | appearance | State |
+| `loader` | Loader | **BUILT** | Percent |
 | `loader-with-logo` | Loader with logo | chip | App |
-| `loading-skeleton` | Loading skeleton | chip | Transition |
-| `maintenance-state` | Maintenance state | chip | Size |
-| `metamodel-widget` | Metamodel widget | chip | Type |
-| `modal` | Modal | **BUILT** | Size & Type |
-| `notification` | Notification | chip | Type |
-| `notification-dropdown` | Notification dropdown | chip | — |
+| `loading-skeleton` | Loading skeleton | appearance | Transition |
+| `maintenance-state` | Maintenance state | appearance | Size |
+| `metamodel-widget` | Metamodel widget | appearance | Type |
+| `modal` | Modal | **BUILT** | Size & Type / Dev status |
+| `notification` | Notification | **BUILT** | Type |
+| `notification-dropdown` | Notification dropdown | appearance | Property 1 |
 | `page-header` | Page header | **BUILT** | Type |
-| `popover` | Popover | chip | Type |
-| `progress-bar-small` | Progress bar small | chip | Size / Completeness |
+| `popover` | ⛔️ Popover | **BUILT** | Type |
+| `progress-bar-small` | Progress bar small | **BUILT** | Size / Completeness |
 | `radio-button` | Radio button | **BUILT** | Format / Selected / State |
-| `rich-text` | Rich text | chip | State |
-| `scroll-bar` | Scroll bar | chip | — |
+| `rich-text` | Rich text | **BUILT** | State |
+| `scroll-bar` | Scroll bar | chip | Property 1 |
 | `search` | Search | **BUILT** | Type / State |
-| `search-dropdown-menu` | Search dropdown menu | chip | Type |
-| `search-filters` | Search filters | chip | Type |
-| `search-result-card` | Search result card | chip | App / State |
-| `segmented-control` | Segmented control | chip | Type |
-| `side-nav` | Side nav | **BUILT** | App / View |
-| `spinner` | Spinner | chip | Color mode / Complete |
-| `stepper` | Stepper | chip | State |
-| `sticky-footer` | Sticky footer | chip | — |
-| `table` | Table | **BUILT** | Built type |
-| `tabs` | Tabs | **BUILT** | — |
-| `tag-catalog` | Tag, Catalog | chip | Type |
-| `tag-catalog-item-type` | Tag, Catalog item type | chip | Type |
-| `tag-default` | Tag, Default | **BUILT** | Color |
-| `tag-glossary-item-type` | Tag, Glossary item type | chip | — |
-| `tag-interactive` | Tag, Interactive | chip | State |
-| `tag-shared` | Tag, Shared | chip | — |
-| `tag-stage` | Tag, Stage | chip | Color |
-| `tag-status` | Tag, Status | chip | Status |
+| `search-dropdown-menu` | Search dropdown menu | appearance | Type |
+| `search-filters` | Search filters | appearance | Type |
+| `search-result-card` | Search result card | appearance | App / State |
+| `segmented-control` | Segmented control | **BUILT** | Type |
+| `side-nav` | ✍️ Side nav | **BUILT** | App / View |
+| `spinner` | Spinner | appearance | Color mode / Complete |
+| `stepper` | Stepper | **BUILT** | State |
+| `sticky-footer` | Sticky footer | **BUILT** | Property 1 |
+| `table` | ✍️ Table | **BUILT** | Built type |
+| `tabs` | Tabs | **BUILT** | Property 1 |
+| `tag-catalog` | ✍️ Tag, Catalog | appearance | Type |
+| `tag-catalog-item-type` | ✍️ Tag, Catalog item type | appearance | Type |
+| `tag-default` | ✍️ Tag, Default | **BUILT** | Color |
+| `tag-glossary-item-type` | ✍️ Tag, Glossary item type | appearance | Property 1 |
+| `tag-interactive` | ✍️ Tag, Interactive | **BUILT** | State |
+| `tag-shared` | ✍️ Tag, Shared | appearance | Property 1 |
+| `tag-stage` | ✍️ Tag, Stage | appearance | Color |
+| `tag-status` | ✍️ Tag, Status | appearance | Status |
+| `text-input` | Text input | **BUILT** | States |
 | `toggle` | Toggle | **BUILT** | Toggle location / Selected / State |
-| `toolbar` | Toolbar | chip | Type / Orientation |
-| `tooltip` | Tooltip | chip | Type |
-| `whats-new-dropdown` | Whats new dropdown | chip | — |
+| `toolbar` | Toolbar | **BUILT** | Type / Orientation |
+| `tooltip` | ⚠️ Tooltip | **BUILT** | Type |
+| `whats-new-dropdown` | Whats new dropdown | appearance | Property 1 |
 
 ## Built leaf props
 
@@ -108,13 +108,17 @@ The following 19 slugs have real HTML leaf renderers. Prop names are case-sensit
 - `props["Leading icon show"]`: `true` renders the `add` icon before the label
 - `props["Trailing icon show"]`: `true` renders a rotated `chevron-up` (chevron-down) after the label
 
-### `input`
+### `text-input`
+
+The text field. (The `input` slug is retired: since the knowledge publish gate
+landed, `input` names an icon in Foundations/Icons and is no longer authorable —
+never author `dsSlug: "input"`.)
 
 ```json
 {
   "type": "INSTANCE",
   "library": "ds",
-  "dsSlug": "input",
+  "dsSlug": "text-input",
   "variant": "States=Default",
   "props": {
     "Label": "Name",
@@ -124,7 +128,7 @@ The following 19 slugs have real HTML leaf renderers. Prop names are case-sensit
 }
 ```
 
-- `variant.States`: `Default` | `Focused` | `Filled` | `Disabled` | `Error` (default: `Default`)
+- `variant.States`: `Default` | `Hover` | `Focus` | `Active` | `Filled` | `Error` | `Warning` | `Disabled` | `Read-only` (default: `Default`; the built leaf styles `Disabled`, other states render the default field)
 - `props.Label`: field label (default: `"Label"`)
 - `props["Placeholder text"]`: placeholder copy (default: `"Placeholder text"`)
 - `props["Trailing icon"]`: `true` renders a chevron-down (used for select-style fields)

--- a/plugins/actian-design-system/scripts/renderers/appearance-render.js
+++ b/plugins/actian-design-system/scripts/renderers/appearance-render.js
@@ -111,6 +111,13 @@
             out[k] = e[k];
           }
         });
+        // Per-variant instance swap (knowledge #354): a delta may carry the
+        // registry slug of the component this instance references for these
+        // values (e.g. a per-status icon). Kept OUT of APPEARANCE_KEYS: it is
+        // content, not paint — the base appearance never carries it, and
+        // appearanceToDecls reads explicit paint keys only, so it can never
+        // leak into a style attribute. String-only by schema (never null).
+        if (typeof e.slug === "string" && e.slug) out.slug = e.slug;
       }
     }
     return out;
@@ -132,7 +139,15 @@
   // is absent, unresolved, or the map entry is malformed, so the caller
   // falls through to the existing placeholder/container path unchanged.
   function renderIconGlyph(node, resolved, opts) {
-    var slug = node.slug;
+    // A matching variant delta may swap the referenced component (per-variant
+    // icon, knowledge #354); the resolved slug wins over the node's base slug
+    // so a Success tag renders its own check glyph, not Fail's x-circle. If
+    // the swapped slug is absent from the icon map, the normal unknown-slug
+    // fallthrough below renders the placeholder — never the WRONG glyph.
+    var slug =
+      resolved && typeof resolved.slug === "string" && resolved.slug
+        ? resolved.slug
+        : node.slug;
     if (typeof slug !== "string" || !slug) return null;
     var iconMap =
       opts && Object.prototype.hasOwnProperty.call(opts, "iconMap")

--- a/plugins/actian-design-system/scripts/renderers/render-authoring-table.js
+++ b/plugins/actian-design-system/scripts/renderers/render-authoring-table.js
@@ -1,0 +1,120 @@
+#!/usr/bin/env node
+"use strict";
+// The vocabulary table in references/generate-flow/ds-components-authoring.md
+// mis-steers screen-generator/generate-flow when it drifts from the code (at
+// audit time: 16 BUILT slugs marked chip, `input` listed after it left the
+// registry, text-input missing). The table is GENERATED from the two sources
+// of truth — the vendored dskit registry (authorable slugs, names, variant
+// axes) and ds-html-map.BUILT_SLUGS + coverage() tiers — and the gate test
+// (tests/integration/authoring-table-sync.test.js) fails when the committed
+// table no longer matches. Regenerate with:
+//   node scripts/renderers/render-authoring-table.js
+var fs = require("fs");
+var path = require("path");
+var PATHS = require(path.join(__dirname, "..", "lib", "paths.js"));
+var BUILT_SLUGS = require(
+  path.join(__dirname, "html-renderers", "ds-html-map.js"),
+).BUILT_SLUGS;
+var coverage = require(path.join(__dirname, "ds-coverage-report.js")).coverage;
+
+var MD_PATH = path.resolve(
+  __dirname,
+  "..",
+  "..",
+  "references",
+  "generate-flow",
+  "ds-components-authoring.md",
+);
+
+function authorableEntries() {
+  var reg = JSON.parse(
+    fs.readFileSync(PATHS.components.registries.dskit, "utf8"),
+  );
+  return Object.keys(reg.components)
+    .filter(function (slug) {
+      var c = reg.components[slug];
+      return c && c.section === "Components";
+    })
+    .sort()
+    .map(function (slug) {
+      return { slug: slug, component: reg.components[slug] };
+    });
+}
+
+// Status mirrors what the render pipeline actually does per tier:
+// override -> the bespoke BUILT leaf; anatomy -> the appearance renderer
+// draws real captured values; degraded (below the ratio floor) and no-doc
+// both fall through to the graceful chip.
+function statusFor(tier) {
+  if (tier === "override") return "**BUILT**";
+  if (tier === "anatomy") return "appearance";
+  return "chip";
+}
+
+function renderTableRows() {
+  var entries = authorableEntries();
+  var tiers = {};
+  coverage(
+    entries.map(function (e) {
+      return e.slug;
+    }),
+    { builtSlugs: BUILT_SLUGS },
+  ).forEach(function (row) {
+    tiers[row.slug] = row.tier;
+  });
+  return entries.map(function (e) {
+    var axes = Object.keys((e.component && e.component.variants) || {});
+    return (
+      "| `" +
+      e.slug +
+      "` | " +
+      (e.component.name || e.slug) +
+      " | " +
+      statusFor(tiers[e.slug]) +
+      " | " +
+      (axes.length ? axes.join(" / ") : "—") +
+      " |"
+    );
+  });
+}
+
+var TABLE_HEADER = "| Slug | Name | Status | Variant axes |";
+
+function replaceTable(md, rows) {
+  var lines = md.split("\n");
+  var start = lines.indexOf(TABLE_HEADER);
+  if (start === -1)
+    throw new Error(
+      "vocabulary table header not found in " + MD_PATH + ": " + TABLE_HEADER,
+    );
+  var end = start + 2; // header + |---| separator
+  while (end < lines.length && lines[end].charAt(0) === "|") end++;
+  return lines
+    .slice(0, start + 2)
+    .concat(rows, lines.slice(end))
+    .join("\n");
+}
+
+module.exports = {
+  authorableEntries: authorableEntries,
+  renderTableRows: renderTableRows,
+  replaceTable: replaceTable,
+  statusFor: statusFor,
+  MD_PATH: MD_PATH,
+  TABLE_HEADER: TABLE_HEADER,
+};
+
+if (require.main === module) {
+  var md = fs.readFileSync(MD_PATH, "utf8");
+  var out = replaceTable(md, renderTableRows());
+  if (out !== md) {
+    fs.writeFileSync(MD_PATH, out);
+    console.log(
+      "[authoring-table] rewrote vocabulary table (" +
+        renderTableRows().length +
+        " rows)",
+    );
+  } else {
+    console.log("[authoring-table] no change");
+  }
+}

--- a/plugins/actian-design-system/tests/integration/authoring-table-sync.test.js
+++ b/plugins/actian-design-system/tests/integration/authoring-table-sync.test.js
@@ -1,0 +1,49 @@
+// tests/integration/authoring-table-sync.test.js
+// Gate: the vocabulary table in ds-components-authoring.md is generated from
+// the vendored dskit registry + ds-html-map.BUILT_SLUGS (see
+// scripts/renderers/render-authoring-table.js). This test fails whenever the
+// committed table drifts from those sources — the exact failure mode the
+// 2026-07-05 audit found (16 BUILT slugs marked chip, a retired `input` row,
+// text-input missing), which mis-steers screen-generator/generate-flow.
+"use strict";
+var test = require("node:test");
+var assert = require("node:assert/strict");
+var fs = require("fs");
+var gen = require("../../scripts/renderers/render-authoring-table.js");
+var BUILT_SLUGS = require(
+  "../../scripts/renderers/html-renderers/ds-html-map.js",
+).BUILT_SLUGS;
+
+test("ds-components-authoring.md vocabulary table is in sync with registry + BUILT_SLUGS", function () {
+  var md = fs.readFileSync(gen.MD_PATH, "utf8");
+  var regenerated = gen.replaceTable(md, gen.renderTableRows());
+  assert.equal(
+    regenerated,
+    md,
+    "Stale vocabulary table — regenerate and commit:\n" +
+      "  node scripts/renderers/render-authoring-table.js",
+  );
+});
+
+test("generated rows mark exactly the built-and-authorable slugs as BUILT", function () {
+  // Invariant derived from data (never a frozen slug list): a row says BUILT
+  // iff its slug is in BUILT_SLUGS. Registry-only slugs must not claim a
+  // bespoke leaf, and no built slug that is authorable may hide as chip.
+  var authorable = {};
+  gen.authorableEntries().forEach(function (e) {
+    authorable[e.slug] = true;
+  });
+  var built = {};
+  BUILT_SLUGS.forEach(function (s) {
+    if (authorable[s]) built[s] = true;
+  });
+  gen.renderTableRows().forEach(function (row) {
+    var m = row.match(/^\| `([^`]+)` \|.*\| (\*\*BUILT\*\*|appearance|chip) \|/);
+    assert.ok(m, "unparseable generated row: " + row);
+    assert.equal(
+      m[2] === "**BUILT**",
+      !!built[m[1]],
+      m[1] + " status disagrees with BUILT_SLUGS membership",
+    );
+  });
+});

--- a/plugins/actian-design-system/tests/renderers/appearance-render.test.js
+++ b/plugins/actian-design-system/tests/renderers/appearance-render.test.js
@@ -207,6 +207,80 @@ test("renderAppearanceNode: absent slug -> placeholder unchanged (byte-identical
   assert.equal(html, '<div class="ds-appearance__instance"></div>');
 });
 
+// Per-variant icon slug swaps (knowledge #354): the anatomy variant delta may
+// carry a `slug` field so each variant renders its OWN glyph instead of the
+// default variant's (the Success-tag-shows-Fail-icon defect).
+var SWAP_ICON_MAP = {
+  "misuse-outline": {
+    viewBox: "0 0 48 48",
+    body: '<path fill="currentColor" d="M1 1"/>',
+  },
+  "check-outline": {
+    viewBox: "0 0 48 48",
+    body: '<path fill="currentColor" d="M2 2"/>',
+  },
+};
+
+function swapNode() {
+  return {
+    kind: "instance",
+    slug: "misuse-outline",
+    appearance: {
+      variants: [
+        { prop: "Status", values: ["Success"], slug: "check-outline" },
+      ],
+    },
+  };
+}
+
+test("resolveNodeAppearance: matching slug delta rides the merge", function () {
+  var ap = r.resolveNodeAppearance(swapNode(), { Status: "Success" });
+  assert.equal(ap.slug, "check-outline");
+});
+
+test("resolveNodeAppearance: non-matching variant leaves slug absent", function () {
+  var ap = r.resolveNodeAppearance(swapNode(), { Status: "Fail" });
+  assert.equal(ap.slug, undefined);
+});
+
+test("renderAppearanceNode: matching variant renders the swapped glyph", function () {
+  var html = r.renderAppearanceNode(
+    swapNode(),
+    { Status: "Success" },
+    { iconMap: SWAP_ICON_MAP },
+  );
+  assert.match(html, /d="M2 2"/); // check-outline's body, not misuse-outline's
+  assert.doesNotMatch(html, /d="M1 1"/);
+});
+
+test("renderAppearanceNode: no variant -> base glyph unchanged", function () {
+  var html = r.renderAppearanceNode(swapNode(), null, {
+    iconMap: SWAP_ICON_MAP,
+  });
+  assert.match(html, /d="M1 1"/);
+});
+
+test("renderAppearanceNode: swapped slug missing from the icon map -> placeholder, never a wrong glyph", function () {
+  var html = r.renderAppearanceNode(
+    swapNode(),
+    { Status: "Success" },
+    { iconMap: { "misuse-outline": SWAP_ICON_MAP["misuse-outline"] } },
+  );
+  assert.equal(html, '<div class="ds-appearance__instance"></div>');
+});
+
+test("renderAppearanceNode: slug delta never leaks into a style attribute", function () {
+  var node = swapNode();
+  node.appearance.text = { color: "#50505d" };
+  var html = r.renderAppearanceNode(
+    node,
+    { Status: "Success" },
+    { iconMap: SWAP_ICON_MAP },
+  );
+  assert.match(html, /style="color:#50505d"/);
+  assert.doesNotMatch(html, /style="[^"]*slug/);
+});
+
 test("renderAppearanceNode: icon map absent entirely (simulated browser without window.dsIcons) -> unchanged placeholder, no throw", function () {
   var node = { kind: "instance", slug: "misuse-outline" };
   var html;


### PR DESCRIPTION
## What (two independent W3 pieces)

### 1. Per-variant icon glyphs — consumer half of knowledge [#354](https://github.com/volivarii/actian-ds-knowledge/pull/354)

The F2 known limitation: a variant renders its **default variant's icon** (a Success tag shows Fail's x-circle). Knowledge #354 captures the swap as a `slug` field on the anatomy variant delta; this PR consumes it:

- `resolveNodeAppearance` merges a matching delta's `slug` (kept **out** of `APPEARANCE_KEYS`: it is content, not paint, and `appearanceToDecls` reads explicit paint keys only, so it can never leak into a style attribute — test-asserted).
- `renderIconGlyph` prefers the resolved slug over the node's base slug.
- **Total-tolerant in either landing order**: with no slug deltas in the vendored data (today's state), rendering is byte-identical; a swapped slug missing from the icon map renders the neutral placeholder, never the wrong glyph (test-asserted).

TDD: red-first tests for the merge, the swap render, non-matching variants, the missing-swap placeholder, and no-style-leak.

### 2. PL1: `ds-components-authoring.md` table regenerated + drift-gated

The hand-maintained vocabulary table mis-steered hi-fi screen generation: 16 built slugs still marked as chip fallbacks, the retired `input` slug listed as the text field, `text-input` missing, stale variant axes (button still showed pre-rename axes). Now:

- `scripts/renderers/render-authoring-table.js` generates the 69-row table from the vendored dskit registry + `BUILT_SLUGS` + the real `coverage()` tiers (statuses **BUILT** / appearance / chip mirror what the pipeline actually renders).
- Axis names are **verbatim from the registry** (including current Figma hygiene artifacts like `Orientation'` and `Property 1`) because authored instance props must match byte-for-byte — cleaning names here would re-create the resolve-to-nothing bug class.
- Gate test `tests/integration/authoring-table-sync.test.js` fails on any future drift and prints the regen command; a second data-derived invariant asserts BUILT statuses always agree with `BUILT_SLUGS` membership (no frozen slug lists).
- The text-field prose section moved `input` → `text-input` with an explicit never-author-`input` note and the registry's current States axis.

## Verification

Full suite 1886/1887; the one failure (`vendor-paths-resolve`) is the known local-only noise (red on clean `main`, absent on CI). `plugin.json` 2026.7.16 -> 2026.7.17 + CHANGELOG.

🤖 Generated with [Claude Code](https://claude.com/claude-code)