### PR TITLE
ci(vendor): self-heal the authoring table inside the nightly vendor PR

### DIFF
--- a/.github/workflows/vendor-snapshot.yml
+++ b/.github/workflows/vendor-snapshot.yml
@@ -148,6 +148,20 @@ jobs:
         run: |
           node scripts/vendor/sync-doc-counts.js
 
+      - name: Regenerate the authoring vocabulary table
+        # The vocabulary table in references/generate-flow/
+        # ds-components-authoring.md is generated from the vendored dskit
+        # registry + BUILT_SLUGS, and the drift gate
+        # (tests/integration/authoring-table-sync.test.js) fails when they
+        # disagree. Without this step, a vendor refresh that renames a
+        # component or a variant axis would leave this auto-merge PR stuck
+        # red with no self-healing path (same class as the doc-counts guard
+        # above). Idempotent no-op when the registry change doesn't touch
+        # the table.
+        working-directory: plugins/actian-design-system
+        run: |
+          node scripts/renderers/render-authoring-table.js
+
       - name: Detect changes
         id: diff
         run: |
@@ -202,6 +216,7 @@ jobs:
             .claude-plugin/marketplace.json
             plugins/actian-design-system/references/context/companion-context.md
             plugins/actian-design-system/references/figma/figma-push-patterns.md
+            plugins/actian-design-system/references/generate-flow/ds-components-authoring.md
 
       - name: Enable auto-merge
         if: steps.diff.outputs.changed == 'true' && steps.cpr.outputs.pull-request-number

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,15 @@ are summarized at the release level.
 
 ## [Unreleased]
 
+### Fixed
+- **Nightly vendor refreshes self-heal the authoring table.** The
+  vendor-snapshot workflow now regenerates the
+  `ds-components-authoring.md` vocabulary table (introduced with its drift
+  gate in 2026.7.17) inside the same auto-merge PR, so a knowledge-side
+  component or variant-axis rename can no longer leave the nightly vendor PR
+  stuck red waiting for a manual regen. Same self-healing class as the
+  doc-counts guard.
+
 ## [2026.7.17] - 2026-07-05
 
 ### Added


### PR DESCRIPTION
## Why

The authoring-table drift gate (added in 2026.7.17, #228) compares the committed `ds-components-authoring.md` vocabulary table against the **vendored** registry + `BUILT_SLUGS`. That means a knowledge-side component or variant-axis rename arriving via the nightly vendor refresh would flip the gate red **inside the auto-merge vendor PR**, leaving it stuck with no self-healing path — the exact failure class the existing doc-counts guard step already solves for prose counts (observed on the v0.30.5 refresh).

## What

- New workflow step after "Sync doc inventory counts": run `scripts/renderers/render-authoring-table.js` (idempotent no-op when the registry change doesn't touch the table).
- `add-paths` whitelist gains `references/generate-flow/ds-components-authoring.md` so the regenerated table ships in the same vendor commit (without this the step would be inert).

Workflow-only change: no plugin source touched, so no CalVer bump per `check-version-bump.js`'s `PLUGIN_PREFIX` rule. CHANGELOG entry under Unreleased.

🤖 Generated with [Claude Code](https://claude.com/claude-code)