### PR TITLE
chore(test): drop the RENAME_ACCEPT transition map (vendor past v0.34.71)

### DIFF
--- a/plugins/actian-design-system/.claude-plugin/plugin.json
+++ b/plugins/actian-design-system/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "actian-design-system",
   "description": "Actian Design System toolkit — generate wireframe flows with prototype wiring, create component briefs, audit designs, compare flows, and build presentations. 8 skills (with tiered generation: recognized / adapted / improvised), 9 agents, 155 tokens (3 themes, 8 collections), WCAG 2.2 AA. DS knowledge vendored from volivarii/actian-ds-knowledge.",
-  "version": "2026.7.18",
+  "version": "2026.7.19",
   "author": {
     "name": "Actian UX Team"
   },

--- a/plugins/actian-design-system/tests/renderers/ds-token-bindings.test.js
+++ b/plugins/actian-design-system/tests/renderers/ds-token-bindings.test.js
@@ -32,16 +32,6 @@ var KNOWN_UNUSED = {
   tabs: new Set(["font-weight-medium"]), // we render the body-standard inactive weight
 };
 
-// Rename transition (knowledge #341): text-link-* retired, text-primary now
-// means interactive text, text-default is body text. Until the vendored
-// guideline docs refresh past that change, their bindings may still name a
-// pre-rename token while the CSS already uses the successor. A binding is
-// "used" if any listed name appears. Delete this map once the vendored
-// knowledge snapshot is newer than v0.34.71 and the suite is green without it.
-var RENAME_ACCEPT = {
-  "color-text-link-default": ["color-text-link-default", "color-text-primary"],
-  "color-text-primary": ["color-text-primary", "color-text-default"],
-};
 
 // Every --zen-* var DEFINED in tokens.css (the "resolves" universe).
 function definedZenVars() {
@@ -106,14 +96,9 @@ Object.keys(ROOT_CLASS).forEach(function (slug) {
             // Whitespace-tolerant: the repo's format-on-save (Prettier) can wrap a
             // long declaration inside `var( ... )`, so match `var(<ws>--zen-token<ws>)`
             // rather than the exact single-line substring.
-            var accepted = RENAME_ACCEPT[b.token] || [b.token];
-            var used = accepted.some(function (name) {
-              return new RegExp("var\\(\\s*--zen-" + name + "\\s*\\)").test(
-                section,
-              );
-            });
+            var usedRe = new RegExp("var\\(\\s*--zen-" + b.token + "\\s*\\)");
             assert.ok(
-              used,
+              usedRe.test(section),
               "binding token --zen-" +
                 b.token +
                 " (" +


### PR DESCRIPTION
Deletes the binding-conformance gate's transitional acceptance map exactly per its own removal condition: the vendored snapshot is now v0.34.75 (#230), whose guideline bindings carry the post-rename token names, and the gate is green with the direct check restored (76/76; full suite 1889/1890, known local-only noise).

Also bumps 2026.7.18 -> 2026.7.19: #230's vendored content merged under the same 2026.7.18 as #231, so without a bump the marketplace version cache could shadow it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)