### PR TITLE
feat(render): P2 consumer — token names ride as var(--token, value)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,28 @@ are summarized at the release level.
 
 ## [Unreleased]
 
+## [2026.7.20] - 2026-07-06
+
+### Added
+- **Token names ride the appearance render (P2 consumer half).** When the
+  vendored anatomy carries the published `--zen-*` custom property a color slot
+  is bound to (knowledge P2, its #356), the appearance renderer now emits
+  `var(<token>, <value>)` at its single emit point (`appearance-style.js`)
+  instead of the bare value: the value stays the fallback (fidelity, no washout
+  if a name is unpublished downstream), the name enables theming. Covers
+  `background`, `border` color, and `text` color, plus resolved icon-glyph
+  color, per variant (the top-level `backgroundToken` now flows through
+  `resolveNodeAppearance` alongside the nested `border`/`text` tokens).
+  Total-tolerant: a slot with no token, a null token, or an unsafe token name
+  degrades to value-only (byte-identical to the previous values-only emit), so
+  with today's token-less vendored data rendering is unchanged — the var()
+  wrapping switches on automatically once the knowledge-side variable-id export
+  is populated and a real sync carries the names. Corner-radius token binding
+  is not emitted (deferred upstream until the REST bind shape is verified). The
+  runtime emit gate now enforces two invariants on real rendered output: every
+  emitted `var()` carries a value fallback (no bare `var(--name)` washout), and
+  every emitted `--zen-*` name resolves in the vendored `tokens.css`.
+
 ## [2026.7.18] - 2026-07-06
 
 ### Fixed

--- a/plugins/actian-design-system/.claude-plugin/plugin.json
+++ b/plugins/actian-design-system/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "actian-design-system",
   "description": "Actian Design System toolkit — generate wireframe flows with prototype wiring, create component briefs, audit designs, compare flows, and build presentations. 8 skills (with tiered generation: recognized / adapted / improvised), 9 agents, 155 tokens (3 themes, 8 collections), WCAG 2.2 AA. DS knowledge vendored from volivarii/actian-ds-knowledge.",
-  "version": "2026.7.19",
+  "version": "2026.7.20",
   "author": {
     "name": "Actian UX Team"
   },

--- a/plugins/actian-design-system/scripts/renderers/appearance-render.js
+++ b/plugins/actian-design-system/scripts/renderers/appearance-render.js
@@ -118,6 +118,17 @@
             isPlainObject(e[k])
           ) {
             out[k] = Object.assign({}, out[k], e[k]);
+            // colorToken pairs with THIS color. The knowledge diffAppearance
+            // ships the whole border/text object but sets colorToken only when
+            // that variant's slot is variable-bound (it never emits a nested
+            // colorToken:null the way it nulls the top-level backgroundToken).
+            // So a delta that re-colors with an UNBOUND value omits colorToken,
+            // and Object.assign would otherwise strand the BASE token over the
+            // variant's different value — theming it to the base color. A delta
+            // always re-specifies color, so the delta's token (present) or its
+            // absence (clear) governs; a color-only delta (same binding) still
+            // carries its colorToken, so this never drops a live binding.
+            if (!("colorToken" in e[k])) delete out[k].colorToken;
           } else {
             out[k] = e[k];
           }

--- a/plugins/actian-design-system/scripts/renderers/appearance-render.js
+++ b/plugins/actian-design-system/scripts/renderers/appearance-render.js
@@ -122,17 +122,30 @@
             // ships the whole border/text object but sets colorToken only when
             // that variant's slot is variable-bound (it never emits a nested
             // colorToken:null the way it nulls the top-level backgroundToken).
-            // So a delta that re-colors with an UNBOUND value omits colorToken,
-            // and Object.assign would otherwise strand the BASE token over the
-            // variant's different value — theming it to the base color. A delta
-            // always re-specifies color, so the delta's token (present) or its
-            // absence (clear) governs; a color-only delta (same binding) still
-            // carries its colorToken, so this never drops a live binding.
-            if (!("colorToken" in e[k])) delete out[k].colorToken;
+            // So a delta that RE-COLORS with an UNBOUND value carries `color`
+            // but omits colorToken, and Object.assign would otherwise strand
+            // the BASE token over the variant's different value — theming it to
+            // the base color. Key off the color: only when the delta actually
+            // re-specifies `color` without a token do we clear the stale base
+            // token. A size/weight-only text delta (border color is always
+            // present; text color is conditional) keeps the base color AND its
+            // still-valid token; a re-bound delta carries its own colorToken.
+            if ("color" in e[k] && !("colorToken" in e[k]))
+              delete out[k].colorToken;
           } else {
             out[k] = e[k];
           }
         });
+        // Same pairing for the top-level background/backgroundToken scalars.
+        // diffAppearance nulls backgroundToken only when it DIFFERS from base;
+        // if the base background is unbound, a variant that recolors it unbound
+        // omits backgroundToken entirely (its token equals the base's absent
+        // one), so in a multi-axis render a value-only background delta would
+        // otherwise strand a token an earlier-matching axis installed. When
+        // this delta re-specifies `background` but carries no backgroundToken,
+        // clear the accumulated one -> value-only for that variant.
+        if ("background" in e && !("backgroundToken" in e))
+          delete out.backgroundToken;
         // Per-variant instance swap (knowledge #354): a delta may carry the
         // registry slug of the component this instance references for these
         // values (e.g. a per-status icon). Kept OUT of APPEARANCE_KEYS: it is

--- a/plugins/actian-design-system/scripts/renderers/appearance-render.js
+++ b/plugins/actian-design-system/scripts/renderers/appearance-render.js
@@ -75,7 +75,18 @@
     return parts.join(";");
   }
 
-  var APPEARANCE_KEYS = ["background", "border", "radius", "text"];
+  // backgroundToken is a top-level scalar sibling of background (P2 name
+  // layer); it must be listed so the base copy AND variant-delta merge carry
+  // it (incl. a null delta that removes the base binding). border/text carry
+  // their colorToken nested inside the object, so they ride the deep-merge
+  // already. radius has no token (radiusToken deferred upstream).
+  var APPEARANCE_KEYS = [
+    "background",
+    "backgroundToken",
+    "border",
+    "radius",
+    "text",
+  ];
 
   // Base appearance (minus variants) with every MATCHING variant delta merged
   // over it. A delta matches when variant[entry.prop] is in entry.values.

--- a/plugins/actian-design-system/scripts/renderers/appearance-style.js
+++ b/plugins/actian-design-system/scripts/renderers/appearance-style.js
@@ -1,8 +1,11 @@
 // scripts/renderers/appearance-style.js
-// Pure appearance -> CSS-declarations mapper. VALUES-ONLY (Phase 1B): each
-// declaration is the raw resolved value captured in the anatomy `appearance`.
-// Phase 2 will teach this single emit point to wrap known token names as
-// var(--name, value) without touching callers.
+// Pure appearance -> CSS-declarations mapper. Each color declaration is the
+// raw resolved value captured in the anatomy `appearance`; when that slot also
+// carries the published --zen-* name it is bound to (P2 name layer), the value
+// is wrapped as var(<token>, <value>) at this single emit point — the value
+// stays the fallback (fidelity), the name enables theming. No token present ->
+// value-only (byte-identical to Phase 1B). radius carries no token yet
+// (radiusToken deferred upstream until the REST bind shape is verified).
 (function (exports) {
   "use strict";
 
@@ -25,18 +28,37 @@
     return true;
   }
 
+  // P2 name layer. A token is a CSS custom-property NAME; accept only a strict
+  // `--` identifier so nothing (a `)` closing the var(), a `;`/`{`/`}`, a
+  // hand-edited/future-dist smuggle) can break out of the var() wrapper. Any
+  // other shape degrades to value-only, never a poisoned declaration.
+  function safeToken(t) {
+    return typeof t === "string" && /^--[A-Za-z0-9-]+$/.test(t);
+  }
+
+  // Wrap an ALREADY-safeValue'd value as var(<token>, <value>) when a valid
+  // token name rides alongside it. The value is the FALLBACK: an unpublished
+  // name degrades to the correct value (no washout), a published name themes.
+  // No/invalid token -> the raw value (byte-identical to Phase 1B).
+  function tokenized(token, value) {
+    return safeToken(token) ? "var(" + token + ", " + value + ")" : value;
+  }
+
   // appearance: { background?, border?:{color,width}, radius?, text?:{...} }
   function appearanceToDecls(appearance) {
     var d = [];
     if (!appearance || typeof appearance !== "object") return d;
 
     if (has(appearance.background) && safeValue(appearance.background))
-      d.push("background:" + appearance.background);
+      d.push(
+        "background:" +
+          tokenized(appearance.backgroundToken, appearance.background),
+      );
 
     var b = appearance.border;
     if (b && typeof b === "object" && has(b.color) && safeValue(b.color)) {
       var w = has(b.width) && safeValue(b.width) ? b.width : "1px";
-      d.push("border:" + w + " solid " + b.color);
+      d.push("border:" + w + " solid " + tokenized(b.colorToken, b.color));
     }
 
     if (has(appearance.radius) && safeValue(appearance.radius))
@@ -44,7 +66,8 @@
 
     var t = appearance.text;
     if (t && typeof t === "object") {
-      if (has(t.color) && safeValue(t.color)) d.push("color:" + t.color);
+      if (has(t.color) && safeValue(t.color))
+        d.push("color:" + tokenized(t.colorToken, t.color));
       if (has(t.size) && safeValue(t.size)) d.push("font-size:" + t.size);
       if (has(t.weight) && safeValue(t.weight))
         d.push("font-weight:" + t.weight);
@@ -75,7 +98,7 @@
     if (!appearance || typeof appearance !== "object") return "";
     var t = appearance.text;
     if (t && typeof t === "object" && has(t.color) && safeValue(t.color)) {
-      return "color:" + t.color;
+      return "color:" + tokenized(t.colorToken, t.color);
     }
     return "";
   }

--- a/plugins/actian-design-system/tests/integration/ds-coverage.test.js
+++ b/plugins/actian-design-system/tests/integration/ds-coverage.test.js
@@ -85,8 +85,9 @@ function implementedCases() {
 // Phase 1B (Task 7): a slug also counts as covered when its vendored anatomy
 // doc carries a captured root `appearance` (the default: seam in
 // ds-html-map.js renders it per-instance via renderAppearanceComponent())
-// (see appearance-emit-values-only.test.js for the runtime values-only
-// gate on that path), so it is reachable WITHOUT a bespoke `case`. This
+// (see appearance-emit-values-only.test.js for the runtime emit gate on
+// that path — var() fallback + token resolution), so it is reachable
+// WITHOUT a bespoke `case`. This
 // credit matters going forward as Task 9 retires bespoke cases in favor of
 // the generic appearance renderer; today every conversion-reachable slug
 // still also has a case, so the credit is additive, not currently load-

--- a/plugins/actian-design-system/tests/renderers/appearance-emit-values-only.test.js
+++ b/plugins/actian-design-system/tests/renderers/appearance-emit-values-only.test.js
@@ -1,30 +1,44 @@
 // tests/renderers/appearance-emit-values-only.test.js
-// Runtime emit gate (Phase 1B, Task 7): renders every vendored appearance
-// doc through the real ds-html-map.js seam (setAnatomyDocMap ->
-// renderDSComponent's default: case) and asserts the emitted HTML never
-// contains a bare var(--name) with no fallback. Phase 1 is VALUES-ONLY:
-// appearance-style.js's appearanceToDecls() emits raw resolved values, never
-// var(--token, value) wrapping (that's Phase 2). This is the runtime
-// replacement for the static token-resolution.test.js source-scan, which
-// cannot see values injected through this doc-map seam.
+// Runtime emit gate: renders every vendored appearance doc through the real
+// ds-html-map.js seam (setAnatomyDocMap -> renderDSComponent's default: case)
+// and enforces the P2 name-layer invariants on the actual emitted HTML — the
+// runtime replacement for the static token-resolution.test.js source-scan,
+// which cannot see values/tokens injected through this doc-map seam.
 //
-// Test-integrity fix (Phase 1B strengthening, Task T1): the bare-var()
-// assertion alone is VACUOUS — it passes 100% even with the appearance path
-// fully broken, because a graceful `.ds-component` chip also contains no
-// var(). This file adds a second, load-bearing assertion: count how many
-// non-BUILT_SLUGS outputs actually rendered via `.ds-appearance` (not a
-// chip) and require a real majority floor, so a total wiring collapse (every
-// slug degrading to a chip) fails the test.
+// Two invariants, both load-bearing:
+//   (1) NO BARE var(--name): every var() the emit produces MUST carry a value
+//       fallback (var(--token, value)). A bare var(--x) is the washout-bug
+//       class — an unpublished name with no fallback resolves to nothing. The
+//       emit is VALUES-ONLY for any slot without a token, and var(token, value)
+//       when a token rides (P2); either way a bare var must never appear.
+//   (2) EMITTED TOKEN NAMES RESOLVE: every --zen-* name the emit wraps in a
+//       var() must be a real custom property defined in the vendored tokens.css
+//       (else it silently falls back — fidelity holds, but theming is dead and
+//       it signals a capture/publish drift). Data-driven: a no-op while the
+//       variable-id export is empty (vendored data carries no token names yet),
+//       it starts enforcing the instant names begin to flow.
+//
+// Non-vacuity floor: the bare-var() assertion alone passes 100% even with the
+// appearance path fully broken (a graceful `.ds-component` chip also has no
+// var()). So this also counts how many non-BUILT_SLUGS outputs actually
+// rendered via `.ds-appearance` (not a chip) and requires a real floor, so a
+// total wiring collapse (every slug degrading to a chip) fails hard.
 "use strict";
 var test = require("node:test");
 var assert = require("node:assert/strict");
 var fs = require("fs");
 var path = require("path");
 var ds = require("../../scripts/renderers/html-renderers/ds-html-map.js");
+var appearanceRender = require("../../scripts/renderers/appearance-render.js");
+var PATHS = require("../../scripts/lib/paths.js");
 
 var ANATOMY_DIR = path.join(__dirname, "../../vendor/components/dist/anatomy");
 // Bare var() with no comma fallback: var(--x) but NOT var(--x, value)
 var BARE_VAR = /var\(\s*--[a-zA-Z0-9-]+\s*\)/;
+// Every var(--name referenced (name only; fallback ignored).
+var VAR_REF = /var\(\s*(--[a-zA-Z0-9-]+)/g;
+// Every --name: defined in a stylesheet.
+var VAR_DEF = /(--[a-zA-Z0-9-]+)\s*:/g;
 
 // Load-bearing floor (Task 8 fix): with the doc map fully populated, a real
 // wiring collapse — e.g. renderAppearanceComponent always returning "" / the
@@ -39,7 +53,15 @@ var BARE_VAR = /var\(\s*--[a-zA-Z0-9-]+\s*\)/;
 // flaky, while a total collapse (0 rendered) still fails hard.
 var MIN_APPEARANCE_RENDERED = 40;
 
-test("appearance-rendered output emits values only (no bare var(--name))", function () {
+function definedVars(src) {
+  var out = new Set(),
+    m;
+  while ((m = VAR_DEF.exec(src))) out.add(m[1]);
+  VAR_DEF.lastIndex = 0;
+  return out;
+}
+
+test("appearance emit: every var() carries a fallback and resolves in tokens.css", function () {
   var slugs = fs.readdirSync(ANATOMY_DIR).filter(function (f) {
     return f.endsWith(".json");
   });
@@ -48,12 +70,14 @@ test("appearance-rendered output emits values only (no bare var(--name))", funct
     var slug = f.replace(/\.json$/, "");
     docs[slug] = JSON.parse(fs.readFileSync(path.join(ANATOMY_DIR, f), "utf8"));
   });
+  var defined = definedVars(fs.readFileSync(PATHS.tokens.css, "utf8"));
   ds.setAnatomyDocMap(docs);
   try {
     var nonBuiltSlugs = Object.keys(docs).filter(function (slug) {
       return ds.BUILT_SLUGS.indexOf(slug) === -1; // bespoke cases excluded
     });
     var appearanceRenderedCount = 0;
+    var unresolved = []; // {slug, name} for any emitted var() name not in tokens.css
     nonBuiltSlugs.forEach(function (slug) {
       var name = docs[slug].root && docs[slug].root.name;
       var html = ds.renderDSComponent({
@@ -63,6 +87,15 @@ test("appearance-rendered output emits values only (no bare var(--name))", funct
         variant: name || "",
       });
       assert.doesNotMatch(html, BARE_VAR, slug + " emitted a bare var(--name)");
+      // (2) Every emitted --zen-* name must resolve in the vendored tokens.css.
+      // A no-op today (vendored anatomy carries no token names until the
+      // variable-id export is populated), it catches a capture/publish drift
+      // the moment names begin to ride — a name that themes to nothing.
+      var m;
+      while ((m = VAR_REF.exec(html))) {
+        if (!defined.has(m[1])) unresolved.push(slug + ":" + m[1]);
+      }
+      VAR_REF.lastIndex = 0;
       // Load-bearing: count outputs that actually took the appearance render
       // path (a real `.ds-appearance` wrapper), not the graceful `.ds-component`
       // chip. The bare-var() assertion above passes vacuously on a chip (a
@@ -72,6 +105,13 @@ test("appearance-rendered output emits values only (no bare var(--name))", funct
         appearanceRenderedCount++;
       }
     });
+    assert.deepEqual(
+      unresolved.sort(),
+      [],
+      "emitted var(--name) with no tokens.css definition (themes to nothing — " +
+        "check the capture/publish join): " +
+        unresolved.join(", "),
+    );
     assert.ok(
       appearanceRenderedCount >= MIN_APPEARANCE_RENDERED,
       "expected at least " +
@@ -87,4 +127,48 @@ test("appearance-rendered output emits values only (no bare var(--name))", funct
   } finally {
     ds.setAnatomyDocMap(null);
   }
+});
+
+// Non-vacuity proof for invariant (2). The gate above is a no-op while vendored
+// anatomy carries no token names, so this drives token-bearing appearance
+// through the SAME emit and confirms the resolution check has teeth: a
+// published name passes and rides as a real var(--name, value); an
+// unpublished one is flagged by the exact defined-set check the gate uses.
+test("resolution check is non-vacuous: published --zen name rides, unpublished is flagged", function () {
+  var defined = definedVars(fs.readFileSync(PATHS.tokens.css, "utf8"));
+  var doc = {
+    slug: "synthetic",
+    root: {
+      name: "",
+      kind: "container",
+      appearance: {
+        background: "#f3f5f9",
+        backgroundToken: "--zen-color-bg-selected", // real, defined in tokens.css
+        border: {
+          color: "#000000",
+          colorToken: "--zen-not-a-real-token-xyz", // deliberately unpublished
+          width: "1px",
+        },
+      },
+      children: [],
+    },
+  };
+  var html = appearanceRender.renderAppearanceComponent(doc, {});
+  assert.doesNotMatch(html, BARE_VAR); // both still carry a value fallback
+  var refs = [];
+  var m;
+  while ((m = VAR_REF.exec(html))) refs.push(m[1]);
+  VAR_REF.lastIndex = 0;
+  assert.ok(
+    refs.indexOf("--zen-color-bg-selected") !== -1,
+    "a published token must ride as var(--name, value)",
+  );
+  var unresolved = refs.filter(function (n) {
+    return !defined.has(n);
+  });
+  assert.deepEqual(
+    unresolved,
+    ["--zen-not-a-real-token-xyz"],
+    "the resolution check must flag exactly the unpublished name",
+  );
 });

--- a/plugins/actian-design-system/tests/renderers/appearance-render.test.js
+++ b/plugins/actian-design-system/tests/renderers/appearance-render.test.js
@@ -433,3 +433,92 @@ test("renderAppearanceComponent: emits var(--token, value) end to end", function
     /border:1px solid var\(--zen-color-border-default, #e1e1e6\)/,
   );
 });
+
+// A nested colorToken pairs with its OWN color. The knowledge diffAppearance
+// emits the whole border/text object per variant but sets colorToken only when
+// that variant's slot is variable-bound (it never emits colorToken:null inside
+// the object, unlike the top-level backgroundToken scalar). So a variant that
+// recolors a base-tokened border/text with an UNBOUND value ships a delta with
+// color but no colorToken — the base token must NOT survive the merge and theme
+// the variant's different color to the base color.
+var P2_STALE_TOKEN_DOC = {
+  slug: "field",
+  variantDefaults: { State: "Default" },
+  root: {
+    name: "State=Default",
+    kind: "container",
+    appearance: {
+      border: {
+        color: "#0f5fdc",
+        colorToken: "--zen-color-primary-500",
+        width: "1px",
+      },
+      text: {
+        color: "#0f5fdc",
+        colorToken: "--zen-color-primary-500",
+        size: "12px",
+      },
+      variants: [
+        // Error: hardcoded red, not token-bound -> delta omits colorToken.
+        {
+          prop: "State",
+          values: ["Error"],
+          border: { color: "#dc3514", width: "1px" },
+          text: { color: "#dc3514", size: "12px" },
+        },
+        // Focus: re-bound to a DIFFERENT token -> delta carries its own token.
+        {
+          prop: "State",
+          values: ["Focus"],
+          border: {
+            color: "#0283be",
+            colorToken: "--zen-color-info-500",
+            width: "1px",
+          },
+        },
+      ],
+    },
+    children: [],
+  },
+};
+
+test("resolveNodeAppearance: an unbound variant color clears the stale base border colorToken", function () {
+  var ap = r.resolveNodeAppearance(P2_STALE_TOKEN_DOC.root, { State: "Error" });
+  assert.equal(ap.border.color, "#dc3514");
+  assert.equal(ap.border.colorToken, undefined); // NOT the base primary-500
+  assert.equal(ap.border.width, "1px"); // base sub-key still preserved (C1)
+  assert.equal(ap.text.color, "#dc3514");
+  assert.equal(ap.text.colorToken, undefined);
+  assert.equal(ap.text.size, "12px");
+});
+
+test("resolveNodeAppearance: a re-bound variant color uses the variant's own token", function () {
+  var ap = r.resolveNodeAppearance(P2_STALE_TOKEN_DOC.root, { State: "Focus" });
+  assert.equal(ap.border.color, "#0283be");
+  assert.equal(ap.border.colorToken, "--zen-color-info-500");
+});
+
+test("renderAppearanceComponent: an unbound variant emits value-only, never the base token", function () {
+  var html = r.renderAppearanceComponent(P2_STALE_TOKEN_DOC, {
+    variant: { State: "Error" },
+  });
+  assert.match(html, /border:1px solid #dc3514/);
+  assert.doesNotMatch(html, /--zen-color-primary-500/); // no stale base token
+});
+
+test("renderAppearanceNode: a resolved icon glyph rides its text colorToken end to end", function () {
+  // Exercises renderIconGlyph -> iconColorDecl -> tokenized (the P2 emit) on
+  // the real glyph path, not just the iconColorDecl unit.
+  var node = {
+    kind: "instance",
+    slug: "misuse-outline",
+    appearance: {
+      text: { color: "#50505d", colorToken: "--zen-color-text-secondary" },
+    },
+  };
+  var html = r.renderAppearanceNode(node, null, { iconMap: ICON_MAP });
+  assert.match(
+    html,
+    /<svg class="ds-icon" style="color:var\(--zen-color-text-secondary, #50505d\)"/,
+  );
+});

--- a/plugins/actian-design-system/tests/renderers/appearance-render.test.js
+++ b/plugins/actian-design-system/tests/renderers/appearance-render.test.js
@@ -522,3 +522,97 @@ test("renderAppearanceNode: a resolved icon glyph rides its text colorToken end 
     /<svg class="ds-icon" style="color:var\(--zen-color-text-secondary, #50505d\)"/,
   );
 });
+
+// A color-less (size/weight-only) text delta: the variant text node has no
+// SOLID fill of its own, so diffAppearance emits {size} with NO color and NO
+// colorToken. The deep-merge preserves the BASE color, whose base token still
+// validly pairs with it — the token must NOT be dropped. So the stale-clear
+// must key on whether the delta RE-SPECIFIES color, not merely on colorToken
+// being absent (border color is always present; text color is conditional).
+test("resolveNodeAppearance: a color-less size-only text delta keeps the base colorToken", function () {
+  var node = {
+    kind: "text",
+    appearance: {
+      text: {
+        color: "#0f5fdc",
+        colorToken: "--zen-color-primary-500",
+        size: "12px",
+      },
+      variants: [{ prop: "Size", values: ["Large"], text: { size: "16px" } }],
+    },
+  };
+  var ap = r.resolveNodeAppearance(node, { Size: "Large" });
+  assert.equal(ap.text.color, "#0f5fdc");
+  assert.equal(ap.text.colorToken, "--zen-color-primary-500"); // color unchanged -> token stays
+  assert.equal(ap.text.size, "16px");
+});
+
+// Residual of the SAME class on the top-level backgroundToken scalar. A
+// multi-axis render where an earlier-sorted axis binds background to a token
+// and a later axis recolors it UNBOUND: diffAppearance omits backgroundToken
+// from the unbound delta (its token equals the base's absent token), so the
+// scalar path must clear the stranded token the way the nested path does.
+var P2_SCALAR_STRAND_DOC = {
+  slug: "chip",
+  variantDefaults: { Emphasis: "Default", State: "Default" },
+  root: {
+    name: "Emphasis=Default, State=Default",
+    kind: "container",
+    appearance: {
+      background: "#ffffff", // base UNBOUND
+      variants: [
+        {
+          prop: "Emphasis",
+          values: ["Strong"],
+          background: "#0050c8",
+          backgroundToken: "--zen-color-primary-500",
+        },
+        { prop: "State", values: ["Error"], background: "#dc3514" }, // unbound recolor
+      ],
+    },
+    children: [],
+  },
+};
+
+test("resolveNodeAppearance: a later unbound background delta clears an earlier axis's stranded backgroundToken", function () {
+  var ap = r.resolveNodeAppearance(P2_SCALAR_STRAND_DOC.root, {
+    Emphasis: "Strong",
+    State: "Error",
+  });
+  assert.equal(ap.background, "#dc3514");
+  assert.equal(ap.backgroundToken, undefined); // NOT primary-500 from the Emphasis axis
+});
+
+test("resolveNodeAppearance: a later BOUND background delta keeps its own token (multi-axis)", function () {
+  var doc = {
+    kind: "container",
+    appearance: {
+      background: "#ffffff",
+      variants: [
+        {
+          prop: "Emphasis",
+          values: ["Strong"],
+          background: "#0050c8",
+          backgroundToken: "--zen-color-primary-500",
+        },
+        {
+          prop: "State",
+          values: ["Info"],
+          background: "#0283be",
+          backgroundToken: "--zen-color-info-500",
+        },
+      ],
+    },
+  };
+  var ap = r.resolveNodeAppearance(doc, { Emphasis: "Strong", State: "Info" });
+  assert.equal(ap.background, "#0283be");
+  assert.equal(ap.backgroundToken, "--zen-color-info-500");
+});
+
+test("renderAppearanceComponent: multi-axis unbound background emits value-only, no stranded token", function () {
+  var html = r.renderAppearanceComponent(P2_SCALAR_STRAND_DOC, {
+    variant: { Emphasis: "Strong", State: "Error" },
+  });
+  assert.match(html, /background:#dc3514/);
+  assert.doesNotMatch(html, /--zen-color-primary-500/);
+});

--- a/plugins/actian-design-system/tests/renderers/appearance-render.test.js
+++ b/plugins/actian-design-system/tests/renderers/appearance-render.test.js
@@ -357,3 +357,79 @@ test("renderAppearanceComponent: escapes HTML special characters in text nodes",
   // (but &lt; and &gt; should be)
   assert.doesNotMatch(html, />\s*a & b < c >/);
 });
+
+// ─── P2 name layer: token bindings flow through resolveNodeAppearance ────────
+// backgroundToken is a TOP-LEVEL sibling of background (a scalar), so it must
+// be in APPEARANCE_KEYS to survive base-copy + variant-delta merge. border and
+// text carry their colorToken nested inside the object, so they ride through
+// the existing deep-merge — but the whole point is the emit downstream sees
+// them, so these tests pin the flow end to end.
+var P2_TOKEN_DOC = {
+  slug: "banner",
+  variantDefaults: { Type: "Default" },
+  root: {
+    name: "Type=Default",
+    kind: "container",
+    appearance: {
+      background: "#ffffff",
+      backgroundToken: "--zen-color-bg-default",
+      border: {
+        color: "#e1e1e6",
+        colorToken: "--zen-color-border-default",
+        width: "1px",
+      },
+      text: {
+        color: "#50505d",
+        colorToken: "--zen-color-text-secondary",
+        size: "12px",
+      },
+      variants: [
+        {
+          prop: "Type",
+          values: ["Selected"],
+          background: "#f3f5f9",
+          backgroundToken: "--zen-color-bg-selected",
+        },
+        {
+          prop: "Type",
+          // A variant whose fill is not token-bound: the base token is removed
+          // (null) so the value rides alone, never a stale name over a new value.
+          values: ["Plain"],
+          background: "#fafafa",
+          backgroundToken: null,
+        },
+      ],
+    },
+    children: [],
+  },
+};
+
+test("resolveNodeAppearance: base carries backgroundToken + nested colorTokens", function () {
+  var ap = r.resolveNodeAppearance(P2_TOKEN_DOC.root, { Type: "Default" });
+  assert.equal(ap.backgroundToken, "--zen-color-bg-default");
+  assert.equal(ap.border.colorToken, "--zen-color-border-default");
+  assert.equal(ap.text.colorToken, "--zen-color-text-secondary");
+});
+
+test("resolveNodeAppearance: a variant delta's backgroundToken merges over base", function () {
+  var ap = r.resolveNodeAppearance(P2_TOKEN_DOC.root, { Type: "Selected" });
+  assert.equal(ap.background, "#f3f5f9");
+  assert.equal(ap.backgroundToken, "--zen-color-bg-selected");
+});
+
+test("resolveNodeAppearance: a null delta backgroundToken removes the base binding", function () {
+  var ap = r.resolveNodeAppearance(P2_TOKEN_DOC.root, { Type: "Plain" });
+  assert.equal(ap.background, "#fafafa");
+  assert.equal(ap.backgroundToken, null);
+});
+
+test("renderAppearanceComponent: emits var(--token, value) end to end", function () {
+  var html = r.renderAppearanceComponent(P2_TOKEN_DOC, {
+    variant: { Type: "Default" },
+  });
+  assert.match(html, /background:var\(--zen-color-bg-default, #ffffff\)/);
+  assert.match(
+    html,
+    /border:1px solid var\(--zen-color-border-default, #e1e1e6\)/,
+  );
+});

--- a/plugins/actian-design-system/tests/renderers/appearance-style.test.js
+++ b/plugins/actian-design-system/tests/renderers/appearance-style.test.js
@@ -107,6 +107,94 @@ test("iconColorDecl: malicious background is never emitted (background unused)",
   assert.equal(s.iconColorDecl({ background: "url(http://x/e.png)" }), "");
 });
 
+// ─── P2 name layer: token names ride as var(--token, value) ─────────────────
+// When the anatomy appearance carries the published --zen-* name a color slot
+// is bound to, the emit wraps the value as var(<token>, <value>): the value is
+// the FALLBACK (fidelity + no washout if the name is unpublished downstream),
+// the name enables theming. No token / null token / unsafe token -> value-only
+// (byte-identical to Phase 1B). A token never rescues an unsafe VALUE.
+
+test("P2: backgroundToken wraps the value as var(token, value)", function () {
+  assert.deepEqual(
+    s.appearanceToDecls({
+      background: "#f3f5f9",
+      backgroundToken: "--zen-color-bg-selected",
+    }),
+    ["background:var(--zen-color-bg-selected, #f3f5f9)"],
+  );
+});
+
+test("P2: border.colorToken wraps the color inside the border shorthand", function () {
+  assert.deepEqual(
+    s.appearanceToDecls({
+      border: {
+        color: "#0f5fdc",
+        colorToken: "--zen-color-primary-500",
+        width: "1px",
+      },
+    }),
+    ["border:1px solid var(--zen-color-primary-500, #0f5fdc)"],
+  );
+});
+
+test("P2: text.colorToken wraps the text color", function () {
+  assert.deepEqual(
+    s.appearanceToDecls({
+      text: {
+        color: "#50505d",
+        colorToken: "--zen-color-text-secondary",
+        size: "12px",
+      },
+    }),
+    ["color:var(--zen-color-text-secondary, #50505d)", "font-size:12px"],
+  );
+});
+
+test("P2: no token / null token -> value-only (unchanged 1B behavior)", function () {
+  assert.deepEqual(s.appearanceToDecls({ background: "#f3f5f9" }), [
+    "background:#f3f5f9",
+  ]);
+  assert.deepEqual(
+    s.appearanceToDecls({ background: "#f3f5f9", backgroundToken: null }),
+    ["background:#f3f5f9"],
+  );
+});
+
+test("P2: an unsafe token name is rejected (value-only), never emitted into var()", function () {
+  // A token carrying anything outside a CSS custom-property identifier must not
+  // reach the output — the value still rides, so fidelity is preserved.
+  assert.deepEqual(
+    s.appearanceToDecls({
+      background: "#fff",
+      backgroundToken: "--zen); color:red",
+    }),
+    ["background:#fff"],
+  );
+  assert.deepEqual(
+    s.appearanceToDecls({ background: "#fff", backgroundToken: "notavar" }),
+    ["background:#fff"],
+  );
+});
+
+test("P2: a token never rescues an UNSAFE value (whole decl still dropped)", function () {
+  assert.deepEqual(
+    s.appearanceToDecls({
+      background: "red;position:fixed",
+      backgroundToken: "--zen-color-bg-selected",
+    }),
+    [],
+  );
+});
+
+test("P2: iconColorDecl wraps text.color with its token", function () {
+  assert.equal(
+    s.iconColorDecl({
+      text: { color: "#50505d", colorToken: "--zen-color-text-secondary" },
+    }),
+    "color:var(--zen-color-text-secondary, #50505d)",
+  );
+});
+
 test("appearanceToDecls: C3 drops url()/braces/markup, keeps hex/rgba/px/rem/%", function () {
   // url(), braces, and </ markup escapes are all rejected.
   assert.deepEqual(


### PR DESCRIPTION
## What

The **P2 name-layer consumer half**. The knowledge repo now captures, on each anatomy node's resolved appearance, the published `--zen-*` custom property a color slot is bound to (its [#356]). This teaches the plugin's **single appearance emit point** to use it: `background`, `border` color, `text` color, and resolved icon-glyph color now emit `var(<token>, <value>)` when the token rides, the raw value otherwise.

The value stays the **fallback** (fidelity + no washout if a name is unpublished downstream); the name enables theming.

- `appearance-style.js`: new `safeToken` (strict `--` identifier) + `tokenized` helper at the one emit point. An unsafe/absent token, or an unsafe value, degrades to value-only.
- `appearance-render.js`: `backgroundToken` (a top-level scalar) joins `APPEARANCE_KEYS` so it flows through `resolveNodeAppearance` base-copy + variant-delta merge. `border`/`text` carry their `colorToken` nested. `radius` has no token (deferred upstream).
- runtime gate (`appearance-emit-values-only.test.js`) reframed: asserts every emitted `var()` carries a value fallback **and** every emitted `--zen-*` name resolves in the vendored `tokens.css`, with a non-vacuity proof.

## Total tolerance / no-op today

With today's token-less vendored data the change is **byte-identical** (goldens + real-data + coverage green). The `var()` wrapping switches on automatically once the knowledge variable-id export is populated and a real sync carries the names.

## Review-driven fixes (the token-strand class)

A full 5-lens adversarial review (3 lenses converged) plus adversarial verification of the fix caught a real, latent bug in **3 corners**, fixed across two follow-up commits:

- A variant re-coloring a base-tokened slot with an **unbound** value stranded the base token over the variant's value (`Object.assign` deep-merge can't clear an absent key) → themed the variant to the *base* color once names publish. Fixed for `border`/`text` (nested) and `background`/`backgroundToken` (scalar), keyed on whether the delta re-specifies the value.
- Also fixed an over-clear: a color-less size-only `text` delta kept its still-valid base token.

A final adversarial pass confirmed the class is **fully closed** — the token set is provably exactly three slots (schema `additionalProperties:false`), the two rules touch disjoint slots, and neither mutates the shared base appearance.

## Known follow-up (NOT in this PR)

P2 activation will also light up the **layout `gap`/`padding`** token path, which currently stores a bare token name (name-XOR-px) and emits invalid CSS. That needs the same value+name treatment (a knowledge-side change) and must land before the export is populated. Tracked separately.

## Verification

- Full suite **1909 pass / 1** (the pre-existing local-only `vendor-paths-resolve` false positive; green on CI)
- Goldens + real-data + coverage green (no-op on token-less data)
- TDD red-first throughout

CalVer `2026.7.19 → 2026.7.20`. CHANGELOG updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)