### PR TITLE
feat(render): P2 layout tokens — flexStyle var-wraps gap/padding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ are summarized at the release level.
 
 ## [Unreleased]
 
-## [2026.7.21] - 2026-07-06
+## [2026.7.22] - 2026-07-06
 
 ### Added
 - **Layout spacing tokens theme too (P2 consumer, layout half).** When the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,20 @@ are summarized at the release level.
 
 ## [Unreleased]
 
+## [2026.7.21] - 2026-07-06
+
+### Added
+- **Layout spacing tokens theme too (P2 consumer, layout half).** When the
+  vendored anatomy carries a `layout.gapToken` / `layout.paddingTokens` (knowledge
+  #357), `flexStyle` now emits `gap:var(--zen-spacing-xs, 8px)` and per-side
+  `padding:var(--zen-spacing-sm, 8px) …` instead of the bare value — the value
+  stays the fallback, the name themes. Uses the same `tokenized` helper as the
+  color emit (now exported from `appearance-style.js`), so a bare token name is
+  never emitted into a CSS value. Total-tolerant: no layout token → value-only,
+  byte-identical to before (goldens/real-data green), so it's a no-op until the
+  knowledge variable-id export is populated. Completes the P2 name-layer consumer
+  surface: appearance colors (2026.7.20) + layout spacing now both theme.
+
 ## [2026.7.20] - 2026-07-06
 
 ### Added

--- a/plugins/actian-design-system/.claude-plugin/plugin.json
+++ b/plugins/actian-design-system/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "actian-design-system",
   "description": "Actian Design System toolkit — generate wireframe flows with prototype wiring, create component briefs, audit designs, compare flows, and build presentations. 8 skills (with tiered generation: recognized / adapted / improvised), 9 agents, 155 tokens (3 themes, 8 collections), WCAG 2.2 AA. DS knowledge vendored from volivarii/actian-ds-knowledge.",
-  "version": "2026.7.20",
+  "version": "2026.7.21",
   "author": {
     "name": "Actian UX Team"
   },

--- a/plugins/actian-design-system/.claude-plugin/plugin.json
+++ b/plugins/actian-design-system/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "actian-design-system",
   "description": "Actian Design System toolkit — generate wireframe flows with prototype wiring, create component briefs, audit designs, compare flows, and build presentations. 8 skills (with tiered generation: recognized / adapted / improvised), 9 agents, 155 tokens (3 themes, 8 collections), WCAG 2.2 AA. DS knowledge vendored from volivarii/actian-ds-knowledge.",
-  "version": "2026.7.21",
+  "version": "2026.7.22",
   "author": {
     "name": "Actian UX Team"
   },

--- a/plugins/actian-design-system/scripts/renderers/appearance-render.js
+++ b/plugins/actian-design-system/scripts/renderers/appearance-render.js
@@ -58,16 +58,25 @@
   function flexStyle(layout) {
     if (!layout || typeof layout !== "object") return "";
     var p = layout.padding || {};
+    var pt = layout.paddingTokens || {};
     var parts = [
       "display:flex",
       "flex-direction:" + (layout.axis === "row" ? "row" : "column"),
     ];
-    if (layout.gap) parts.push("gap:" + layout.gap);
+    // P2 layout tokens: a spacing slot rides var(<token>, <value>) when the
+    // knowledge capture bound it, value-only otherwise — the same tokenized()
+    // the color emit uses (value is the fallback; a bare name is never
+    // emitted). No token -> byte-identical to the prior value-only output.
+    if (layout.gap)
+      parts.push("gap:" + style.tokenized(layout.gapToken, layout.gap));
     parts.push(
       "padding:" +
-        [p.top || "0", p.right || "0", p.bottom || "0", p.left || "0"].join(
-          " ",
-        ),
+        [
+          style.tokenized(pt.top, p.top || "0"),
+          style.tokenized(pt.right, p.right || "0"),
+          style.tokenized(pt.bottom, p.bottom || "0"),
+          style.tokenized(pt.left, p.left || "0"),
+        ].join(" "),
     );
     var a = layout.align || {};
     if (a.main) parts.push("justify-content:" + mapAlign(a.main));

--- a/plugins/actian-design-system/scripts/renderers/appearance-style.js
+++ b/plugins/actian-design-system/scripts/renderers/appearance-style.js
@@ -105,6 +105,8 @@
 
   exports.appearanceToDecls = appearanceToDecls;
   exports.iconColorDecl = iconColorDecl;
+  // Shared by flexStyle for the layout gap/padding token wrap (P2).
+  exports.tokenized = tokenized;
 })(
   typeof module !== "undefined"
     ? module.exports

--- a/plugins/actian-design-system/tests/renderers/appearance-emit-values-only.test.js
+++ b/plugins/actian-design-system/tests/renderers/appearance-emit-values-only.test.js
@@ -172,3 +172,46 @@ test("resolution check is non-vacuous: published --zen name rides, unpublished i
     "the resolution check must flag exactly the unpublished name",
   );
 });
+
+// Same teeth for the LAYOUT emit (flexStyle gap/padding), which the invariant-2
+// scan covers structurally but no vendored data exercises yet. Drives a layout
+// token through the SAME emit + gate regexes: a published spacing token rides as
+// a real var() and an unpublished one is flagged, proving the layout path is not
+// silently escaping the runtime gate.
+test("resolution check is non-vacuous for LAYOUT tokens (flexStyle gap/padding)", function () {
+  var defined = definedVars(fs.readFileSync(PATHS.tokens.css, "utf8"));
+  var doc = {
+    slug: "synthetic-layout",
+    root: {
+      name: "",
+      kind: "container",
+      layout: {
+        axis: "row",
+        gap: "8px",
+        gapToken: "--zen-spacing-xs", // real, defined in tokens.css
+        padding: { top: "16px", right: "8px", bottom: "16px", left: "8px" },
+        paddingTokens: { left: "--zen-not-a-real-spacing-xyz" }, // unpublished
+        align: { main: "start", cross: "center" },
+      },
+      children: [],
+    },
+  };
+  var html = appearanceRender.renderAppearanceComponent(doc, {});
+  assert.doesNotMatch(html, BARE_VAR); // gap + padding both carry a fallback
+  var refs = [];
+  var m;
+  while ((m = VAR_REF.exec(html))) refs.push(m[1]);
+  VAR_REF.lastIndex = 0;
+  assert.ok(
+    refs.indexOf("--zen-spacing-xs") !== -1,
+    "a published layout token must ride as var(--name, value)",
+  );
+  var unresolved = refs.filter(function (n) {
+    return !defined.has(n);
+  });
+  assert.deepEqual(
+    unresolved,
+    ["--zen-not-a-real-spacing-xyz"],
+    "the gate must flag an unpublished layout token exactly as it does a color one",
+  );
+});

--- a/plugins/actian-design-system/tests/renderers/appearance-render.test.js
+++ b/plugins/actian-design-system/tests/renderers/appearance-render.test.js
@@ -616,3 +616,55 @@ test("renderAppearanceComponent: multi-axis unbound background emits value-only,
   assert.match(html, /background:#dc3514/);
   assert.doesNotMatch(html, /--zen-color-primary-500/);
 });
+
+// ─── P2 layout tokens: gap/padding ride as var(--token, value) ──────────────
+// The knowledge layout capture (its #357) stores layout.gapToken beside
+// layout.gap and layout.paddingTokens per bound side beside layout.padding.
+// flexStyle var-wraps them (value = fallback), value-only otherwise — the same
+// tokenized() the color emit uses, so a bare token name is never emitted.
+test("flexStyle: gap + padding ride their layout tokens as var(--token, value)", function () {
+  var doc = {
+    slug: "card",
+    root: {
+      name: "Card",
+      kind: "container",
+      layout: {
+        axis: "row",
+        gap: "8px",
+        gapToken: "--zen-spacing-xs",
+        padding: { top: "16px", right: "8px", bottom: "16px", left: "8px" },
+        paddingTokens: { right: "--zen-spacing-sm", left: "--zen-spacing-sm" },
+        align: { main: "start", cross: "center" },
+      },
+      children: [],
+    },
+  };
+  var html = r.renderAppearanceComponent(doc, {});
+  assert.match(html, /gap:var\(--zen-spacing-xs, 8px\)/);
+  // per-side var-wrap in the padding shorthand (top/bottom unbound = raw value)
+  assert.match(
+    html,
+    /padding:16px var\(--zen-spacing-sm, 8px\) 16px var\(--zen-spacing-sm, 8px\)/,
+  );
+});
+
+test("flexStyle: no layout tokens -> value-only gap/padding (byte-identical to today)", function () {
+  var doc = {
+    slug: "card",
+    root: {
+      name: "Card",
+      kind: "container",
+      layout: {
+        axis: "column",
+        gap: "4px",
+        padding: { top: "0", right: "0", bottom: "0", left: "0" },
+        align: { main: "start", cross: "start" },
+      },
+      children: [],
+    },
+  };
+  var html = r.renderAppearanceComponent(doc, {});
+  assert.match(html, /gap:4px/);
+  assert.match(html, /padding:0 0 0 0/);
+  assert.doesNotMatch(html, /var\(/);
+});


### PR DESCRIPTION
## What

The **final P2 consumer piece**: layout spacing now themes. When the vendored anatomy carries a `layout.gapToken` / `layout.paddingTokens` (knowledge #357), `flexStyle` emits `gap:var(--zen-spacing-xs, 8px)` and per-side `padding:var(--zen-spacing-sm, 8px) …` instead of the bare value — value = fidelity fallback, name = theming.

Uses the same `tokenized` helper as the color emit (now exported from `appearance-style.js`), so a bare token name is **never** emitted into a CSS value (the invalid-CSS hazard the knowledge side removed — closed on the consumer too).

## Total tolerance / no-op today

No `gapToken`/`paddingTokens` → value-only, **byte-identical** to before. Verified: goldens actually exercise the layout path and stay green; zero `var()` in any golden today. A no-op until the knowledge variable-id export is populated.

## Review

Two adversarial verifiers, both clean (emit correctness on every axis; no-op proven byte-identical). One real coverage gap found + fixed: the runtime gate's non-vacuity proof only covered the color path, so a **layout** non-vacuity test was added (a published spacing token rides as a real `var()` through `flexStyle`; an unpublished one is flagged by the same tokens.css resolution check) — the gate now demonstrably has teeth for layout output. A pre-existing note (layout values aren't `safeValue`-gated like colors) is deferred: not introduced here, unreachable from real numeric geometry.

## Verification

- Full suite **1911 pass / 1** (the pre-existing local-only `vendor-paths-resolve` false positive) + the new layout gate test
- Goldens + real-data green (no-op on token-less data)
- End-to-end: `gap:var(--zen-spacing-xs, 8px)`, per-side `padding` var()s
- TDD red-first

CalVer `2026.7.20 → 2026.7.21`. CHANGELOG updated. Completes the P2 name-layer consumer surface: appearance colors (2026.7.20) + layout spacing now both theme via `var(--token, value)`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)