### PR TITLE
feat(vendor): honor vendor-exclude.json so render seeds stay out of the plugin (slice 1b)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@ are summarized at the release level.
 ## [Unreleased]
 
 ### Added
-- **The vendor snapshot can now exclude heavy sub-paths declared by the substrate.** `vendor-snapshot-core.js` reads an optional `vendor-exclude.json` from the knowledge repo root and skips those repo-relative paths when copying, even when their top-level directory is included. The substrate declares `components/render/src` (the 15 MB self-contained render seeds, a capture intermediate) so only the ~1 MB deduplicated render dist reaches the plugin, not the seeds.
+- **The vendor snapshot can now exclude heavy sub-paths declared by the substrate.** ([#252](https://github.com/volivarii/Actian-DS-Claude-plugin/pull/252)) `vendor-snapshot-core.js` reads an optional `vendor-exclude.json` from the knowledge repo root and skips those repo-relative paths when copying, even when their top-level directory is included. The substrate declares `components/render/src` (the 15 MB self-contained render seeds, a capture intermediate) so only the ~1 MB deduplicated render dist reaches the plugin, not the seeds.
 - **Generalized the canonical-render capture from Button to the full 35-slug render set.**
   `plugins/actian-design-system/scripts/render/capture-seed.js` gained `captureMatrix(slug)`, a
   registry-driven generalization of the Button-only capture: it builds each slug's variant matrix from

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ are summarized at the release level.
 ## [Unreleased]
 
 ### Added
+- **The vendor snapshot can now exclude heavy sub-paths declared by the substrate.** `vendor-snapshot-core.js` reads an optional `vendor-exclude.json` from the knowledge repo root and skips those repo-relative paths when copying, even when their top-level directory is included. The substrate declares `components/render/src` (the 15 MB self-contained render seeds, a capture intermediate) so only the ~1 MB deduplicated render dist reaches the plugin, not the seeds.
 - **Generalized the canonical-render capture from Button to the full 35-slug render set.**
   `plugins/actian-design-system/scripts/render/capture-seed.js` gained `captureMatrix(slug)`, a
   registry-driven generalization of the Button-only capture: it builds each slug's variant matrix from

--- a/plugins/actian-design-system/.claude-plugin/plugin.json
+++ b/plugins/actian-design-system/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "actian-design-system",
   "description": "Actian Design System toolkit — generate wireframe flows with prototype wiring, create component briefs, audit designs, compare flows, and build presentations. 8 skills (with tiered generation: recognized / adapted / improvised), 9 agents, 155 tokens (3 themes, 8 collections), WCAG 2.2 AA. DS knowledge vendored from volivarii/actian-ds-knowledge.",
-  "version": "2026.7.32",
+  "version": "2026.7.33",
   "author": {
     "name": "Actian UX Team"
   },

--- a/plugins/actian-design-system/scripts/vendor/vendor-snapshot-core.js
+++ b/plugins/actian-design-system/scripts/vendor/vendor-snapshot-core.js
@@ -356,7 +356,12 @@ function selectEntries(names, includeSet, excludeSet) {
 function vendorContent(extractedRepoRoot, vendorDir, excludeSet) {
   fs.mkdirSync(vendorDir, { recursive: true });
   var includeSet = readVendorInclude(extractedRepoRoot);
-  var excludeSet = readVendorExclude(extractedRepoRoot);
+  // Sub-path excludes (vendor-exclude.json) are a SEPARATE concept from the
+  // caller's top-level excludeSet parameter (config.excludeTopLevel, consulted
+  // by selectEntries in the legacy fallback branch below). Do not reuse the
+  // name "excludeSet" here: that would shadow the parameter and silently
+  // discard the caller's top-level exclusions before selectEntries reads them.
+  var subPathExcludeSet = readVendorExclude(extractedRepoRoot);
   if (includeSet) {
     process.stdout.write(
       "[vendor] inclusion mode — copying " +
@@ -380,7 +385,7 @@ function vendorContent(extractedRepoRoot, vendorDir, excludeSet) {
     var srcPath = path.join(extractedRepoRoot, name);
     var destPath = path.join(vendorDir, name);
     if (fs.statSync(srcPath).isDirectory()) {
-      copyDirectory(srcPath, destPath, name, excludeSet);
+      copyDirectory(srcPath, destPath, name, subPathExcludeSet);
     } else {
       fs.copyFileSync(srcPath, destPath);
     }

--- a/plugins/actian-design-system/scripts/vendor/vendor-snapshot-core.js
+++ b/plugins/actian-design-system/scripts/vendor/vendor-snapshot-core.js
@@ -284,15 +284,18 @@ function extractTarball(tarballPath, destDir) {
   return path.join(destDir, entries[0]);
 }
 
-function copyDirectory(src, dest) {
+function copyDirectory(src, dest, relBase, excludeSet) {
+  relBase = relBase || "";
   fs.mkdirSync(dest, { recursive: true });
   var entries = fs.readdirSync(src, { withFileTypes: true });
   for (var i = 0; i < entries.length; i++) {
     var entry = entries[i];
+    var rel = relBase ? relBase + "/" + entry.name : entry.name;
+    if (excludeSet && excludeSet.has(rel)) continue; // heavy intermediate: skip
     var srcPath = path.join(src, entry.name);
     var destPath = path.join(dest, entry.name);
     if (entry.isDirectory()) {
-      copyDirectory(srcPath, destPath);
+      copyDirectory(srcPath, destPath, rel, excludeSet);
     } else {
       fs.copyFileSync(srcPath, destPath);
     }
@@ -321,6 +324,20 @@ function readVendorInclude(extractedRepoRoot) {
   return null;
 }
 
+// Repo-relative sub-paths the vendor must skip even when their top-level dir is
+// included. Returns a Set of forward-slash paths, or null if the file is absent.
+function readVendorExclude(extractedRepoRoot) {
+  var p = path.join(extractedRepoRoot, "vendor-exclude.json");
+  if (!fs.existsSync(p)) return null;
+  try {
+    var decl = JSON.parse(fs.readFileSync(p, "utf8"));
+    if (decl && Array.isArray(decl.exclude)) return new Set(decl.exclude);
+  } catch (e) {
+    /* malformed → no exclusions */
+  }
+  return null;
+}
+
 // Decide which top-level entries to vendor. Inclusion-first: if the substrate
 // declared an include-set, copy ONLY those (tooling is structurally absent).
 // Otherwise fall back to the legacy exclude-set.
@@ -339,6 +356,7 @@ function selectEntries(names, includeSet, excludeSet) {
 function vendorContent(extractedRepoRoot, vendorDir, excludeSet) {
   fs.mkdirSync(vendorDir, { recursive: true });
   var includeSet = readVendorInclude(extractedRepoRoot);
+  var excludeSet = readVendorExclude(extractedRepoRoot);
   if (includeSet) {
     process.stdout.write(
       "[vendor] inclusion mode — copying " +
@@ -362,7 +380,7 @@ function vendorContent(extractedRepoRoot, vendorDir, excludeSet) {
     var srcPath = path.join(extractedRepoRoot, name);
     var destPath = path.join(vendorDir, name);
     if (fs.statSync(srcPath).isDirectory()) {
-      copyDirectory(srcPath, destPath);
+      copyDirectory(srcPath, destPath, name, excludeSet);
     } else {
       fs.copyFileSync(srcPath, destPath);
     }
@@ -516,5 +534,7 @@ module.exports = {
   notifyIfNewerAvailable: notifyIfNewerAvailable,
   selectEntries: selectEntries,
   readVendorInclude: readVendorInclude,
+  readVendorExclude: readVendorExclude,
+  vendorContent: vendorContent,
   readVendoredJson: readVendoredJson,
 };

--- a/plugins/actian-design-system/tests/vendor/vendor-exclude.test.js
+++ b/plugins/actian-design-system/tests/vendor/vendor-exclude.test.js
@@ -6,23 +6,110 @@ var os = require("node:os");
 var path = require("node:path");
 var core = require("../../scripts/vendor/vendor-snapshot-core.js");
 
-function tmp() { return fs.mkdtempSync(path.join(os.tmpdir(), "vex-")); }
+function tmp() {
+  return fs.mkdtempSync(path.join(os.tmpdir(), "vex-"));
+}
 
 test("vendorContent skips a declared excluded sub-path but copies its siblings", function () {
   var root = tmp();
   // A fake extracted knowledge tarball root.
-  fs.mkdirSync(path.join(root, "components", "render", "src"), { recursive: true });
-  fs.mkdirSync(path.join(root, "components", "render", "dist", "fragments"), { recursive: true });
-  fs.writeFileSync(path.join(root, "components", "render", "src", "button.html"), "SEED");
-  fs.writeFileSync(path.join(root, "components", "render", "dist", "render.css"), "CSS");
-  fs.writeFileSync(path.join(root, "components", "render", "dist", "fragments", "button.html"), "FRAG");
-  fs.writeFileSync(path.join(root, "vendor-include.json"), JSON.stringify({ include: ["components", "vendor-include.json"] }));
-  fs.writeFileSync(path.join(root, "vendor-exclude.json"), JSON.stringify({ exclude: ["components/render/src"] }));
+  fs.mkdirSync(path.join(root, "components", "render", "src"), {
+    recursive: true,
+  });
+  fs.mkdirSync(path.join(root, "components", "render", "dist", "fragments"), {
+    recursive: true,
+  });
+  fs.writeFileSync(
+    path.join(root, "components", "render", "src", "button.html"),
+    "SEED",
+  );
+  fs.writeFileSync(
+    path.join(root, "components", "render", "dist", "render.css"),
+    "CSS",
+  );
+  fs.writeFileSync(
+    path.join(root, "components", "render", "dist", "fragments", "button.html"),
+    "FRAG",
+  );
+  fs.writeFileSync(
+    path.join(root, "vendor-include.json"),
+    JSON.stringify({ include: ["components", "vendor-include.json"] }),
+  );
+  fs.writeFileSync(
+    path.join(root, "vendor-exclude.json"),
+    JSON.stringify({ exclude: ["components/render/src"] }),
+  );
 
   var vendorDir = path.join(tmp(), "vendor");
   core.vendorContent(root, vendorDir, null);
 
-  assert.ok(fs.existsSync(path.join(vendorDir, "components", "render", "dist", "render.css")), "dist copied");
-  assert.ok(fs.existsSync(path.join(vendorDir, "components", "render", "dist", "fragments", "button.html")), "fragments copied");
-  assert.ok(!fs.existsSync(path.join(vendorDir, "components", "render", "src")), "src excluded");
+  assert.ok(
+    fs.existsSync(
+      path.join(vendorDir, "components", "render", "dist", "render.css"),
+    ),
+    "dist copied",
+  );
+  assert.ok(
+    fs.existsSync(
+      path.join(
+        vendorDir,
+        "components",
+        "render",
+        "dist",
+        "fragments",
+        "button.html",
+      ),
+    ),
+    "fragments copied",
+  );
+  assert.ok(
+    !fs.existsSync(path.join(vendorDir, "components", "render", "src")),
+    "src excluded",
+  );
+});
+
+test("vendorContent fallback mode (no vendor-include.json) honors BOTH the caller's top-level excludeSet and a declared sub-path exclude", function () {
+  var root = tmp();
+  // No vendor-include.json here: forces the legacy exclude-fallback branch in
+  // selectEntries, which relies on the caller's top-level excludeSet param.
+  fs.mkdirSync(path.join(root, "components", "render", "src"), {
+    recursive: true,
+  });
+  fs.mkdirSync(path.join(root, "components", "render", "dist"), {
+    recursive: true,
+  });
+  fs.mkdirSync(path.join(root, "scripts"), { recursive: true });
+  fs.writeFileSync(
+    path.join(root, "components", "render", "src", "button.html"),
+    "SEED",
+  );
+  fs.writeFileSync(
+    path.join(root, "components", "render", "dist", "render.css"),
+    "CSS",
+  );
+  fs.writeFileSync(path.join(root, "scripts", "build.js"), "BUILD");
+  fs.writeFileSync(
+    path.join(root, "vendor-exclude.json"),
+    JSON.stringify({ exclude: ["components/render/src"] }),
+  );
+
+  var vendorDir = path.join(tmp(), "vendor");
+  // The caller's top-level excludeSet parameter (config.excludeTopLevel):
+  // "scripts" must NOT be vendored, regardless of the sub-path exclude.
+  core.vendorContent(root, vendorDir, new Set(["scripts"]));
+
+  assert.ok(
+    !fs.existsSync(path.join(vendorDir, "scripts")),
+    "top-level excludeSet param honored: scripts NOT copied",
+  );
+  assert.ok(
+    !fs.existsSync(path.join(vendorDir, "components", "render", "src")),
+    "sub-path exclude honored: src NOT copied",
+  );
+  assert.ok(
+    fs.existsSync(
+      path.join(vendorDir, "components", "render", "dist", "render.css"),
+    ),
+    "components copied (not excluded)",
+  );
 });

--- a/plugins/actian-design-system/tests/vendor/vendor-exclude.test.js
+++ b/plugins/actian-design-system/tests/vendor/vendor-exclude.test.js
@@ -1,0 +1,28 @@
+"use strict";
+var test = require("node:test");
+var assert = require("node:assert/strict");
+var fs = require("node:fs");
+var os = require("node:os");
+var path = require("node:path");
+var core = require("../../scripts/vendor/vendor-snapshot-core.js");
+
+function tmp() { return fs.mkdtempSync(path.join(os.tmpdir(), "vex-")); }
+
+test("vendorContent skips a declared excluded sub-path but copies its siblings", function () {
+  var root = tmp();
+  // A fake extracted knowledge tarball root.
+  fs.mkdirSync(path.join(root, "components", "render", "src"), { recursive: true });
+  fs.mkdirSync(path.join(root, "components", "render", "dist", "fragments"), { recursive: true });
+  fs.writeFileSync(path.join(root, "components", "render", "src", "button.html"), "SEED");
+  fs.writeFileSync(path.join(root, "components", "render", "dist", "render.css"), "CSS");
+  fs.writeFileSync(path.join(root, "components", "render", "dist", "fragments", "button.html"), "FRAG");
+  fs.writeFileSync(path.join(root, "vendor-include.json"), JSON.stringify({ include: ["components", "vendor-include.json"] }));
+  fs.writeFileSync(path.join(root, "vendor-exclude.json"), JSON.stringify({ exclude: ["components/render/src"] }));
+
+  var vendorDir = path.join(tmp(), "vendor");
+  core.vendorContent(root, vendorDir, null);
+
+  assert.ok(fs.existsSync(path.join(vendorDir, "components", "render", "dist", "render.css")), "dist copied");
+  assert.ok(fs.existsSync(path.join(vendorDir, "components", "render", "dist", "fragments", "button.html")), "fragments copied");
+  assert.ok(!fs.existsSync(path.join(vendorDir, "components", "render", "src")), "src excluded");
+});

--- a/plugins/actian-design-system/vendor/clients/vendor-snapshot.js
+++ b/plugins/actian-design-system/vendor/clients/vendor-snapshot.js
@@ -356,7 +356,12 @@ function selectEntries(names, includeSet, excludeSet) {
 function vendorContent(extractedRepoRoot, vendorDir, excludeSet) {
   fs.mkdirSync(vendorDir, { recursive: true });
   var includeSet = readVendorInclude(extractedRepoRoot);
-  var excludeSet = readVendorExclude(extractedRepoRoot);
+  // Sub-path excludes (vendor-exclude.json) are a SEPARATE concept from the
+  // caller's top-level excludeSet parameter (config.excludeTopLevel, consulted
+  // by selectEntries in the legacy fallback branch below). Do not reuse the
+  // name "excludeSet" here: that would shadow the parameter and silently
+  // discard the caller's top-level exclusions before selectEntries reads them.
+  var subPathExcludeSet = readVendorExclude(extractedRepoRoot);
   if (includeSet) {
     process.stdout.write(
       "[vendor] inclusion mode — copying " +
@@ -380,7 +385,7 @@ function vendorContent(extractedRepoRoot, vendorDir, excludeSet) {
     var srcPath = path.join(extractedRepoRoot, name);
     var destPath = path.join(vendorDir, name);
     if (fs.statSync(srcPath).isDirectory()) {
-      copyDirectory(srcPath, destPath, name, excludeSet);
+      copyDirectory(srcPath, destPath, name, subPathExcludeSet);
     } else {
       fs.copyFileSync(srcPath, destPath);
     }

--- a/plugins/actian-design-system/vendor/clients/vendor-snapshot.js
+++ b/plugins/actian-design-system/vendor/clients/vendor-snapshot.js
@@ -284,15 +284,18 @@ function extractTarball(tarballPath, destDir) {
   return path.join(destDir, entries[0]);
 }
 
-function copyDirectory(src, dest) {
+function copyDirectory(src, dest, relBase, excludeSet) {
+  relBase = relBase || "";
   fs.mkdirSync(dest, { recursive: true });
   var entries = fs.readdirSync(src, { withFileTypes: true });
   for (var i = 0; i < entries.length; i++) {
     var entry = entries[i];
+    var rel = relBase ? relBase + "/" + entry.name : entry.name;
+    if (excludeSet && excludeSet.has(rel)) continue; // heavy intermediate: skip
     var srcPath = path.join(src, entry.name);
     var destPath = path.join(dest, entry.name);
     if (entry.isDirectory()) {
-      copyDirectory(srcPath, destPath);
+      copyDirectory(srcPath, destPath, rel, excludeSet);
     } else {
       fs.copyFileSync(srcPath, destPath);
     }
@@ -321,6 +324,20 @@ function readVendorInclude(extractedRepoRoot) {
   return null;
 }
 
+// Repo-relative sub-paths the vendor must skip even when their top-level dir is
+// included. Returns a Set of forward-slash paths, or null if the file is absent.
+function readVendorExclude(extractedRepoRoot) {
+  var p = path.join(extractedRepoRoot, "vendor-exclude.json");
+  if (!fs.existsSync(p)) return null;
+  try {
+    var decl = JSON.parse(fs.readFileSync(p, "utf8"));
+    if (decl && Array.isArray(decl.exclude)) return new Set(decl.exclude);
+  } catch (e) {
+    /* malformed → no exclusions */
+  }
+  return null;
+}
+
 // Decide which top-level entries to vendor. Inclusion-first: if the substrate
 // declared an include-set, copy ONLY those (tooling is structurally absent).
 // Otherwise fall back to the legacy exclude-set.
@@ -339,6 +356,7 @@ function selectEntries(names, includeSet, excludeSet) {
 function vendorContent(extractedRepoRoot, vendorDir, excludeSet) {
   fs.mkdirSync(vendorDir, { recursive: true });
   var includeSet = readVendorInclude(extractedRepoRoot);
+  var excludeSet = readVendorExclude(extractedRepoRoot);
   if (includeSet) {
     process.stdout.write(
       "[vendor] inclusion mode — copying " +
@@ -362,7 +380,7 @@ function vendorContent(extractedRepoRoot, vendorDir, excludeSet) {
     var srcPath = path.join(extractedRepoRoot, name);
     var destPath = path.join(vendorDir, name);
     if (fs.statSync(srcPath).isDirectory()) {
-      copyDirectory(srcPath, destPath);
+      copyDirectory(srcPath, destPath, name, excludeSet);
     } else {
       fs.copyFileSync(srcPath, destPath);
     }
@@ -516,5 +534,7 @@ module.exports = {
   notifyIfNewerAvailable: notifyIfNewerAvailable,
   selectEntries: selectEntries,
   readVendorInclude: readVendorInclude,
+  readVendorExclude: readVendorExclude,
+  vendorContent: vendorContent,
   readVendoredJson: readVendoredJson,
 };


### PR DESCRIPTION
## What this is

North Star **slice 1b** (plugin side): honor the substrate's vendor exclusions so the 15 MB captured render seeds never ship into the plugin, while the ~1 MB deduplicated render dist does. Pairs with knowledge **volivarii/actian-ds-knowledge#438** (which declares the exclusion and ships the dedup dist).

## The problem

The vendor snapshot copies `components` as a whole subtree and could not prune sub-paths. As of the Step A merge, the 15 MB self-contained seeds at `components/render/src/` are git-tracked in knowledge, so the next nightly vendor refresh would copy all 15 MB into the plugin vendor, with no consumer.

## What is here

- **`vendor-snapshot-core.js`** gains `readVendorExclude` (reads `vendor-exclude.json` from the extracted knowledge root) and threads a repo-relative-path exclude set through `copyDirectory`, so a declared sub-path (`components/render/src`) is skipped while its siblings (`dist/`, `schema/`) still vendor. The mechanism lives canonically in the knowledge repo (`clients/vendor-snapshot.js`) and is byte-mirrored here to `vendor/clients/vendor-snapshot.js` and `scripts/vendor/vendor-snapshot-core.js`, guarded by the existing drift test.
- **Fallback-mode fix**: `vendorContent` no longer shadows its top-level `excludeSet` parameter (a whole-branch-review finding), so the caller's `config.excludeTopLevel` still applies in the legacy no-manifest branch. Covered by a new fallback-mode test.

## Verification

New `vendor-exclude.test.js` (RED to GREEN, including the fallback-mode discrimination); full plugin vendor suite **27/27**; the three vendor-snapshot copies are byte-identical (drift guard green).

Version bumped to `2026.7.33`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
