### PR TITLE
feat(render): generalize capture-seed from Button to the 35-slug render set (North Star Step A)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,14 @@ are summarized at the release level.
 ## [Unreleased]
 
 ### Added
+- **Generalized the canonical-render capture from Button to the full 35-slug render set.**
+  `plugins/actian-design-system/scripts/render/capture-seed.js` gained `captureMatrix(slug)`, a
+  registry-driven generalization of the Button-only capture: it builds each slug's variant matrix from
+  the registry (via `variantMatrix`, from the slice-1 bootstrap) instead of a hand-picked list, and
+  derives its `@dsCard` group from the component's own registry category. `captureButtonMatrix()` is now
+  `captureMatrix("button")`. A new `RENDER_SLUGS` constant enumerates the 35 slugs the HTML renderer
+  supports, and a `--all <destDir>` CLI mode captures every one of them into a destination directory in
+  one pass (skipping and reporting any slug that throws), replacing the single-slug-only bootstrap CLI.
 - **Seeded the canonical component render for the knowledge substrate (North Star slice 1).** ([#250](https://github.com/volivarii/Actian-DS-Claude-plugin/pull/250)) A new
   one-time bootstrap, `plugins/actian-design-system/scripts/render/capture-seed.js`, captures the
   plugin's hand-authored Button render as a single self-contained, token-bound `@dsCard` document (the

--- a/plugins/actian-design-system/.claude-plugin/plugin.json
+++ b/plugins/actian-design-system/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "actian-design-system",
   "description": "Actian Design System toolkit — generate wireframe flows with prototype wiring, create component briefs, audit designs, compare flows, and build presentations. 8 skills (with tiered generation: recognized / adapted / improvised), 9 agents, 155 tokens (3 themes, 8 collections), WCAG 2.2 AA. DS knowledge vendored from volivarii/actian-ds-knowledge.",
-  "version": "2026.7.31",
+  "version": "2026.7.32",
   "author": {
     "name": "Actian UX Team"
   },

--- a/plugins/actian-design-system/scripts/render/capture-seed.js
+++ b/plugins/actian-design-system/scripts/render/capture-seed.js
@@ -7,11 +7,15 @@
 // derive-from-facts in the knowledge repo; this script is the bootstrap, not the
 // permanent producer.
 //
-// captureButtonMatrix() returns one self-contained HTML document whose first
-// line is the DesignSync `@dsCard` marker, containing one rendered Button per
-// (Intent x Emphasis) variant plus a disabled state, all sharing the single
-// inlined stylesheet (tokens + fonts + base + button CSS) that render-leaf
-// already assembles.
+// captureMatrix(slug) returns one self-contained HTML document whose first
+// line is the DesignSync `@dsCard` marker, containing one rendered instance of
+// the slug per registry-derived variant cell (see variantMatrix) plus a
+// disabled state where the registry offers one, all sharing the single
+// inlined stylesheet (tokens + fonts + base + component CSS) that render-leaf
+// already assembles. captureButtonMatrix() is captureMatrix("button"), kept
+// as a named alias for the original slice-1 bootstrap caller. RENDER_SLUGS is
+// the full 35-slug set (the html-renderers switch); the --all CLI mode
+// captures every one of them into a destination directory.
 "use strict";
 
 var path = require("node:path");
@@ -22,20 +26,45 @@ var HR = path.join(__dirname, "..", "renderers", "html-renderers");
 var dsMap = require(path.join(HR, "ds-html-map.js"));
 var PATHS = require("../lib/paths");
 
-// The Button taxonomy is Intent x Emphasis (knowledge v0.34.x). These six cells
-// exercise every emphasis class the renderer produces (primary, secondary,
-// tertiary, critical, critical-secondary) plus a disabled example. The variant
-// strings use the same `Key=Value` form parseVariant() reads from Figma.
-var MATRIX = [
-  { label: "Primary", variant: "Emphasis=Filled" },
-  { label: "Secondary", variant: "Emphasis=Outlined" },
-  { label: "Tertiary", variant: "Emphasis=Ghost" },
-  { label: "Critical", variant: "Intent=Critical, Emphasis=Filled" },
-  {
-    label: "Critical secondary",
-    variant: "Intent=Critical, Emphasis=Outlined",
-  },
-  { label: "Disabled", variant: "Emphasis=Filled, State=Disabled" },
+// The 35 render slugs are the `case "<slug>":` branches in
+// scripts/renderers/html-renderers/ds-html-map.js. This list drives the
+// --all CLI mode and is the seed set for the canonical render library bootstrap.
+var RENDER_SLUGS = [
+  "account-dropdown",
+  "alert-banner",
+  "app-switcher-dropdown",
+  "badge",
+  "breadcrumb",
+  "button",
+  "calendar",
+  "card-for-items",
+  "chat-with-ai-steward",
+  "checkbox",
+  "dropdown-select-default",
+  "empty-state",
+  "global-header",
+  "input-date",
+  "loader",
+  "modal",
+  "notification",
+  "page-header",
+  "popover",
+  "progress-bar-small",
+  "radio-button",
+  "rich-text",
+  "search",
+  "segmented-control",
+  "side-nav",
+  "stepper",
+  "sticky-footer",
+  "table",
+  "tabs",
+  "tag-default",
+  "tag-interactive",
+  "text-input",
+  "toggle",
+  "toolbar",
+  "tooltip",
 ];
 
 var _regCache = null;
@@ -144,14 +173,23 @@ function variantMatrix(slug) {
   return cells;
 }
 
-// Each cell stacks the rendered Button over a caption naming the variant. The
-// caption inherits the body text color at reduced opacity, so no color is
+// The @dsCard group comes from the component's registry category (falling
+// back to its group), so the seed lands under the same grouping DesignSync
+// already uses; "Components" is the last-resort default when a slug carries
+// neither (e.g. it is missing from all three registries).
+function groupFor(slug) {
+  var comp = findComponent(slug);
+  return (comp && (comp.category || comp.group)) || "Components";
+}
+
+// Each cell stacks the rendered component over a caption naming the variant.
+// The caption inherits the body text color at reduced opacity, so no color is
 // hardcoded and no token name is guessed.
-function renderCell(cell) {
+function renderCell(slug, cell) {
   var fragment = dsMap.renderDSComponent({
-    dsSlug: "button",
+    dsSlug: slug,
     variant: cell.variant,
-    props: { Label: cell.label },
+    props: cell.props || {},
   });
   return (
     '<div style="display:flex;flex-direction:column;gap:8px;align-items:flex-start">' +
@@ -163,34 +201,72 @@ function renderCell(cell) {
   );
 }
 
-function captureButtonMatrix() {
+// Generalized capture: builds the full variant matrix for any of the 35
+// render slugs into one self-contained @dsCard doc. Slice 1 seeded only
+// button by hand; this generalizes that bootstrap to the whole render set
+// using the registry-derived variantMatrix() instead of a hand-picked list.
+function captureMatrix(slug) {
   var grid =
     '<div style="display:flex;flex-wrap:wrap;gap:24px;align-items:flex-start">' +
-    MATRIX.map(renderCell).join("") +
+    variantMatrix(slug)
+      .map(function (cell) {
+        return renderCell(slug, cell);
+      })
+      .join("") +
     "</div>";
   // buildLeafHtml inlines the whole stylesheet and wraps the fragment in a
   // self-contained page. fullWidth lets the matrix use the viewport width.
-  var doc = leaf.buildLeafHtml("button", grid, { fullWidth: true });
-  return '<!-- @dsCard group="Components" -->\n' + doc;
+  var doc = leaf.buildLeafHtml(slug, grid, { fullWidth: true });
+  return '<!-- @dsCard group="' + groupFor(slug) + '" -->\n' + doc;
+}
+
+function captureButtonMatrix() {
+  return captureMatrix("button");
 }
 
 if (require.main === module) {
   var argv = process.argv.slice(2);
-  var wi = argv.indexOf("--write");
-  var html = captureButtonMatrix();
-  if (wi >= 0 && argv[wi + 1]) {
-    var out = path.resolve(argv[wi + 1]);
-    fs.mkdirSync(path.dirname(out), { recursive: true });
-    fs.writeFileSync(out, html);
-    process.stdout.write("wrote " + out + " (" + html.length + " bytes)\n");
+  var allIdx = argv.indexOf("--all");
+  if (allIdx >= 0 && argv[allIdx + 1]) {
+    var destDir = path.resolve(argv[allIdx + 1]);
+    fs.mkdirSync(destDir, { recursive: true });
+    var wrote = 0,
+      skipped = [];
+    RENDER_SLUGS.forEach(function (slug) {
+      try {
+        fs.writeFileSync(
+          path.join(destDir, slug + ".html"),
+          captureMatrix(slug),
+        );
+        wrote++;
+      } catch (e) {
+        skipped.push(slug + " (" + e.message + ")");
+      }
+    });
+    process.stdout.write("wrote " + wrote + " seed(s) -> " + destDir + "\n");
+    if (skipped.length)
+      process.stdout.write("skipped: " + skipped.join(", ") + "\n");
   } else {
-    process.stdout.write(html);
+    // existing single --write / stdout behavior, now slug-parameterized
+    var wi = argv.indexOf("--write");
+    var slug =
+      argv.indexOf("--slug") >= 0 ? argv[argv.indexOf("--slug") + 1] : "button";
+    var html = captureMatrix(slug);
+    if (wi >= 0 && argv[wi + 1]) {
+      var out = path.resolve(argv[wi + 1]);
+      fs.mkdirSync(path.dirname(out), { recursive: true });
+      fs.writeFileSync(out, html);
+      process.stdout.write("wrote " + out + " (" + html.length + " bytes)\n");
+    } else {
+      process.stdout.write(html);
+    }
   }
 }
 
 module.exports = {
   captureButtonMatrix: captureButtonMatrix,
-  MATRIX: MATRIX,
+  captureMatrix: captureMatrix,
+  RENDER_SLUGS: RENDER_SLUGS,
   findComponent: findComponent,
   variantMatrix: variantMatrix,
 };

--- a/plugins/actian-design-system/scripts/render/capture-seed.js
+++ b/plugins/actian-design-system/scripts/render/capture-seed.js
@@ -116,7 +116,47 @@ function disabledValue(values) {
   );
 }
 
+// Per-slug curated matrices. Button is the flagship: its Intent x Emphasis
+// richness (including the Critical variants) reads better than a single-axis
+// registry derivation, so it is authored here rather than derived. Kept in the
+// deriver so a re-run of --all reproduces it instead of clobbering it.
+var MATRIX_OVERRIDES = {
+  button: [
+    {
+      label: "Primary",
+      variant: "Emphasis=Filled",
+      props: { Label: "Primary" },
+    },
+    {
+      label: "Secondary",
+      variant: "Emphasis=Outlined",
+      props: { Label: "Secondary" },
+    },
+    {
+      label: "Tertiary",
+      variant: "Emphasis=Ghost",
+      props: { Label: "Tertiary" },
+    },
+    {
+      label: "Critical",
+      variant: "Intent=Critical, Emphasis=Filled",
+      props: { Label: "Critical" },
+    },
+    {
+      label: "Critical secondary",
+      variant: "Intent=Critical, Emphasis=Outlined",
+      props: { Label: "Critical secondary" },
+    },
+    {
+      label: "Disabled",
+      variant: "Emphasis=Filled, State=Disabled",
+      props: { Label: "Disabled" },
+    },
+  ],
+};
+
 function variantMatrix(slug) {
+  if (MATRIX_OVERRIDES[slug]) return MATRIX_OVERRIDES[slug];
   var comp = findComponent(slug);
   var variants = (comp && comp.variants) || {};
   var stateAxis = stateAxisName(variants);

--- a/plugins/actian-design-system/scripts/render/capture-seed.js
+++ b/plugins/actian-design-system/scripts/render/capture-seed.js
@@ -20,6 +20,7 @@ var fs = require("node:fs");
 var leaf = require("../fidelity/render-leaf.js");
 var HR = path.join(__dirname, "..", "renderers", "html-renderers");
 var dsMap = require(path.join(HR, "ds-html-map.js"));
+var PATHS = require("../lib/paths");
 
 // The Button taxonomy is Intent x Emphasis (knowledge v0.34.x). These six cells
 // exercise every emphasis class the renderer produces (primary, secondary,
@@ -30,9 +31,70 @@ var MATRIX = [
   { label: "Secondary", variant: "Emphasis=Outlined" },
   { label: "Tertiary", variant: "Emphasis=Ghost" },
   { label: "Critical", variant: "Intent=Critical, Emphasis=Filled" },
-  { label: "Critical secondary", variant: "Intent=Critical, Emphasis=Outlined" },
+  {
+    label: "Critical secondary",
+    variant: "Intent=Critical, Emphasis=Outlined",
+  },
   { label: "Disabled", variant: "Emphasis=Filled, State=Disabled" },
 ];
+
+function readRegistry(kit) {
+  try {
+    return JSON.parse(
+      fs.readFileSync(PATHS.components.registries[kit], "utf8"),
+    );
+  } catch (e) {
+    return { components: {} };
+  }
+}
+
+// A render slug may live in any kit; search ds -> meta -> fm.
+function findComponent(slug) {
+  var kits = ["dskit", "metakit", "fmkit"];
+  for (var i = 0; i < kits.length; i++) {
+    var reg = readRegistry(kits[i]);
+    if (reg.components && reg.components[slug]) return reg.components[slug];
+  }
+  return null;
+}
+
+var SECONDARY_AXES = { Size: 1, State: 1 };
+
+// Derives a small variant matrix straight from the registry, so any of the 35
+// render slugs (not just Button) gets a representative set of cells without a
+// per-slug hand-authored MATRIX. Primary axis = the richest non-Size/State
+// axis; cells = one per primary-axis value (capped at 5) plus a disabled
+// state cell when the State axis offers one. Slugs with no usable variants
+// fall back to a single default cell so callers always get at least one.
+function variantMatrix(slug) {
+  var comp = findComponent(slug);
+  var variants = (comp && comp.variants) || {};
+  var axes = Object.keys(variants).filter(function (a) {
+    return (
+      !SECONDARY_AXES[a] && Array.isArray(variants[a]) && variants[a].length
+    );
+  });
+  if (!axes.length) {
+    return [{ label: slug, variant: "", props: { Label: slug } }];
+  }
+  // Primary axis = the non-Size/State axis with the most values.
+  axes.sort(function (a, b) {
+    return variants[b].length - variants[a].length;
+  });
+  var primary = axes[0];
+  var cells = variants[primary].slice(0, 5).map(function (v) {
+    return { label: v, variant: primary + "=" + v, props: { Label: v } };
+  });
+  // Add a disabled state cell when the State axis offers it.
+  if (variants.State && variants.State.indexOf("Disabled") >= 0) {
+    cells.push({
+      label: "Disabled",
+      variant: primary + "=" + variants[primary][0] + ", State=Disabled",
+      props: { Label: "Disabled" },
+    });
+  }
+  return cells;
+}
 
 // Each cell stacks the rendered Button over a caption naming the variant. The
 // caption inherits the body text color at reduced opacity, so no color is
@@ -78,4 +140,9 @@ if (require.main === module) {
   }
 }
 
-module.exports = { captureButtonMatrix: captureButtonMatrix, MATRIX: MATRIX };
+module.exports = {
+  captureButtonMatrix: captureButtonMatrix,
+  MATRIX: MATRIX,
+  findComponent: findComponent,
+  variantMatrix: variantMatrix,
+};

--- a/plugins/actian-design-system/scripts/render/capture-seed.js
+++ b/plugins/actian-design-system/scripts/render/capture-seed.js
@@ -38,14 +38,22 @@ var MATRIX = [
   { label: "Disabled", variant: "Emphasis=Filled, State=Disabled" },
 ];
 
+var _regCache = null;
 function readRegistry(kit) {
-  try {
-    return JSON.parse(
-      fs.readFileSync(PATHS.components.registries[kit], "utf8"),
-    );
-  } catch (e) {
-    return { components: {} };
+  if (!_regCache) _regCache = {};
+  if (_regCache[kit] === undefined) {
+    try {
+      _regCache[kit] = JSON.parse(
+        fs.readFileSync(PATHS.components.registries[kit], "utf8"),
+      );
+    } catch (e) {
+      process.stderr.write(
+        "capture-seed: registry read failed (" + kit + "): " + e.message + "\n",
+      );
+      _regCache[kit] = { components: {} };
+    }
   }
+  return _regCache[kit];
 }
 
 // A render slug may live in any kit; search ds -> meta -> fm.
@@ -58,40 +66,80 @@ function findComponent(slug) {
   return null;
 }
 
-var SECONDARY_AXES = { Size: 1, State: 1 };
+// Size and State (singular or plural) are secondary axes: they vary interaction,
+// not the component's identity. Matched case and pluralization insensitively so
+// real data ("States") is caught.
+function isSecondaryAxis(name) {
+  return /^(size|states?)$/i.test(name);
+}
+function stateAxisName(variants) {
+  return (
+    Object.keys(variants).find(function (a) {
+      return /^states?$/i.test(a);
+    }) || null
+  );
+}
+function disabledValue(values) {
+  return (
+    (values || []).find(function (v) {
+      return /disabled/i.test(v);
+    }) || null
+  );
+}
 
-// Derives a small variant matrix straight from the registry, so any of the 35
-// render slugs (not just Button) gets a representative set of cells without a
-// per-slug hand-authored MATRIX. Primary axis = the richest non-Size/State
-// axis; cells = one per primary-axis value (capped at 5) plus a disabled
-// state cell when the State axis offers one. Slugs with no usable variants
-// fall back to a single default cell so callers always get at least one.
 function variantMatrix(slug) {
   var comp = findComponent(slug);
   var variants = (comp && comp.variants) || {};
-  var axes = Object.keys(variants).filter(function (a) {
+  var stateAxis = stateAxisName(variants);
+  var primaryAxes = Object.keys(variants).filter(function (a) {
     return (
-      !SECONDARY_AXES[a] && Array.isArray(variants[a]) && variants[a].length
+      !isSecondaryAxis(a) && Array.isArray(variants[a]) && variants[a].length
     );
   });
-  if (!axes.length) {
+  // Primary axis = most values; deterministic name tie-break so the pick is stable
+  // across registry re-vendors.
+  primaryAxes.sort(function (a, b) {
+    return variants[b].length - variants[a].length || a.localeCompare(b);
+  });
+
+  var cells = [];
+  var primary = null;
+  if (primaryAxes.length) {
+    primary = primaryAxes[0];
+    cells = variants[primary].slice(0, 5).map(function (v) {
+      return { label: v, variant: primary + "=" + v, props: { Label: v } };
+    });
+  } else if (stateAxis) {
+    // No identity axis: the state axis is the component's only variance; show a few.
+    primary = stateAxis;
+    cells = variants[stateAxis].slice(0, 5).map(function (v) {
+      return { label: v, variant: stateAxis + "=" + v, props: { Label: v } };
+    });
+  }
+
+  if (!cells.length) {
     return [{ label: slug, variant: "", props: { Label: slug } }];
   }
-  // Primary axis = the non-Size/State axis with the most values.
-  axes.sort(function (a, b) {
-    return variants[b].length - variants[a].length;
-  });
-  var primary = axes[0];
-  var cells = variants[primary].slice(0, 5).map(function (v) {
-    return { label: v, variant: primary + "=" + v, props: { Label: v } };
-  });
-  // Add a disabled state cell when the State axis offers it.
-  if (variants.State && variants.State.indexOf("Disabled") >= 0) {
-    cells.push({
-      label: "Disabled",
-      variant: primary + "=" + variants[primary][0] + ", State=Disabled",
-      props: { Label: "Disabled" },
+
+  // Ensure a disabled example when the state axis offers one and none is shown yet.
+  // The state axis name is used verbatim (button uses "State", text-input "States"),
+  // because the renderer keys on the exact axis name.
+  if (stateAxis) {
+    var dv = disabledValue(variants[stateAxis]);
+    var alreadyDisabled = cells.some(function (c) {
+      return /disabled/i.test(c.variant);
     });
+    if (dv && !alreadyDisabled) {
+      var base =
+        primary && primary !== stateAxis
+          ? primary + "=" + variants[primary][0] + ", "
+          : "";
+      cells.push({
+        label: dv,
+        variant: base + stateAxis + "=" + dv,
+        props: { Label: dv },
+      });
+    }
   }
   return cells;
 }

--- a/plugins/actian-design-system/scripts/render/capture-seed.js
+++ b/plugins/actian-design-system/scripts/render/capture-seed.js
@@ -95,12 +95,20 @@ function findComponent(slug) {
   return null;
 }
 
-// Size and State (singular or plural) are secondary axes: they vary interaction,
-// not the component's identity. Matched case and pluralization insensitively so
-// real data ("States") is caught.
+// Size, State (singular or plural), and Breakpoint(s) are secondary axes: they
+// vary density/interaction/responsive width, not the component's identity, so
+// they should not become the card's matrix (a global-header shown at five
+// breakpoints is noise). Matched case and pluralization insensitively so real
+// data ("States", "Breakpoints") is caught.
 function isSecondaryAxis(name) {
-  return /^(size|states?)$/i.test(name);
+  return /^(size|states?|breakpoints?)$/i.test(name);
 }
+
+// When two axes tie on value count, prefer the one whose name reads as the
+// component's identity (Type/Variant/Emphasis/Intent/Kind/Style/Appearance)
+// over an incidental layout axis, so the matrix shows what distinguishes the
+// component. Falls through to alphabetical for a stable, re-vendor-proof pick.
+var IDENTITY_AXIS = /type|variant|emphasis|intent|kind|style|appearance/i;
 function stateAxisName(variants) {
   return (
     Object.keys(variants).find(function (a) {
@@ -168,7 +176,11 @@ function variantMatrix(slug) {
   // Primary axis = most values; deterministic name tie-break so the pick is stable
   // across registry re-vendors.
   primaryAxes.sort(function (a, b) {
-    return variants[b].length - variants[a].length || a.localeCompare(b);
+    return (
+      variants[b].length - variants[a].length ||
+      (IDENTITY_AXIS.test(b) ? 1 : 0) - (IDENTITY_AXIS.test(a) ? 1 : 0) ||
+      a.localeCompare(b)
+    );
   });
 
   var cells = [];

--- a/plugins/actian-design-system/tests/render/capture-seed.test.js
+++ b/plugins/actian-design-system/tests/render/capture-seed.test.js
@@ -53,3 +53,34 @@ test("variantMatrix: a slug with no registry variants falls back to a single def
   assert.equal(cells.length, 1);
   assert.equal(cells[0].variant, "");
 });
+
+test("variantMatrix: text-input (axis named 'States') still yields a disabled cell", function () {
+  var cells = C.variantMatrix("text-input");
+  assert.ok(
+    cells.some(function (c) {
+      return /States=Disabled/.test(c.variant);
+    }),
+    "has a disabled cell",
+  );
+});
+
+test("variantMatrix: a state-only component (tag-interactive) shows its states, not a bare fallback", function () {
+  var cells = C.variantMatrix("tag-interactive");
+  assert.ok(cells.length > 1, "more than the single fallback cell");
+  assert.ok(
+    cells.some(function (c) {
+      return /disabled/i.test(c.variant);
+    }),
+    "includes a disabled state",
+  );
+});
+
+test("variantMatrix: a tie between two identity axes is broken deterministically (toggle -> Selection)", function () {
+  var cells = C.variantMatrix("toggle");
+  assert.ok(
+    cells.every(function (c) {
+      return /^Selection=/.test(c.variant) || c.variant === "";
+    }),
+    "picks Selection over Toggle position",
+  );
+});

--- a/plugins/actian-design-system/tests/render/capture-seed.test.js
+++ b/plugins/actian-design-system/tests/render/capture-seed.test.js
@@ -105,3 +105,9 @@ test("captureButtonMatrix still works (alias) and carries an @dsCard group", fun
     assert.ok(html.indexOf(c) >= 0, "has " + c);
   });
 });
+
+test("variantMatrix: button uses the curated override (keeps the Critical variants)", function () {
+  var cells = C.variantMatrix("button");
+  assert.ok(cells.some(function (c) { return /Intent=Critical/.test(c.variant); }), "Critical present");
+  assert.equal(cells.length, 6, "the six curated button cells");
+});

--- a/plugins/actian-design-system/tests/render/capture-seed.test.js
+++ b/plugins/actian-design-system/tests/render/capture-seed.test.js
@@ -8,14 +8,48 @@ test("captureButtonMatrix: one self-contained @dsCard doc with all variants + a 
     !/src=|href=|@import/.test(html),
     "must be self-contained (no external refs)",
   );
-  ["ds-button--primary", "ds-button--secondary", "ds-button--tertiary", "ds-button--critical"].forEach(
-    function (c) {
-      assert.ok(html.indexOf(c) >= 0, "missing variant class " + c);
-    },
-  );
+  [
+    "ds-button--primary",
+    "ds-button--secondary",
+    "ds-button--tertiary",
+    "ds-button--critical",
+  ].forEach(function (c) {
+    assert.ok(html.indexOf(c) >= 0, "missing variant class " + c);
+  });
   assert.ok(/is-disabled|disabled/.test(html), "missing disabled state");
   assert.ok(
-    !/var\(--zen-[a-z0-9-]+\)(?![^{]*:)/.test(html) || html.indexOf("--zen-") >= 0,
+    !/var\(--zen-[a-z0-9-]+\)(?![^{]*:)/.test(html) ||
+      html.indexOf("--zen-") >= 0,
     "tokens present",
   );
+});
+
+test("variantMatrix: button derives cells from the registry primary axis + a disabled state", function () {
+  var cells = C.variantMatrix("button");
+  assert.ok(cells.length >= 2 && cells.length <= 6, "capped cell count");
+  // Emphasis is the richest non-Size/State axis (Filled/Outlined/Ghost/Icon-only).
+  assert.ok(
+    cells.some(function (c) {
+      return /Emphasis=Filled/.test(c.variant);
+    }),
+    "primary axis cell",
+  );
+  assert.ok(
+    cells.some(function (c) {
+      return /State=Disabled/.test(c.variant);
+    }),
+    "disabled state cell",
+  );
+  cells.forEach(function (c) {
+    assert.ok(
+      c.props && typeof c.props.Label === "string",
+      "each cell carries a Label prop",
+    );
+  });
+});
+
+test("variantMatrix: a slug with no registry variants falls back to a single default cell", function () {
+  var cells = C.variantMatrix("__nonexistent-slug__");
+  assert.equal(cells.length, 1);
+  assert.equal(cells[0].variant, "");
 });

--- a/plugins/actian-design-system/tests/render/capture-seed.test.js
+++ b/plugins/actian-design-system/tests/render/capture-seed.test.js
@@ -98,7 +98,7 @@ test("captureMatrix: renders a self-contained @dsCard doc for a non-button slug"
   );
 });
 
-test("captureButtonMatrix still works (alias) and keeps the Components group", function () {
+test("captureButtonMatrix still works (alias) and carries an @dsCard group", function () {
   var html = C.captureButtonMatrix();
   assert.match(html.split("\n")[0], /^<!-- @dsCard group="/);
   ["ds-button--primary", "ds-button--secondary"].forEach(function (c) {

--- a/plugins/actian-design-system/tests/render/capture-seed.test.js
+++ b/plugins/actian-design-system/tests/render/capture-seed.test.js
@@ -3,7 +3,10 @@ var assert = require("node:assert/strict");
 var C = require("../../scripts/render/capture-seed.js");
 test("captureButtonMatrix: one self-contained @dsCard doc with all variants + a disabled state", function () {
   var html = C.captureButtonMatrix();
-  assert.match(html.split("\n")[0], /^<!-- @dsCard group="Components" -->/);
+  // group is now registry-derived (button's registry category is "Action",
+  // not the hardcoded "Components" the slice-1 bootstrap used); assert the
+  // @dsCard marker shape, not a specific category string.
+  assert.match(html.split("\n")[0], /^<!-- @dsCard group="[^"]+" -->/);
   assert.ok(
     !/src=|href=|@import/.test(html),
     "must be self-contained (no external refs)",
@@ -83,4 +86,22 @@ test("variantMatrix: a tie between two identity axes is broken deterministically
     }),
     "picks Selection over Toggle position",
   );
+});
+
+test("captureMatrix: renders a self-contained @dsCard doc for a non-button slug", function () {
+  var html = C.captureMatrix("toggle");
+  assert.match(html.split("\n")[0], /^<!-- @dsCard group="[^"]+" -->/);
+  assert.ok(!/\ssrc=|\shref=|@import/.test(html), "self-contained");
+  assert.ok(
+    html.indexOf("ds-toggle") >= 0 || html.indexOf("toggle") >= 0,
+    "renders the component",
+  );
+});
+
+test("captureButtonMatrix still works (alias) and keeps the Components group", function () {
+  var html = C.captureButtonMatrix();
+  assert.match(html.split("\n")[0], /^<!-- @dsCard group="/);
+  ["ds-button--primary", "ds-button--secondary"].forEach(function (c) {
+    assert.ok(html.indexOf(c) >= 0, "has " + c);
+  });
 });


### PR DESCRIPTION
## What this is

North Star **Step A** (plugin side): generalize the slice-1 Button capture bootstrap to **all 35 slugs the HTML renderer supports**, so the substrate can seed a full canonical render library. Pairs with knowledge **volivarii/actian-ds-knowledge#432** (where the 35 captured seeds land).

## What is here

- **`scripts/render/capture-seed.js`**: `captureMatrix(slug)` replaces the Button-only `captureButtonMatrix` (kept as an alias). Each slug's variant matrix is derived from its **registry variant axes** via `variantMatrix(slug)`:
  - primary axis = the axis with the most values, capped, plus a disabled cell when the registry offers one;
  - `Size` / `State(s)` / `Breakpoint(s)` are treated as **secondary** (they vary density/interaction/width, not identity);
  - ties are broken toward the **identity axis** (Type/Variant/Emphasis/Intent/...) then alphabetically, so the pick is stable across re-vendors.
- `MATRIX_OVERRIDES` keeps the **rich Button** matrix (Intent x Emphasis, including the Critical variants) rather than a single-axis derivation.
- The `@dsCard` group is derived from the component's **registry category**.
- A `--all <destDir>` CLI mode captures every one of the 35 slugs in one pass (skipping and reporting any that throw).

## Determinism

`capture-seed.js --all` reproduces the 35 seeds committed to the knowledge PR **bit-for-bit**, none skipped. The seeds are a reproducible capture, not a hand-edited pile.

Tests: 9/9 green (registry-derived matrix, plural `States`, state-only components, deterministic tie-break, single-cell fallback, the Button override).

Version bumped `2026.7.31 → 2026.7.32`; CHANGELOG updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
