### PR TITLE
fix(lib): deterministic ref-collision resolution in registry key maps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,19 @@ are summarized at the release level.
 
 ## [Unreleased]
 
+## [2026.7.18] - 2026-07-06
+
 ### Fixed
+- **Ref-collision in the registry key maps is now deterministic.** Two
+  registry slugs can derive the same camelCase ref (`chip` and `fm-chip`
+  both become `fmChip` because ref derivation strips the kit prefix), and
+  the winner used to be whichever entry the registry emitted last. The
+  knowledge sync's move to canonically sorted keys (its #355) flipped that
+  order and silently re-pointed `fmChip` from the single chip component to
+  the `fm-chip` set, breaking Figma push for FM chips on the vendor PR.
+  Collision resolution is now order-independent: a plain slug beats a
+  prefix-stripped one, then sorted-first wins; applies to both the key maps
+  and the ref→slug maps.
 - **Nightly vendor refreshes self-heal the authoring table.** The
   vendor-snapshot workflow now regenerates the
   `ds-components-authoring.md` vocabulary table (introduced with its drift

--- a/plugins/actian-design-system/.claude-plugin/plugin.json
+++ b/plugins/actian-design-system/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "actian-design-system",
   "description": "Actian Design System toolkit — generate wireframe flows with prototype wiring, create component briefs, audit designs, compare flows, and build presentations. 8 skills (with tiered generation: recognized / adapted / improvised), 9 agents, 155 tokens (3 themes, 8 collections), WCAG 2.2 AA. DS knowledge vendored from volivarii/actian-ds-knowledge.",
-  "version": "2026.7.17",
+  "version": "2026.7.18",
   "author": {
     "name": "Actian UX Team"
   },

--- a/plugins/actian-design-system/scripts/lib/shared-constants.js
+++ b/plugins/actian-design-system/scripts/lib/shared-constants.js
@@ -158,15 +158,58 @@ function slugToRef(slug, prefix) {
 }
 
 /**
+ * Deterministic ref-collision resolution. Two registry slugs can derive the
+ * SAME ref ("chip" and "fm-chip" both -> fmChip, because slugToRef strips
+ * the kit prefix). The winner must never depend on registry emit order —
+ * that flipped when the knowledge sync moved to canonically sorted keys
+ * (knowledge #352/#355) and silently swapped fmChip from the single "chip"
+ * component to the "fm-chip" set. Preference: a plain slug beats a
+ * prefix-stripped one (a slug already carrying the kit prefix is the
+ * anomaly); otherwise sorted-first wins. Returns { refName: winningSlug }.
+ */
+function resolveRefWinners(store, prefix, overrides) {
+  var winners = {};
+  var strippedBy = {};
+  var slugs = Object.keys(store).sort();
+  for (var i = 0; i < slugs.length; i++) {
+    var slug = slugs[i];
+    var ref = (overrides && overrides[slug]) || slugToRef(slug, prefix);
+    var stripped = slug.indexOf(prefix + "-") === 0;
+    if (Object.prototype.hasOwnProperty.call(winners, ref)) {
+      // Keep the current winner unless it needed stripping and this slug is plain.
+      if (!(strippedBy[ref] && !stripped)) continue;
+    }
+    winners[ref] = slug;
+    strippedBy[ref] = stripped;
+  }
+  return winners;
+}
+
+/**
  * Build { refName: slug } map from a registry, deriving ref names from slugs.
  */
 function buildSlugMap(registryName, prefix, section, overrides) {
   var registry = loadRegistry(registryName);
-  var store = registry[section || "components"];
+  return resolveRefWinners(
+    registry[section || "components"],
+    prefix,
+    overrides,
+  );
+}
+
+/**
+ * Build { refName: { key, method } } map from a plain slug->entry store.
+ * Pure and injectable — buildKeyMapFromRegistry is the disk-backed wrapper.
+ */
+function buildKeyMapFromStore(store, prefix, overrides) {
+  var winners = resolveRefWinners(store, prefix, overrides);
   var result = {};
-  for (var slug of Object.keys(store)) {
-    var ref = (overrides && overrides[slug]) || slugToRef(slug, prefix);
-    result[ref] = slug;
+  for (var ref in winners) {
+    var entry = store[winners[ref]];
+    result[ref] = {
+      key: entry.key,
+      method: entry.importMethod === "set" ? "set" : "single",
+    };
   }
   return result;
 }
@@ -176,17 +219,11 @@ function buildSlugMap(registryName, prefix, section, overrides) {
  */
 function buildKeyMapFromRegistry(registryName, prefix, section, overrides) {
   var registry = loadRegistry(registryName);
-  var store = registry[section || "components"];
-  var result = {};
-  for (var slug of Object.keys(store)) {
-    var entry = store[slug];
-    var ref = (overrides && overrides[slug]) || slugToRef(slug, prefix);
-    result[ref] = {
-      key: entry.key,
-      method: entry.importMethod === "set" ? "set" : "single",
-    };
-  }
-  return result;
+  return buildKeyMapFromStore(
+    registry[section || "components"],
+    prefix,
+    overrides,
+  );
 }
 
 // ---------------------------------------------------------------------------
@@ -425,6 +462,7 @@ module.exports = {
   slugToRef,
   slugFromKey,
   buildSlugMap,
+  buildKeyMapFromStore,
   buildKeyMapFromRegistry,
   TOKEN_COLORS,
   PALETTE,

--- a/plugins/actian-design-system/tests/lib/shared-constants.test.js
+++ b/plugins/actian-design-system/tests/lib/shared-constants.test.js
@@ -12,6 +12,45 @@ var sc = require(
 );
 
 describe("shared-constants", function () {
+  describe("buildKeyMapFromStore ref-collision handling", function () {
+    // "chip" and "fm-chip" both derive the ref fmChip (slugToRef strips the
+    // kit prefix). Before the fix, the winner was whichever the registry
+    // emitted LAST — which flipped when the knowledge sync started emitting
+    // canonically sorted keys (#355) and broke render-node-figma's fmChip.
+    var single = {
+      key: "46e1d850aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+      importMethod: "single",
+    };
+    var set = {
+      key: "0861d937bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+      importMethod: "set",
+    };
+
+    it("prefers the plain slug over the prefix-stripped one, in either store order", function () {
+      var a = sc.buildKeyMapFromStore({ chip: single, "fm-chip": set }, "fm");
+      var b = sc.buildKeyMapFromStore({ "fm-chip": set, chip: single }, "fm");
+      assert.deepStrictEqual(a.fmChip, { key: single.key, method: "single" });
+      assert.deepStrictEqual(b.fmChip, { key: single.key, method: "single" });
+    });
+
+    it("falls back to sorted-first-wins when neither colliding slug is prefix-stripped", function () {
+      var a = sc.buildKeyMapFromStore({ "a-b": set, aB: single }, "fm");
+      var b = sc.buildKeyMapFromStore({ aB: single, "a-b": set }, "fm");
+      // "a-b" sorts before "aB" — same winner regardless of insertion order.
+      assert.deepStrictEqual(a.fmAB, { key: set.key, method: "set" });
+      assert.deepStrictEqual(b.fmAB, a.fmAB);
+    });
+
+    it("non-colliding slugs are unaffected", function () {
+      var m = sc.buildKeyMapFromStore(
+        { chip: single, button: { key: "cc", importMethod: "set" } },
+        "fm",
+      );
+      assert.deepStrictEqual(m.fmChip, { key: single.key, method: "single" });
+      assert.deepStrictEqual(m.fmButton, { key: "cc", method: "set" });
+    });
+  });
+
   describe("FM_SLUGS", function () {
     it("maps fmButton to fm-button", function () {
       assert.strictEqual(sc.FM_SLUGS.fmButton, "fm-button");


### PR DESCRIPTION
## Why

Vendor PR #230 (knowledge v0.34.75) failed `render-node-figma — INSTANCE`: `fmChip` suddenly emitted `importComponentSetByKeyAsync` for the `fm-chip` **set** instead of `importComponentByKeyAsync` for the single **chip** component.

Root cause is a latent order-dependence the canonical key sort (knowledge #352/#355) exposed: `chip` and `fm-chip` both derive the ref `fmChip` (ref derivation strips the kit prefix), and `buildKeyMapFromRegistry`/`buildSlugMap` resolved the collision by silent last-writer-wins over registry iteration order. Sorted keys flipped the winner.

## What

- Shared `resolveRefWinners`: iterate **sorted** slugs; on collision a plain slug beats a prefix-stripped one (a Figma component whose name already carries the kit prefix is the anomaly), tiebreak sorted-first. The winner can never again depend on registry emit order.
- `buildKeyMapFromStore` extracted as the pure, injectable half (TDD: identical winners for both insertion orders, plus the sorted-first tiebreak and a no-collision control).
- Applies to both the key maps (`FM_KEYS`/`DS_KEYS`) and the ref→slug maps.

## Safety

Full suite 1889/1890 against the **current pre-sort vendor** (the one failure is the known local-only vendor-paths noise), so this lands safely ahead of the vendor refresh; #230 then needs only its stale `tagStatusSuccess` golden updated (the per-variant icon feature working, handled on that branch after this merges).

Bump 2026.7.17 -> 2026.7.18 + CHANGELOG (also folds in the released-but-unversioned #229 entry).

🤖 Generated with [Claude Code](https://claude.com/claude-code)