### PR TITLE
feat(render): make the HTML renderer report its own fidelity, and gate it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,22 @@ are summarized at the release level.
 
 ## [Unreleased]
 
+### Added
+- **The HTML renderer now reports its own fidelity, and a CI gate holds the line.** The DS coverage
+  report gained a **blank-box count** (the empty grey placeholder boxes a generated flow actually shows
+  a reader: **136** today, across 25 of the 37 non-override slugs) and a **renderability verdict** read
+  from the anatomy doc itself. `tests/renderers/blank-box-budget.test.js` ratchets that count downward
+  and fails on a regression.
+
+  This exists because the tier table was measuring the wrong thing. `quality.ratio` is computed upstream
+  as `nodesNormalized / nodesTotal`, which scores whether the **Figma component was drawn with
+  auto-layout**. That is a hygiene score, not a fidelity score, and it is wrong in both directions:
+  `spinner` scores 0.83 and renders as five grey boxes, while `notification-dropdown` scores 0.50 with an
+  empty `degraded[]` list yet has 9 of its 9 instances unresolved. 13 anatomy-tier slugs are not actually
+  renderable. **No render behavior changed:** the report now tells the truth, and the anatomy floor is
+  retired by attrition as real leaves land, rather than by flipping a gate, which would demote 17 slugs to
+  chips before their replacements exist.
+
 ### Fixed
 - **Adapted to the 2026-07 Figma form-control rework** (knowledge sync #378), which is what has kept
   every vendor-refresh PR red since 2026-07-07. The DS renamed the selection axis on the form

--- a/plugins/actian-design-system/.claude-plugin/plugin.json
+++ b/plugins/actian-design-system/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "actian-design-system",
   "description": "Actian Design System toolkit — generate wireframe flows with prototype wiring, create component briefs, audit designs, compare flows, and build presentations. 8 skills (with tiered generation: recognized / adapted / improvised), 9 agents, 155 tokens (3 themes, 8 collections), WCAG 2.2 AA. DS knowledge vendored from volivarii/actian-ds-knowledge.",
-  "version": "2026.7.26",
+  "version": "2026.7.27",
   "author": {
     "name": "Actian UX Team"
   },

--- a/plugins/actian-design-system/scripts/renderers/ds-coverage-report.js
+++ b/plugins/actian-design-system/scripts/renderers/ds-coverage-report.js
@@ -8,10 +8,12 @@ var { loadAnatomy, passesRatioGate } = require(
 var { isRenderable, countBlankBoxes } = require(
   path.join(__dirname, "renderability.js"),
 );
-var dsMap = require(path.join(__dirname, "html-renderers", "ds-html-map.js"));
-var { buildDsAnatomyDocMap } = require(
-  path.join(__dirname, "ds-anatomy-map.js"),
-);
+// ds-html-map.js and ds-anatomy-map.js are required LAZILY inside
+// measureBlankBoxes(), not at module level. coverage() is the light path (it
+// only reads anatomy docs), and render-authoring-table.js imports this module
+// for coverage() alone: hoisting the render stack to load time would make that
+// tool pull in the whole renderer for nothing. The CommonJS module cache makes
+// the in-function require free after the first call.
 
 // Strict mode (no opts): a missing/non-numeric ratio FAILS the gate here,
 // matching passesRatioGate's own strict default; see its doc comment in
@@ -95,6 +97,10 @@ function authorableSlugs() {
 // emits. This is the number a PM actually sees on a generated flow.
 function measureBlankBoxes(opts) {
   opts = opts || {};
+  var dsMap = require(path.join(__dirname, "html-renderers", "ds-html-map.js"));
+  var buildDsAnatomyDocMap = require(
+    path.join(__dirname, "ds-anatomy-map.js"),
+  ).buildDsAnatomyDocMap;
   var slugs = opts.slugs || authorableSlugs();
   var built = {};
   (dsMap.BUILT_SLUGS || []).forEach(function (s) {
@@ -151,7 +157,11 @@ module.exports = {
 };
 
 if (require.main === module) {
-  var BUILT_SLUGS = dsMap.BUILT_SLUGS;
+  // Same lazy require as measureBlankBoxes(): the render stack is only needed
+  // when this file runs as a CLI, never when it is imported for coverage().
+  var BUILT_SLUGS = require(
+    path.join(__dirname, "html-renderers", "ds-html-map.js"),
+  ).BUILT_SLUGS;
 
   var slugs = authorableSlugs();
   var rows = coverage(slugs, { builtSlugs: BUILT_SLUGS });

--- a/plugins/actian-design-system/scripts/renderers/ds-coverage-report.js
+++ b/plugins/actian-design-system/scripts/renderers/ds-coverage-report.js
@@ -4,6 +4,7 @@ var path = require("path");
 var { loadAnatomy, passesRatioGate } = require(
   path.join(__dirname, "anatomy-render.js"),
 );
+var { isRenderable } = require(path.join(__dirname, "renderability.js"));
 
 // Strict mode (no opts): a missing/non-numeric ratio FAILS the gate here,
 // matching passesRatioGate's own strict default; see its doc comment in
@@ -17,15 +18,41 @@ function coverage(slugs, opts) {
     built[s] = true;
   });
   return (slugs || []).map(function (slug) {
-    if (built[slug]) return { slug: slug, tier: "override", ratio: null };
+    // An override does not consult the anatomy doc at all, so a renderability
+    // verdict is meaningless for it: report null, not false.
+    if (built[slug])
+      return {
+        slug: slug,
+        tier: "override",
+        ratio: null,
+        renderable: null,
+        why: "",
+      };
     var spec = loadAnatomy(slug, opts.anatomyLoader);
-    if (!spec || !spec.root) return { slug: slug, tier: "chip", ratio: null };
+    if (!spec || !spec.root)
+      return {
+        slug: slug,
+        tier: "chip",
+        ratio: null,
+        renderable: false,
+        why: "no anatomy doc",
+      };
     var ratio =
       spec.quality && typeof spec.quality.ratio === "number"
         ? spec.quality.ratio
         : null;
+    // tier still reflects what the RENDERER actually does today (the R2 ratio
+    // floor). renderable reflects the TRUTH. Reporting both side by side is
+    // the whole point: where they disagree, the floor is faking it.
     var tier = passesRatioGate(ratio, minRatio) ? "anatomy" : "degraded";
-    return { slug: slug, tier: tier, ratio: ratio };
+    var verdict = isRenderable(spec);
+    return {
+      slug: slug,
+      tier: tier,
+      ratio: ratio,
+      renderable: verdict.ok,
+      why: verdict.why,
+    };
   });
 }
 
@@ -33,9 +60,12 @@ module.exports = { coverage: coverage };
 
 if (require.main === module) {
   var fs = require("fs");
-  var BUILT_SLUGS = require(
-    path.join(__dirname, "html-renderers", "ds-html-map.js"),
-  ).BUILT_SLUGS;
+  var dsMap = require(path.join(__dirname, "html-renderers", "ds-html-map.js"));
+  var BUILT_SLUGS = dsMap.BUILT_SLUGS;
+  var { buildDsAnatomyDocMap } = require(
+    path.join(__dirname, "ds-anatomy-map.js"),
+  );
+  var { countBlankBoxes } = require(path.join(__dirname, "renderability.js"));
 
   // Parse authorable slugs from the markdown table in ds-components-authoring.md
   var mdPath = path.resolve(
@@ -54,6 +84,35 @@ if (require.main === module) {
   });
 
   var rows = coverage(authorableSlugs, { builtSlugs: BUILT_SLUGS });
+
+  // Render every authorable slug through the REAL seam (the same doc map
+  // assemble-flow-share builds) and count the empty grey placeholder boxes it
+  // emits. This is the number a PM actually sees on a generated flow.
+  dsMap.setAnatomyDocMap(buildDsAnatomyDocMap(authorableSlugs, {}));
+  var blanks = {};
+  var blankTotal = 0;
+  rows.forEach(function (r) {
+    if (r.tier === "override") {
+      blanks[r.slug] = 0;
+      return;
+    }
+    var html = "";
+    try {
+      html = String(
+        dsMap.renderDSComponent({
+          dsSlug: r.slug,
+          library: "ds",
+          props: {},
+          variant: "",
+        }),
+      );
+    } catch (e) {
+      html = "";
+    }
+    var n = countBlankBoxes(html);
+    blanks[r.slug] = n;
+    blankTotal += n;
+  });
 
   // Print table
   var col1 = Math.max(
@@ -77,13 +136,46 @@ if (require.main === module) {
     );
   }
 
-  console.log(pad("slug", col1) + "  " + pad("tier", col2) + "  " + "ratio");
   console.log(
-    "-".repeat(col1) + "  " + "-".repeat(col2) + "  " + "-".repeat(6),
+    pad("slug", col1) +
+      "  " +
+      pad("tier", col2) +
+      "  " +
+      pad("ratio", 6) +
+      "  " +
+      pad("renders?", 9) +
+      "  " +
+      pad("blanks", 6) +
+      "  why",
+  );
+  console.log(
+    "-".repeat(col1) +
+      "  " +
+      "-".repeat(col2) +
+      "  " +
+      "-".repeat(6) +
+      "  " +
+      "-".repeat(9) +
+      "  " +
+      "-".repeat(6) +
+      "  ---",
   );
   rows.forEach(function (r) {
     var ratioStr = r.ratio != null ? r.ratio.toFixed(2) : "—";
-    console.log(pad(r.slug, col1) + "  " + pad(r.tier, col2) + "  " + ratioStr);
+    var rend = r.renderable == null ? "—" : r.renderable ? "yes" : "NO";
+    console.log(
+      pad(r.slug, col1) +
+        "  " +
+        pad(r.tier, col2) +
+        "  " +
+        pad(ratioStr, 6) +
+        "  " +
+        pad(rend, 9) +
+        "  " +
+        pad(String(blanks[r.slug] || 0), 6) +
+        "  " +
+        (r.why || ""),
+    );
   });
 
   // Counts summary
@@ -97,6 +189,21 @@ if (require.main === module) {
   console.log("degraded: " + counts.degraded);
   console.log("chip:     " + counts.chip);
   console.log("total:    " + rows.length);
+
+  var fakingIt = rows.filter(function (r) {
+    return r.tier === "anatomy" && r.renderable === false;
+  }).length;
+  console.log("\n--- Fidelity ---");
+  console.log("BLANK BOXES (total):      " + blankTotal);
+  console.log(
+    "slugs emitting blanks:    " +
+      rows.filter(function (r) {
+        return (blanks[r.slug] || 0) > 0;
+      }).length,
+  );
+  console.log(
+    "anatomy-tier but NOT renderable (the floor is faking these): " + fakingIt,
+  );
 
   process.exit(0);
 }

--- a/plugins/actian-design-system/scripts/renderers/ds-coverage-report.js
+++ b/plugins/actian-design-system/scripts/renderers/ds-coverage-report.js
@@ -1,10 +1,17 @@
 #!/usr/bin/env node
 "use strict";
+var fs = require("fs");
 var path = require("path");
 var { loadAnatomy, passesRatioGate } = require(
   path.join(__dirname, "anatomy-render.js"),
 );
-var { isRenderable } = require(path.join(__dirname, "renderability.js"));
+var { isRenderable, countBlankBoxes } = require(
+  path.join(__dirname, "renderability.js"),
+);
+var dsMap = require(path.join(__dirname, "html-renderers", "ds-html-map.js"));
+var { buildDsAnatomyDocMap } = require(
+  path.join(__dirname, "ds-anatomy-map.js"),
+);
 
 // Strict mode (no opts): a missing/non-numeric ratio FAILS the gate here,
 // matching passesRatioGate's own strict default; see its doc comment in
@@ -56,18 +63,11 @@ function coverage(slugs, opts) {
   });
 }
 
-module.exports = { coverage: coverage };
-
-if (require.main === module) {
-  var fs = require("fs");
-  var dsMap = require(path.join(__dirname, "html-renderers", "ds-html-map.js"));
-  var BUILT_SLUGS = dsMap.BUILT_SLUGS;
-  var { buildDsAnatomyDocMap } = require(
-    path.join(__dirname, "ds-anatomy-map.js"),
-  );
-  var { countBlankBoxes } = require(path.join(__dirname, "renderability.js"));
-
-  // Parse authorable slugs from the markdown table in ds-components-authoring.md
+// Parse authorable slugs from the markdown table in ds-components-authoring.md.
+// This is the SINGLE parse of that table. Both the CLI report below and the CI
+// budget gate (tests/renderers/blank-box-budget.test.js) call this function,
+// so the two can never silently disagree on which slugs count as authorable.
+function authorableSlugs() {
   var mdPath = path.resolve(
     __dirname,
     "..",
@@ -77,42 +77,87 @@ if (require.main === module) {
     "ds-components-authoring.md",
   );
   var mdContent = fs.readFileSync(mdPath, "utf8");
-  var authorableSlugs = [];
+  var slugs = [];
   mdContent.split("\n").forEach(function (line) {
     var m = line.match(/^\|\s*`([^`]+)`/);
-    if (m) authorableSlugs.push(m[1]);
+    if (m) slugs.push(m[1]);
+  });
+  return slugs;
+}
+
+// Exported so the CI gate (tests/renderers/blank-box-budget.test.js) measures
+// the SAME thing this report prints, by construction rather than by
+// coincidence. Two independent measurers would be free to drift, and the gate
+// would then guard a number nobody is looking at.
+//
+// Renders every authorable slug through the REAL seam (the same doc map
+// assemble-flow-share builds) and counts the empty grey placeholder boxes it
+// emits. This is the number a PM actually sees on a generated flow.
+function measureBlankBoxes(opts) {
+  opts = opts || {};
+  var slugs = opts.slugs || authorableSlugs();
+  var built = {};
+  (dsMap.BUILT_SLUGS || []).forEach(function (s) {
+    built[s] = true;
   });
 
-  var rows = coverage(authorableSlugs, { builtSlugs: BUILT_SLUGS });
+  var total = 0;
+  var perSlug = {};
+  var anyAnatomy = false;
+  var chipSlugs = [];
 
-  // Render every authorable slug through the REAL seam (the same doc map
-  // assemble-flow-share builds) and count the empty grey placeholder boxes it
-  // emits. This is the number a PM actually sees on a generated flow.
-  dsMap.setAnatomyDocMap(buildDsAnatomyDocMap(authorableSlugs, {}));
-  var blanks = {};
-  var blankTotal = 0;
-  rows.forEach(function (r) {
-    if (r.tier === "override") {
-      blanks[r.slug] = 0;
-      return;
-    }
-    var html = "";
-    try {
-      html = String(
-        dsMap.renderDSComponent({
-          dsSlug: r.slug,
-          library: "ds",
-          props: {},
-          variant: "",
-        }),
-      );
-    } catch (e) {
-      html = "";
-    }
-    var n = countBlankBoxes(html);
-    blanks[r.slug] = n;
-    blankTotal += n;
-  });
+  dsMap.setAnatomyDocMap(buildDsAnatomyDocMap(slugs, {}));
+  try {
+    slugs.forEach(function (slug) {
+      if (built[slug]) return;
+      var html = "";
+      try {
+        html = String(
+          dsMap.renderDSComponent({
+            dsSlug: slug,
+            library: "ds",
+            props: {},
+            variant: "",
+          }),
+        );
+      } catch (e) {
+        html = "";
+      }
+      if (html.indexOf('data-ds-slug="') !== -1) anyAnatomy = true;
+      if (html.indexOf('class="ds-component"') !== -1) chipSlugs.push(slug);
+      var n = countBlankBoxes(html);
+      perSlug[slug] = n;
+      total += n;
+    });
+  } finally {
+    // Reset module-level state so it never leaks into a later assembly, same
+    // convention as assemble-flow-share.js's render loop.
+    dsMap.setAnatomyDocMap(null);
+  }
+
+  return {
+    slugs: slugs,
+    total: total,
+    perSlug: perSlug,
+    chipSlugs: chipSlugs,
+    anyAnatomy: anyAnatomy,
+  };
+}
+
+module.exports = {
+  coverage: coverage,
+  authorableSlugs: authorableSlugs,
+  measureBlankBoxes: measureBlankBoxes,
+};
+
+if (require.main === module) {
+  var BUILT_SLUGS = dsMap.BUILT_SLUGS;
+
+  var slugs = authorableSlugs();
+  var rows = coverage(slugs, { builtSlugs: BUILT_SLUGS });
+  var measured = measureBlankBoxes({ slugs: slugs });
+  var blanks = measured.perSlug;
+  var blankTotal = measured.total;
 
   // Print table
   var col1 = Math.max(
@@ -127,7 +172,6 @@ if (require.main === module) {
       : "slug".length,
   );
   var col2 = 8; // "degraded".length
-  var col3 = 5; // "ratio".length
 
   function pad(s, n) {
     return (
@@ -204,6 +248,4 @@ if (require.main === module) {
   console.log(
     "anatomy-tier but NOT renderable (the floor is faking these): " + fakingIt,
   );
-
-  process.exit(0);
 }

--- a/plugins/actian-design-system/scripts/renderers/renderability.js
+++ b/plugins/actian-design-system/scripts/renderers/renderability.js
@@ -102,13 +102,23 @@
 
   // A BLANK BOX is an EMPTY placeholder div. ds-base.css paints these with
   // min-width/min-height var(--zen-size-md) and a neutral background so media
-  // leaves do not collapse to 0x0 — which is precisely what makes them read as
+  // leaves do not collapse to 0x0, which is precisely what makes them read as
   // grey boxes on screen. This is the metric a PM actually sees.
   //
   // Deliberately requires the element to be EMPTY (`></div>` immediately after
   // the open tag): a placeholder that got real content is not a blank box.
+  //
+  // "image" is intentionally absent: the anatomy classifier emits "icon" (and
+  // "vector"), never "image" (see appearance-render.js's C2 comment), so it
+  // never matched here. Kept out rather than kept as dead weight.
+  //
+  // /g means this regex carries mutable lastIndex state. Safe only because
+  // every caller uses String.prototype.match(), which resets lastIndex on
+  // each call. If a future caller reaches for .test() or .exec() instead,
+  // that call needs its own regex instance (or lastIndex reset first), or it
+  // will silently miss matches on the second and later calls.
   var BLANK_BOX =
-    /<div class="ds-appearance__(?:vector|image|icon|instance)"[^>]*><\/div>/g;
+    /<div class="ds-appearance__(?:vector|icon|instance)"[^>]*><\/div>/g;
 
   function countBlankBoxes(html) {
     if (typeof html !== "string" || !html) return 0;

--- a/plugins/actian-design-system/scripts/renderers/renderability.js
+++ b/plugins/actian-design-system/scripts/renderers/renderability.js
@@ -1,0 +1,126 @@
+#!/usr/bin/env node
+"use strict";
+
+/**
+ * renderability.js — REPORT-ONLY predicates describing what an anatomy doc can
+ * actually render, and how much of a render is blank placeholder boxes.
+ *
+ * Why this exists: `quality.ratio` (nodesNormalized/nodesTotal) is computed
+ * UPSTREAM and measures whether the Figma component was drawn with auto-layout
+ * and solid fills. It is a Figma HYGIENE score, not a renderability score, and
+ * it is wrong in BOTH directions: `spinner` scores 0.83 and renders as five
+ * grey boxes; `notification-dropdown` scores 0.50 with an EMPTY degraded[]
+ * list yet every one of its instances is unresolved. These predicates read the
+ * doc itself instead.
+ *
+ * NOTHING here gates the render path. The anatomy floor is retired by
+ * ATTRITION (each slug earns a real leaf), not by flipping a gate: flipping it
+ * before the leaves exist would demote 17 slugs to chips and make the
+ * deliverable worse. This module exists so the coverage report can tell the
+ * truth while that work lands.
+ *
+ * Pure: no fs, no side effects at load, never throws on a malformed doc.
+ */
+(function (exports) {
+  "use strict";
+
+  function isNonEmptyObject(o) {
+    return !!o && typeof o === "object" && Object.keys(o).length > 0;
+  }
+
+  // Walk an anatomy doc's node tree and report what it actually carries.
+  function docStats(doc) {
+    var s = {
+      nodes: 0,
+      rootHasLayout: false,
+      nonRoot: 0,
+      placeable: 0,
+      instances: 0,
+      unresolved: 0,
+    };
+    if (!doc || !doc.root || typeof doc.root !== "object") return s;
+    s.rootHasLayout = isNonEmptyObject(doc.root.layout);
+
+    function walk(n, isRoot) {
+      if (!n || typeof n !== "object") return;
+      s.nodes++;
+      if (!isRoot) {
+        s.nonRoot++;
+        // "placeable" = carries something to place (layout) or something to
+        // paint (appearance). A node with neither emits a bare <div>: no box
+        // model, no color, an invisible nothing.
+        if (isNonEmptyObject(n.layout) || isNonEmptyObject(n.appearance)) {
+          s.placeable++;
+        }
+      }
+      if (n.kind === "instance") {
+        s.instances++;
+        if (n.unresolved) s.unresolved++;
+      }
+      var kids = Array.isArray(n.children) ? n.children : [];
+      for (var i = 0; i < kids.length; i++) walk(kids[i], false);
+    }
+    walk(doc.root, true);
+    return s;
+  }
+
+  // Can this doc render a credible component, or is the anatomy floor faking
+  // it? Thresholds CALIBRATED against vendored knowledge v0.34.96: over the 37
+  // non-override authorable slugs this admits 20 and rejects 17.
+  function isRenderable(doc) {
+    if (!doc || !doc.root || typeof doc.root !== "object") {
+      return { ok: false, why: "no anatomy doc" };
+    }
+    var s = docStats(doc);
+
+    // 1. No root layout => no box model. Children stack; nothing is sized or
+    //    padded. This is why spinner/avatar/loading-skeleton/scroll-bar render
+    //    as unsized blobs despite passing the upstream ratio gate.
+    if (!s.rootHasLayout) return { ok: false, why: "root has no layout" };
+
+    // 2. Under half the non-root nodes carry layout OR appearance => the tree
+    //    is mostly invisible nothings.
+    if (s.nonRoot > 0 && s.placeable / s.nonRoot < 0.5) {
+      return {
+        ok: false,
+        why: "only " + s.placeable + "/" + s.nonRoot + " nodes placeable",
+      };
+    }
+
+    // 3. Half or more instances unresolved => the render is mostly blank
+    //    boxes. notification-dropdown is 9/9: a well-styled container full of
+    //    nine empty menu items.
+    if (s.instances > 0 && s.unresolved / s.instances >= 0.5) {
+      return {
+        ok: false,
+        why: s.unresolved + "/" + s.instances + " instances unresolved",
+      };
+    }
+
+    return { ok: true, why: "" };
+  }
+
+  // A BLANK BOX is an EMPTY placeholder div. ds-base.css paints these with
+  // min-width/min-height var(--zen-size-md) and a neutral background so media
+  // leaves do not collapse to 0x0 — which is precisely what makes them read as
+  // grey boxes on screen. This is the metric a PM actually sees.
+  //
+  // Deliberately requires the element to be EMPTY (`></div>` immediately after
+  // the open tag): a placeholder that got real content is not a blank box.
+  var BLANK_BOX =
+    /<div class="ds-appearance__(?:vector|image|icon|instance)"[^>]*><\/div>/g;
+
+  function countBlankBoxes(html) {
+    if (typeof html !== "string" || !html) return 0;
+    var m = html.match(BLANK_BOX);
+    return m ? m.length : 0;
+  }
+
+  exports.docStats = docStats;
+  exports.isRenderable = isRenderable;
+  exports.countBlankBoxes = countBlankBoxes;
+})(
+  typeof module !== "undefined"
+    ? module.exports
+    : (window.renderability = window.renderability || {}),
+);

--- a/plugins/actian-design-system/tests/renderers/blank-box-budget.test.js
+++ b/plugins/actian-design-system/tests/renderers/blank-box-budget.test.js
@@ -46,6 +46,18 @@ var { countBlankBoxes } = require(
 // message, which slugs regressed and why.
 var BUDGET = 136;
 
+// The number of authorable slugs that render a bare graceful-degradation chip
+// (ds-html-map.js's gracefulChip(), a `<span class="ds-component" ...>` with
+// no real anatomy). This is a SEPARATE ceiling from BUDGET, and it exists to
+// close a loophole: if the anatomy doc map partially collapses, slugs that
+// used to render real markup (and blank boxes) demote to chips instead. That
+// makes BUDGET look like it improved while the actual output got worse. This
+// ceiling also RATCHETS DOWN, never up, as slugs get real anatomy authored.
+//
+//   2026-07-13  4  baseline (glossary-item-hierarchy-diagram, lineage-connecting-line,
+//                  notification-dropdown, scroll-bar)
+var CHIP_BUDGET = 4;
+
 function authorableSlugs() {
   var mdPath = path.resolve(
     __dirname,
@@ -75,6 +87,7 @@ function renderAll() {
   var total = 0;
   var perSlug = {};
   var anyAnatomy = false;
+  var chipSlugs = [];
   slugs.forEach(function (slug) {
     if (built[slug]) return;
     var html = "";
@@ -91,6 +104,7 @@ function renderAll() {
       html = "";
     }
     if (html.indexOf('data-ds-slug="') !== -1) anyAnatomy = true;
+    if (html.indexOf('class="ds-component"') !== -1) chipSlugs.push(slug);
     var n = countBlankBoxes(html);
     perSlug[slug] = n;
     total += n;
@@ -100,6 +114,7 @@ function renderAll() {
     perSlug: perSlug,
     anyAnatomy: anyAnatomy,
     slugs: slugs,
+    chipSlugs: chipSlugs,
   };
 }
 
@@ -148,6 +163,40 @@ describe("blank-box budget", function () {
         "). " +
         "Worst offenders: " +
         worst,
+    );
+  });
+
+  it("SANITY: the blank-box detector is not silently reading zero", function () {
+    // We know today's total is 136, not 0. If countBlankBoxes ever drifts out
+    // of sync with the markup shape it's matching against, it can silently
+    // return 0 for everything, and the budget assertion above passes
+    // vacuously (0 <= BUDGET is always true). This control forces a failure
+    // in that case instead of a false green.
+    //
+    // Self-retiring: when the blank-box count legitimately reaches 0, the
+    // fidelity job is done. At that point delete this control AND the
+    // BUDGET assertion above deliberately, rather than letting either rot.
+    var r = renderAll();
+    assert.ok(
+      r.total > 0,
+      "expected a positive blank-box count (today's baseline is 136), got 0. " +
+        "This likely means countBlankBoxes stopped matching the emitted markup " +
+        "shape and is silently reading zero, not that the renderer got fixed.",
+    );
+  });
+
+  it("emits no more bare graceful-degradation chips than the chip budget", function () {
+    var r = renderAll();
+    assert.ok(
+      r.chipSlugs.length <= CHIP_BUDGET,
+      "bare-chip count regressed to " +
+        r.chipSlugs.length +
+        " (budget " +
+        CHIP_BUDGET +
+        "). A bare chip means the slug renders nothing real, so a lower " +
+        "blank-box total from this slug is a demotion, not an improvement. " +
+        "Chip slugs: " +
+        r.chipSlugs.join(", "),
     );
   });
 });

--- a/plugins/actian-design-system/tests/renderers/blank-box-budget.test.js
+++ b/plugins/actian-design-system/tests/renderers/blank-box-budget.test.js
@@ -3,37 +3,15 @@
 var { describe, it } = require("node:test");
 var assert = require("node:assert");
 var path = require("path");
-var fs = require("fs");
 
-var dsMap = require(
+var { measureBlankBoxes } = require(
   path.resolve(
     __dirname,
     "..",
     "..",
     "scripts",
     "renderers",
-    "html-renderers",
-    "ds-html-map.js",
-  ),
-);
-var { buildDsAnatomyDocMap } = require(
-  path.resolve(
-    __dirname,
-    "..",
-    "..",
-    "scripts",
-    "renderers",
-    "ds-anatomy-map.js",
-  ),
-);
-var { countBlankBoxes } = require(
-  path.resolve(
-    __dirname,
-    "..",
-    "..",
-    "scripts",
-    "renderers",
-    "renderability.js",
+    "ds-coverage-report.js",
   ),
 );
 
@@ -58,64 +36,14 @@ var BUDGET = 136;
 //                  notification-dropdown, scroll-bar)
 var CHIP_BUDGET = 4;
 
-function authorableSlugs() {
-  var mdPath = path.resolve(
-    __dirname,
-    "..",
-    "..",
-    "references",
-    "generate-flow",
-    "ds-components-authoring.md",
-  );
-  var out = [];
-  fs.readFileSync(mdPath, "utf8")
-    .split("\n")
-    .forEach(function (line) {
-      var m = line.match(/^\|\s*`([^`]+)`/);
-      if (m) out.push(m[1]);
-    });
-  return out;
-}
-
+// measureBlankBoxes() re-parses the authoring markdown, rebuilds the doc map
+// over ~72 slugs, and re-renders 37 components: expensive to repeat, and
+// every assertion below wants the identical measurement anyway. Compute once
+// and share it instead of calling it fresh from each `it` block.
+var cached = null;
 function renderAll() {
-  var slugs = authorableSlugs();
-  dsMap.setAnatomyDocMap(buildDsAnatomyDocMap(slugs, {}));
-  var built = {};
-  dsMap.BUILT_SLUGS.forEach(function (s) {
-    built[s] = true;
-  });
-  var total = 0;
-  var perSlug = {};
-  var anyAnatomy = false;
-  var chipSlugs = [];
-  slugs.forEach(function (slug) {
-    if (built[slug]) return;
-    var html = "";
-    try {
-      html = String(
-        dsMap.renderDSComponent({
-          dsSlug: slug,
-          library: "ds",
-          props: {},
-          variant: "",
-        }),
-      );
-    } catch (e) {
-      html = "";
-    }
-    if (html.indexOf('data-ds-slug="') !== -1) anyAnatomy = true;
-    if (html.indexOf('class="ds-component"') !== -1) chipSlugs.push(slug);
-    var n = countBlankBoxes(html);
-    perSlug[slug] = n;
-    total += n;
-  });
-  return {
-    total: total,
-    perSlug: perSlug,
-    anyAnatomy: anyAnatomy,
-    slugs: slugs,
-    chipSlugs: chipSlugs,
-  };
+  if (!cached) cached = measureBlankBoxes();
+  return cached;
 }
 
 describe("blank-box budget", function () {

--- a/plugins/actian-design-system/tests/renderers/blank-box-budget.test.js
+++ b/plugins/actian-design-system/tests/renderers/blank-box-budget.test.js
@@ -1,0 +1,153 @@
+#!/usr/bin/env node
+"use strict";
+var { describe, it } = require("node:test");
+var assert = require("node:assert");
+var path = require("path");
+var fs = require("fs");
+
+var dsMap = require(
+  path.resolve(
+    __dirname,
+    "..",
+    "..",
+    "scripts",
+    "renderers",
+    "html-renderers",
+    "ds-html-map.js",
+  ),
+);
+var { buildDsAnatomyDocMap } = require(
+  path.resolve(
+    __dirname,
+    "..",
+    "..",
+    "scripts",
+    "renderers",
+    "ds-anatomy-map.js",
+  ),
+);
+var { countBlankBoxes } = require(
+  path.resolve(
+    __dirname,
+    "..",
+    "..",
+    "scripts",
+    "renderers",
+    "renderability.js",
+  ),
+);
+
+// The number of empty grey placeholder boxes the DS HTML renderer emits across
+// the whole authorable vocabulary. This is a CEILING, and it RATCHETS DOWN:
+//
+//   2026-07-13  136  baseline (knowledge v0.34.96, 25 of 37 non-override slugs)
+//
+// Lower it as each lane lands. NEVER raise it without saying, in the commit
+// message, which slugs regressed and why.
+var BUDGET = 136;
+
+function authorableSlugs() {
+  var mdPath = path.resolve(
+    __dirname,
+    "..",
+    "..",
+    "references",
+    "generate-flow",
+    "ds-components-authoring.md",
+  );
+  var out = [];
+  fs.readFileSync(mdPath, "utf8")
+    .split("\n")
+    .forEach(function (line) {
+      var m = line.match(/^\|\s*`([^`]+)`/);
+      if (m) out.push(m[1]);
+    });
+  return out;
+}
+
+function renderAll() {
+  var slugs = authorableSlugs();
+  dsMap.setAnatomyDocMap(buildDsAnatomyDocMap(slugs, {}));
+  var built = {};
+  dsMap.BUILT_SLUGS.forEach(function (s) {
+    built[s] = true;
+  });
+  var total = 0;
+  var perSlug = {};
+  var anyAnatomy = false;
+  slugs.forEach(function (slug) {
+    if (built[slug]) return;
+    var html = "";
+    try {
+      html = String(
+        dsMap.renderDSComponent({
+          dsSlug: slug,
+          library: "ds",
+          props: {},
+          variant: "",
+        }),
+      );
+    } catch (e) {
+      html = "";
+    }
+    if (html.indexOf('data-ds-slug="') !== -1) anyAnatomy = true;
+    var n = countBlankBoxes(html);
+    perSlug[slug] = n;
+    total += n;
+  });
+  return {
+    total: total,
+    perSlug: perSlug,
+    anyAnatomy: anyAnatomy,
+    slugs: slugs,
+  };
+}
+
+describe("blank-box budget", function () {
+  it("POSITIVE CONTROL: the anatomy doc map is actually live", function () {
+    // Without this, a broken/unset doc map chips every slug, emits zero blank
+    // boxes, and the budget below passes while measuring NOTHING. Assert the
+    // anatomy marker attribute (data-ds-slug=) is present in real output.
+    var r = renderAll();
+    assert.ok(
+      r.anyAnatomy,
+      "no slug rendered anatomy markup, so the doc map is not live and the " +
+        "blank-box budget would pass vacuously",
+    );
+  });
+
+  it("the authorable vocabulary is non-empty (guards a silent parse break)", function () {
+    var r = renderAll();
+    assert.ok(
+      r.slugs.length > 50,
+      "expected the ds-components-authoring.md table to parse to >50 slugs, got " +
+        r.slugs.length,
+    );
+  });
+
+  it("emits no more blank grey boxes than the budget", function () {
+    var r = renderAll();
+    var worst = Object.keys(r.perSlug)
+      .filter(function (s) {
+        return r.perSlug[s] > 0;
+      })
+      .sort(function (a, b) {
+        return r.perSlug[b] - r.perSlug[a];
+      })
+      .slice(0, 8)
+      .map(function (s) {
+        return s + ":" + r.perSlug[s];
+      })
+      .join(", ");
+    assert.ok(
+      r.total <= BUDGET,
+      "blank-box count regressed to " +
+        r.total +
+        " (budget " +
+        BUDGET +
+        "). " +
+        "Worst offenders: " +
+        worst,
+    );
+  });
+});

--- a/plugins/actian-design-system/tests/renderers/ds-coverage-report.test.js
+++ b/plugins/actian-design-system/tests/renderers/ds-coverage-report.test.js
@@ -60,3 +60,40 @@ describe("ds-coverage-report", function () {
     assert.strictEqual(rows[0].ratio, 0.4);
   });
 });
+
+describe("coverage(): renderability columns", function () {
+  var path = require("path");
+  var { coverage } = require(
+    path.resolve(
+      __dirname,
+      "..",
+      "..",
+      "scripts",
+      "renderers",
+      "ds-coverage-report.js",
+    ),
+  );
+
+  it("marks an override row renderable:null (an override ignores the doc)", function () {
+    var rows = coverage(["button"], { builtSlugs: ["button"] });
+    assert.strictEqual(rows[0].tier, "override");
+    assert.strictEqual(rows[0].renderable, null);
+  });
+
+  it("reports renderable:false with a reason where the floor is faking it", function () {
+    var rows = coverage(["spinner"], { builtSlugs: [] });
+    assert.strictEqual(rows[0].renderable, false);
+    assert.match(rows[0].why, /root has no layout/);
+  });
+
+  it("keeps the ratio column so the two signals can be compared", function () {
+    var rows = coverage(["spinner"], { builtSlugs: [] });
+    assert.ok(rows[0].ratio >= 0.6, "spinner still passes the old ratio gate");
+    assert.strictEqual(rows[0].renderable, false, "but is not renderable");
+  });
+
+  it("reports renderable:true for a doc with real layout and resolvable children", function () {
+    var rows = coverage(["collapse-accordion"], { builtSlugs: [] });
+    assert.strictEqual(rows[0].renderable, true);
+  });
+});

--- a/plugins/actian-design-system/tests/renderers/renderability.test.js
+++ b/plugins/actian-design-system/tests/renderers/renderability.test.js
@@ -1,0 +1,114 @@
+#!/usr/bin/env node
+"use strict";
+var { describe, it } = require("node:test");
+var assert = require("node:assert");
+var path = require("path");
+
+var R = require(
+  path.resolve(__dirname, "..", "..", "scripts", "renderers", "renderability.js"),
+);
+var { loadAnatomy } = require(
+  path.resolve(__dirname, "..", "..", "scripts", "renderers", "anatomy-render.js"),
+);
+
+describe("renderability.docStats", function () {
+  it("returns a zeroed shape for a missing or malformed doc", function () {
+    var s = R.docStats(null);
+    assert.strictEqual(s.nodes, 0);
+    assert.strictEqual(s.rootHasLayout, false);
+    assert.strictEqual(s.instances, 0);
+  });
+
+  it("counts nodes, instances and unresolved instances on a real doc", function () {
+    // notification-dropdown is the canonical case: every one of its instances
+    // is unresolved, so it renders a styled container full of blank items.
+    var doc = loadAnatomy("notification-dropdown");
+    assert.ok(doc, "fixture: notification-dropdown anatomy must exist");
+    var s = R.docStats(doc);
+    assert.ok(s.nodes > 1, "should walk the whole tree");
+    assert.ok(s.instances > 0, "notification-dropdown has instance nodes");
+    assert.strictEqual(
+      s.unresolved,
+      s.instances,
+      "every notification-dropdown instance is unresolved",
+    );
+  });
+
+  it("does not count the root as a non-root node", function () {
+    var doc = loadAnatomy("notification-dropdown");
+    var s = R.docStats(doc);
+    assert.strictEqual(s.nonRoot, s.nodes - 1);
+  });
+});
+
+describe("renderability.isRenderable", function () {
+  it("rejects a doc whose root carries no layout (no box model)", function () {
+    // spinner scores 0.83 on the upstream ratio yet renders as five grey
+    // boxes: its root has no layout at all.
+    var doc = loadAnatomy("spinner");
+    assert.ok(doc, "fixture: spinner anatomy must exist");
+    var v = R.isRenderable(doc);
+    assert.strictEqual(v.ok, false);
+    assert.match(v.why, /root has no layout/);
+  });
+
+  it("rejects a doc whose instances are mostly unresolved", function () {
+    var doc = loadAnatomy("notification-dropdown");
+    var v = R.isRenderable(doc);
+    assert.strictEqual(v.ok, false);
+    assert.match(v.why, /instances unresolved/);
+  });
+
+  it("admits a doc that carries real layout, paint and resolvable children", function () {
+    var doc = loadAnatomy("collapse-accordion");
+    assert.ok(doc, "fixture: collapse-accordion anatomy must exist");
+    var v = R.isRenderable(doc);
+    assert.strictEqual(v.ok, true, "collapse-accordion should be renderable");
+    assert.strictEqual(v.why, "");
+  });
+
+  it("rejects a missing doc without throwing", function () {
+    assert.strictEqual(R.isRenderable(null).ok, false);
+    assert.strictEqual(R.isRenderable({}).ok, false);
+  });
+
+  it("does NOT simply mirror the upstream quality.ratio", function () {
+    // The whole point: the ratio is a Figma auto-layout hygiene score, not a
+    // renderability score. spinner proves they disagree.
+    var doc = loadAnatomy("spinner");
+    assert.ok(doc.quality.ratio >= 0.6, "spinner passes the old ratio gate");
+    assert.strictEqual(
+      R.isRenderable(doc).ok,
+      false,
+      "yet it is not renderable",
+    );
+  });
+});
+
+describe("renderability.countBlankBoxes", function () {
+  it("counts empty placeholder divs", function () {
+    var html =
+      '<div class="ds-appearance"><div class="ds-appearance__instance"></div>' +
+      '<div class="ds-appearance__vector" style="background:#eee" aria-hidden="true"></div>' +
+      "</div>";
+    assert.strictEqual(R.countBlankBoxes(html), 2);
+  });
+
+  it("does NOT count a placeholder that has content", function () {
+    var html = '<div class="ds-appearance__instance">Notification</div>';
+    assert.strictEqual(R.countBlankBoxes(html), 0);
+  });
+
+  it("does not count ordinary containers or text", function () {
+    var html =
+      '<div class="ds-appearance__container"></div>' +
+      '<span class="ds-appearance__text">hi</span>';
+    assert.strictEqual(R.countBlankBoxes(html), 0);
+  });
+
+  it("returns 0 for empty or non-string input", function () {
+    assert.strictEqual(R.countBlankBoxes(""), 0);
+    assert.strictEqual(R.countBlankBoxes(null), 0);
+    assert.strictEqual(R.countBlankBoxes(undefined), 0);
+  });
+});


### PR DESCRIPTION
## The renderer was grading itself with the wrong number

The DS HTML output is a first-class deliverable: PMs and other non-designers have no Figma seat, so for most of the plugin's audience **the HTML is the product**. But the coverage report graded its own fidelity with `quality.ratio`, which is computed upstream as `nodesNormalized / nodesTotal`. That measures whether the **Figma component was drawn with auto-layout**. It is a hygiene score, not a fidelity score, and it is wrong in both directions:

- `spinner` scores **0.83**, passes the gate, and renders as **five stacked grey boxes** (its root carries no layout, so it has no box model).
- `notification-dropdown` scores **0.50** and is rejected, yet its `degraded[]` list is **empty**. It has 9 of 9 instances unresolved, so it renders a well-styled container full of nine blank menu items.

**13 of the 33 "anatomy" slugs are not actually renderable.** The floor is faking them, and the report was reporting success.

## What this PR does

Measurement only. **Zero render change**: no golden moved, and `ds-html-map.js`, `ds-anatomy-map.js`, `appearance-render.js` and `ds-base.css` are untouched.

- **`renderability.js`** (new, pure): predicates read from the anatomy doc itself instead of the upstream hygiene score.
- **The coverage report** now prints the number a reader actually sees: **136 blank grey boxes** across 25 of the 37 non-override slugs, a renderability verdict alongside the old ratio, and the count of slugs the floor is faking.
- **`blank-box-budget.test.js`**: a CI gate.

## Two ceilings, not one

The gate holds **`BUDGET = 136`** (blank boxes) *and* **`CHIP_BUDGET = 4`** (bare graceful-degradation chips). Both ratchet **down**.

The second one exists because a blank-box ceiling alone **defends only one direction**. Collapse the anatomy doc map and blank boxes fall toward zero, so the gate would report a triumph *during a real regression*, because slugs silently demote to chips. Together, the two ceilings close that loophole: you can no longer lower one by quietly sacrificing the other.

There is also a self-retiring control asserting the total is `> 0`, so a drifted regex cannot silently read zero and pass vacuously, and a positive control asserting the anatomy doc map is live (without it, every slug chips, zero blanks are emitted, and the budget would pass while measuring nothing).

## Why the gate does not flip today

Switching the **render** gate to the honest predicate would demote **17** slugs to chips before their replacement leaves exist, making the deliverable worse. So the anatomy floor is retired by **attrition**: as real component leaves land, slugs leave the floor, and both ceilings ratchet down. When all 37 have a leaf, nothing authorable reaches the floor and the gate is moot.

This is Plan 1 of a series. Next: 8 picture slugs exported as SVG (reusing the icon pipeline), 6 tag siblings folded into the tag leaf, and 23 hand-authored components.

## Review notes

A full high-effort review raised 8 findings; all 8 are fixed in this branch. The headline one was thematically damning for a PR about honest measurement: **the blank-box metric was implemented twice** (once in the report, once in the gate), agreeing on 136 only by coincidence of identical logic. They now share one exported `measureBlankBoxes()`, so they agree **by construction**. Also fixed: `process.exit(0)` could truncate the trailing Fidelity block when piped, and the doc map was set without the `finally` reset that `assemble-flow-share.js` establishes as the convention.

Both gates were proven to fail before being trusted (`BUDGET = 10` and `CHIP_BUDGET = 0` each fail, naming the offending slugs).

Full suite **1933/1933**. Plugin `2026.7.27`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
