### PR TITLE
fix(ci): the vendor-queue alarm could not clear itself

### DIFF
--- a/.github/scripts/vendor-queue-alarm.sh
+++ b/.github/scripts/vendor-queue-alarm.sh
@@ -1,0 +1,83 @@
+#!/usr/bin/env bash
+#
+# Tell a human when the plugin has stopped consuming knowledge.
+#
+# Vendor refresh PRs are opened with auto-merge, so when their checks fail they
+# silently do not merge and each night quietly adds another to the pile. That is
+# exactly what happened: five vendor PRs (#237 to #241) stacked up red between
+# 2026-07-07 and 2026-07-12 while the plugin consumed no knowledge for five
+# days. The pile IS the signal, and nobody was looking at it. This runs nightly
+# from vendor-snapshot.yml, so it is the natural place to notice. One tracking
+# issue, cleared as soon as nothing is stuck.
+#
+# It lives in a file rather than inline in the workflow so its branches can be
+# tested: see tests/vendor/vendor-queue-alarm.test.js, which runs it against a
+# stubbed `gh`. It was inline shell when it shipped, which is why the defect
+# below went unnoticed for eight days.
+#
+# Requires: gh on PATH, GH_TOKEN in the environment.
+# Best-effort by contract: it must never fail the refresh it runs inside, so
+# every path exits 0.
+set +e
+
+# Clear the alarm. Called from BOTH not-stuck paths on purpose.
+#
+# The original version only cleared when the queue was completely EMPTY, and
+# the body it posts promises "this issue auto-closes when the queue drains". It
+# does not: this very workflow opens tonight's vendor PR moments before this
+# step runs, so the queue is almost never empty here, and the healthy-queue path
+# below simply exited. Issue #272 outlived its cause by eight days that way,
+# still saying the plugin was not consuming knowledge after the refresh had
+# resumed. An alarm that cannot clear itself trains the reader to ignore the
+# label, which is the failure this whole script exists to prevent.
+clear_alarm() {
+  for n in $(gh issue list --state open --label vendor-blocked --json number --jq '.[].number' 2>/dev/null); do
+    gh issue close "$n" --comment "$1" 2>/dev/null
+  done
+}
+
+open_prs=$(gh pr list --state open --label vendor --json number,title,createdAt --jq '.[] | [.number, .createdAt[0:10], .title] | @tsv' 2>/dev/null)
+if [ -z "$open_prs" ]; then
+  clear_alarm "✅ The vendor queue has drained: no open vendor PRs remain."
+  exit 0
+fi
+
+# A PR is only "stuck" if a check has actually FAILED, or it has
+# conflicts. Do NOT use mergeStateStatus == BLOCKED: a PR whose checks
+# are still running is also BLOCKED, and this step runs in the same
+# workflow that just opened tonight's PR. That would fire a false alarm
+# every single night, and a nightly false alarm is how a signal becomes
+# noise and then gets ignored, which is the exact failure this whole
+# change exists to prevent.
+blocked=""
+while IFS=$'\t' read -r num created title; do
+  [ -z "$num" ] && continue
+  failed=$(gh pr view "$num" --json statusCheckRollup \
+    --jq '[.statusCheckRollup[]? | select(.conclusion == "FAILURE" or .conclusion == "TIMED_OUT" or .conclusion == "CANCELLED")] | length' 2>/dev/null)
+  dirty=$(gh pr view "$num" --json mergeStateStatus --jq 'select(.mergeStateStatus == "DIRTY") | "conflicts"' 2>/dev/null)
+  reason=""
+  [ "${failed:-0}" -gt 0 ] 2>/dev/null && reason="${failed} failing check(s)"
+  [ -n "$dirty" ] && reason="${reason:+$reason, }merge conflicts"
+  if [ -n "$reason" ]; then
+    blocked="${blocked}- #${num} (opened ${created}): ${title} — ${reason}"$'\n'
+  fi
+done <<< "$open_prs"
+
+if [ -z "$blocked" ]; then
+  # There are open vendor PRs and none of them is stuck, so knowledge is
+  # flowing again even though the queue is not empty. This is the path that
+  # used to leave a stale alarm lit.
+  clear_alarm "✅ Nothing in the vendor queue is stuck any more: the open vendor PR(s) are healthy, so the plugin is consuming knowledge again."
+  exit 0
+fi
+
+count=$(printf '%s' "$blocked" | grep -c '^- ')
+gh label create vendor-blocked --color B60205 --description "Vendor refresh PRs are stuck; the plugin is not consuming knowledge" 2>/dev/null
+body="**${count} vendor refresh PR(s) are stuck.** While they are, the plugin is consuming NO new knowledge: every substrate change is piling up on the wrong side of the pipe."$'\n\n'"${blocked}"$'\n'"This issue closes automatically as soon as nothing in the queue is stuck."
+existing=$(gh issue list --state open --label vendor-blocked --json number --jq '.[0].number // empty' 2>/dev/null)
+if [ -n "$existing" ]; then
+  gh issue comment "$existing" --body "Still blocked (${count} PR(s))."$'\n\n'"${blocked}" 2>/dev/null
+else
+  gh issue create --title "🔴 Vendor refresh is blocked: the plugin is not consuming knowledge" --label vendor-blocked --body "$body" 2>/dev/null
+fi
+exit 0

--- a/.github/scripts/vendor-queue-alarm.sh
+++ b/.github/scripts/vendor-queue-alarm.sh
@@ -7,77 +7,143 @@
 # exactly what happened: five vendor PRs (#237 to #241) stacked up red between
 # 2026-07-07 and 2026-07-12 while the plugin consumed no knowledge for five
 # days. The pile IS the signal, and nobody was looking at it. This runs nightly
-# from vendor-snapshot.yml, so it is the natural place to notice. One tracking
-# issue, cleared as soon as nothing is stuck.
+# from vendor-snapshot.yml, so it is the natural place to notice.
+#
+# THREE STATES, and the distinction is the whole design:
+#
+#   stuck    a PR has a failed check or merge conflicts   -> raise/update the alarm
+#   healthy  every open PR positively reported success    -> clear the alarm
+#   unknown  gh could not say, or checks have not reported -> touch NOTHING
+#
+# The two defects this shape exists to prevent, both real:
+#
+#  1. The original only cleared when the queue was completely EMPTY, while this
+#     same workflow opens tonight's vendor PR moments before this step runs, so
+#     the queue is almost never empty here. Issue #272 therefore outlived its
+#     cause by eight days, still claiming the plugin was not consuming knowledge
+#     after the refresh had resumed. An alarm that cannot clear itself trains the
+#     reader to ignore the label, which is the failure this script exists for.
+#
+#  2. The first fix then read "gh told me nothing is stuck" and "gh could not
+#     tell me" as the same thing, so an expired token or a rate limit would CLOSE
+#     a real alarm claiming knowledge was flowing again. This repo had just lost
+#     11 nights to an expired PAT. A false all-clear is worse than the silence it
+#     replaced, so nothing but a positive healthy reading may clear.
 #
 # It lives in a file rather than inline in the workflow so its branches can be
 # tested: see tests/vendor/vendor-queue-alarm.test.js, which runs it against a
-# stubbed `gh`. It was inline shell when it shipped, which is why the defect
-# below went unnoticed for eight days.
+# stubbed gh and pins both the verdicts and the queries.
 #
 # Requires: gh on PATH, GH_TOKEN in the environment.
 # Best-effort by contract: it must never fail the refresh it runs inside, so
 # every path exits 0.
 set +e
 
-# Clear the alarm. Called from BOTH not-stuck paths on purpose.
+ALARM_TITLE="🔴 Vendor refresh is blocked: the plugin is not consuming knowledge"
+
+# The issues this script is allowed to close: its own, matched by title.
 #
-# The original version only cleared when the queue was completely EMPTY, and
-# the body it posts promises "this issue auto-closes when the queue drains". It
-# does not: this very workflow opens tonight's vendor PR moments before this
-# step runs, so the queue is almost never empty here, and the healthy-queue path
-# below simply exited. Issue #272 outlived its cause by eight days that way,
-# still saying the plugin was not consuming knowledge after the refresh had
-# resumed. An alarm that cannot clear itself trains the reader to ignore the
-# label, which is the failure this whole script exists to prevent.
+# Scoping by the label alone would close a human's issue that merely wears
+# vendor-blocked to be findable, and it would do so on the healthy path, which
+# is now the frequently taken one. An identity filter (--author @me) is
+# deliberately not used: if it failed to resolve under a CI token the alarm would
+# silently stop clearing, which is defect 1 all over again.
+own_alarm_issues() {
+  gh issue list --state open --label vendor-blocked --json number,title \
+    --jq ".[] | select(.title == \"${ALARM_TITLE}\") | .number" 2>/dev/null
+}
+
 clear_alarm() {
-  for n in $(gh issue list --state open --label vendor-blocked --json number --jq '.[].number' 2>/dev/null); do
+  for n in $(own_alarm_issues); do
     gh issue close "$n" --comment "$1" 2>/dev/null
   done
 }
 
 open_prs=$(gh pr list --state open --label vendor --json number,title,createdAt --jq '.[] | [.number, .createdAt[0:10], .title] | @tsv' 2>/dev/null)
+if [ $? -ne 0 ]; then
+  # An empty list and a failed list are the same empty string, so this has to be
+  # checked before the emptiness is trusted as "drained".
+  echo "vendor-queue-alarm: could not read the vendor PR queue, so the queue state is UNKNOWN. Leaving any existing alarm exactly as it is."
+  exit 0
+fi
+
 if [ -z "$open_prs" ]; then
   clear_alarm "✅ The vendor queue has drained: no open vendor PRs remain."
   exit 0
 fi
 
-# A PR is only "stuck" if a check has actually FAILED, or it has
-# conflicts. Do NOT use mergeStateStatus == BLOCKED: a PR whose checks
-# are still running is also BLOCKED, and this step runs in the same
-# workflow that just opened tonight's PR. That would fire a false alarm
-# every single night, and a nightly false alarm is how a signal becomes
-# noise and then gets ignored, which is the exact failure this whole
-# change exists to prevent.
 blocked=""
+unknown=""
 while IFS=$'\t' read -r num created title; do
   [ -z "$num" ] && continue
-  failed=$(gh pr view "$num" --json statusCheckRollup \
-    --jq '[.statusCheckRollup[]? | select(.conclusion == "FAILURE" or .conclusion == "TIMED_OUT" or .conclusion == "CANCELLED")] | length' 2>/dev/null)
+
+  # `.conclusion // .state` on purpose: a modern CheckRun carries .conclusion,
+  # a legacy commit status (StatusContext) carries .state, and reading only the
+  # first let a red legacy status pass as healthy. A check with neither has not
+  # reported, which is PENDING, not success.
+  checks=$(gh pr view "$num" --json statusCheckRollup \
+    --jq '[.statusCheckRollup[]? | (.conclusion // .state // "PENDING")] | join(",")' 2>/dev/null)
+  checks_rc=$?
   dirty=$(gh pr view "$num" --json mergeStateStatus --jq 'select(.mergeStateStatus == "DIRTY") | "conflicts"' 2>/dev/null)
+  dirty_rc=$?
+
+  if [ "$checks_rc" -ne 0 ] || [ "$dirty_rc" -ne 0 ]; then
+    unknown="${unknown}- #${num}: gh could not report its state"$'\n'
+    continue
+  fi
+
   reason=""
-  [ "${failed:-0}" -gt 0 ] 2>/dev/null && reason="${failed} failing check(s)"
+  case ",$checks," in
+    *,FAILURE,* | *,TIMED_OUT,* | *,CANCELLED,* | *,ERROR,* | *,STARTUP_FAILURE,* | *,ACTION_REQUIRED,*)
+      reason="failing check(s)"
+      ;;
+  esac
   [ -n "$dirty" ] && reason="${reason:+$reason, }merge conflicts"
+
   if [ -n "$reason" ]; then
     blocked="${blocked}- #${num} (opened ${created}): ${title} — ${reason}"$'\n'
+    continue
   fi
+
+  # Not stuck. That is only HEALTHY if every check positively reported success.
+  #
+  # Do NOT read pending as healthy: this step runs in the same workflow that
+  # just opened tonight's PR, so pending is the normal state moments after
+  # opening, and clearing on it would drop a real alarm on nothing but timing.
+  # (This is also why mergeStateStatus == BLOCKED is not used as the stuck test:
+  # a PR whose checks are still running is BLOCKED too, and that would fire a
+  # false alarm every single night.)
+  if [ -z "$checks" ]; then
+    unknown="${unknown}- #${num}: no checks have reported yet"$'\n'
+    continue
+  fi
+  case ",$checks," in
+    *,PENDING,* | *,EXPECTED,* | *,IN_PROGRESS,* | *,QUEUED,* | *,WAITING,* | *,REQUESTED,*)
+      unknown="${unknown}- #${num}: checks still running"$'\n'
+      continue
+      ;;
+  esac
 done <<< "$open_prs"
 
-if [ -z "$blocked" ]; then
-  # There are open vendor PRs and none of them is stuck, so knowledge is
-  # flowing again even though the queue is not empty. This is the path that
-  # used to leave a stale alarm lit.
-  clear_alarm "✅ Nothing in the vendor queue is stuck any more: the open vendor PR(s) are healthy, so the plugin is consuming knowledge again."
+if [ -n "$blocked" ]; then
+  count=$(printf '%s' "$blocked" | grep -c '^- ')
+  gh label create vendor-blocked --color B60205 --description "Vendor refresh PRs are stuck; the plugin is not consuming knowledge" 2>/dev/null
+  body="**${count} vendor refresh PR(s) are stuck.** While they are, the plugin is consuming NO new knowledge: every substrate change is piling up on the wrong side of the pipe."$'\n\n'"${blocked}"$'\n'"This issue closes automatically once every open vendor PR reports healthy."
+  existing=$(own_alarm_issues | head -1)
+  if [ -n "$existing" ]; then
+    gh issue comment "$existing" --body "Still blocked (${count} PR(s))."$'\n\n'"${blocked}" 2>/dev/null
+  else
+    gh issue create --title "$ALARM_TITLE" --label vendor-blocked --body "$body" 2>/dev/null
+  fi
   exit 0
 fi
 
-count=$(printf '%s' "$blocked" | grep -c '^- ')
-gh label create vendor-blocked --color B60205 --description "Vendor refresh PRs are stuck; the plugin is not consuming knowledge" 2>/dev/null
-body="**${count} vendor refresh PR(s) are stuck.** While they are, the plugin is consuming NO new knowledge: every substrate change is piling up on the wrong side of the pipe."$'\n\n'"${blocked}"$'\n'"This issue closes automatically as soon as nothing in the queue is stuck."
-existing=$(gh issue list --state open --label vendor-blocked --json number --jq '.[0].number // empty' 2>/dev/null)
-if [ -n "$existing" ]; then
-  gh issue comment "$existing" --body "Still blocked (${count} PR(s))."$'\n\n'"${blocked}" 2>/dev/null
-else
-  gh issue create --title "🔴 Vendor refresh is blocked: the plugin is not consuming knowledge" --label vendor-blocked --body "$body" 2>/dev/null
+if [ -n "$unknown" ]; then
+  echo "vendor-queue-alarm: nothing is provably stuck, but the state of some PR(s) is UNKNOWN, so the alarm is left exactly as it is:"
+  printf '%s' "$unknown"
+  exit 0
 fi
+
+# Every open vendor PR positively reported success.
+clear_alarm "✅ Every open vendor PR reports healthy, so the plugin is consuming knowledge again."
 exit 0

--- a/.github/workflows/vendor-snapshot.yml
+++ b/.github/workflows/vendor-snapshot.yml
@@ -236,64 +236,15 @@ jobs:
             echo "### Vendor: no changes (already at ${{ steps.target.outputs.label }})" >> "$GITHUB_STEP_SUMMARY"
           fi
 
-      # A vendor PR that goes RED just sits there. Nothing says so.
-      #
-      # That is exactly what happened: five vendor PRs (#237 to #241) stacked up
-      # red between 2026-07-07 and 2026-07-12 while the plugin consumed no
-      # knowledge for five days. They are opened with auto-merge, so when the
-      # checks fail they silently do not merge, and each night quietly adds
-      # another one to the pile. The pile IS the signal, and nobody was looking
-      # at it.
-      #
-      # This runs nightly (the workflow is already here), so it is the natural
-      # place to notice. One tracking issue, auto-closed when the queue drains.
+      # A vendor PR that goes RED just sits there. Nothing says so. The why, the
+      # incident behind it, and the stuck-vs-still-running distinction all live
+      # in the script's own header, so they are not restated here where one copy
+      # would go stale.
       - name: Raise the alarm if the vendor queue is blocked
         if: always()
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        # Best-effort: this must never fail the refresh itself.
-        run: |
-          set +e
-          open_prs=$(gh pr list --state open --label vendor --json number,title,createdAt --jq '.[] | [.number, .createdAt[0:10], .title] | @tsv' 2>/dev/null)
-          if [ -z "$open_prs" ]; then
-            for n in $(gh issue list --state open --label vendor-blocked --json number --jq '.[].number' 2>/dev/null); do
-              gh issue close "$n" --comment "✅ The vendor queue has drained: no open vendor PRs remain." 2>/dev/null
-            done
-            exit 0
-          fi
-
-          # A PR is only "stuck" if a check has actually FAILED, or it has
-          # conflicts. Do NOT use mergeStateStatus == BLOCKED: a PR whose checks
-          # are still running is also BLOCKED, and this step runs in the same
-          # workflow that just opened tonight's PR. That would fire a false alarm
-          # every single night, and a nightly false alarm is how a signal becomes
-          # noise and then gets ignored, which is the exact failure this whole
-          # change exists to prevent.
-          blocked=""
-          while IFS=$'\t' read -r num created title; do
-            [ -z "$num" ] && continue
-            failed=$(gh pr view "$num" --json statusCheckRollup \
-              --jq '[.statusCheckRollup[]? | select(.conclusion == "FAILURE" or .conclusion == "TIMED_OUT" or .conclusion == "CANCELLED")] | length' 2>/dev/null)
-            dirty=$(gh pr view "$num" --json mergeStateStatus --jq 'select(.mergeStateStatus == "DIRTY") | "conflicts"' 2>/dev/null)
-            reason=""
-            [ "${failed:-0}" -gt 0 ] 2>/dev/null && reason="${failed} failing check(s)"
-            [ -n "$dirty" ] && reason="${reason:+$reason, }merge conflicts"
-            if [ -n "$reason" ]; then
-              blocked="${blocked}- #${num} (opened ${created}): ${title} — ${reason}"$'\n'
-            fi
-          done <<< "$open_prs"
-
-          if [ -z "$blocked" ]; then
-            exit 0
-          fi
-
-          count=$(printf '%s' "$blocked" | grep -c '^- ')
-          gh label create vendor-blocked --color B60205 --description "Vendor refresh PRs are stuck; the plugin is not consuming knowledge" 2>/dev/null
-          body="**${count} vendor refresh PR(s) are stuck.** While they are, the plugin is consuming NO new knowledge: every substrate change is piling up on the wrong side of the pipe."$'\n\n'"${blocked}"$'\n'"This issue auto-closes when the queue drains."
-          existing=$(gh issue list --state open --label vendor-blocked --json number --jq '.[0].number // empty' 2>/dev/null)
-          if [ -n "$existing" ]; then
-            gh issue comment "$existing" --body "Still blocked (${count} PR(s))."$'\n\n'"${blocked}" 2>/dev/null
-          else
-            gh issue create --title "🔴 Vendor refresh is blocked: the plugin is not consuming knowledge" --label vendor-blocked --body "$body" 2>/dev/null
-          fi
-          exit 0
+        # Best-effort by contract: it must never fail the refresh itself. Kept in
+        # a script, not inline, so its branches are testable:
+        # plugins/actian-design-system/tests/vendor/vendor-queue-alarm.test.js
+        run: .github/scripts/vendor-queue-alarm.sh

--- a/.github/workflows/vendor-snapshot.yml
+++ b/.github/workflows/vendor-snapshot.yml
@@ -247,4 +247,11 @@ jobs:
         # Best-effort by contract: it must never fail the refresh itself. Kept in
         # a script, not inline, so its branches are testable:
         # plugins/actian-design-system/tests/vendor/vendor-queue-alarm.test.js
-        run: .github/scripts/vendor-queue-alarm.sh
+        #
+        # `bash <path> || true` and not a bare path: GitHub runs a `run:` under
+        # `bash -e`, so a lost exec bit (a Windows checkout, a rebase, a future
+        # move of the file) would fail this step and with it a workflow whose real
+        # job, vendoring knowledge, had already succeeded. The inline version
+        # could not fail that way, and this contract must not weaken just because
+        # the code moved.
+        run: bash .github/scripts/vendor-queue-alarm.sh || true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,24 @@ are summarized at the release level.
 ## [Unreleased]
 
 ### Fixed
+- **The vendor-queue alarm could not clear itself, so it spent eight days reporting a queue that had
+  already drained.** ([#PR](_PR link added at open_)) Issue #272 said "the plugin is not consuming
+  knowledge" from 2026-08-03 to 2026-08-11, and its own body promised "this issue auto-closes when the
+  queue drains". It could not: the only close path required **zero** open vendor PRs, and this same
+  workflow opens tonight's vendor PR moments before the alarm step runs, so the queue is almost never
+  empty at that point. The healthy-queue path simply exited, leaving the alarm lit after the refresh
+  had resumed.
+
+  An alarm that cannot clear itself is worse than no alarm, because it trains the reader to ignore the
+  label, which is the exact failure the queue alarm was written to prevent. It now clears on **both**
+  not-stuck paths: an empty queue, and a queue whose open PRs are all healthy.
+
+  The step was inline shell in `vendor-snapshot.yml`, which is why nothing tested it and why the defect
+  survived. It now lives in `.github/scripts/vendor-queue-alarm.sh` and all four of its branches are
+  exercised against a stubbed `gh` in `tests/vendor/vendor-queue-alarm.test.js`, mutation-verified:
+  removing the new clear reds exactly the one test that covers it. The long explanation of the original
+  incident moved into the script header rather than being restated in the workflow.
+
 - **The nightly vendor snapshot flows again, and four of the gates that blocked it no longer rot on
   normal Figma activity.** ([#PR](_PR link added at open_)) The knowledge v0.34.122 refresh PR had
   been red every night since 2026-07-25 (15 consecutive runs), so `main` stayed pinned at v0.34.117,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@ are summarized at the release level.
 
 ### Fixed
 - **The vendor-queue alarm could not clear itself, so it spent eight days reporting a queue that had
-  already drained.** ([#PR](_PR link added at open_)) Issue #272 said "the plugin is not consuming
+  already drained.** ([#276](https://github.com/volivarii/Actian-DS-Claude-plugin/pull/276)) Issue #272 said "the plugin is not consuming
   knowledge" from 2026-08-03 to 2026-08-11, and its own body promised "this issue auto-closes when the
   queue drains". It could not: the only close path required **zero** open vendor PRs, and this same
   workflow opens tonight's vendor PR moments before the alarm step runs, so the queue is almost never

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,7 +30,20 @@ are summarized at the release level.
 
   An alarm that cannot clear itself is worse than no alarm, because it trains the reader to ignore the
   label, which is the exact failure the queue alarm was written to prevent. It now clears on **both**
-  not-stuck paths: an empty queue, and a queue whose open PRs are all healthy.
+  not-stuck paths: an empty queue, and a queue whose open PRs all positively report healthy.
+
+  **The first version of that fix was worse than the bug**, and an independent review caught it. It read
+  "gh told me nothing is stuck" and "gh could not tell me" as the same state, so an expired token or a
+  rate limit would have **closed a real alarm** claiming the plugin was consuming knowledge again, on a
+  repo that had just lost 11 nights to an expired PAT. A silent no-op became an affirmative false
+  all-clear. The script is now explicitly three-state: `stuck` raises or updates the alarm, `healthy`
+  clears it, and **`unknown` touches nothing and says why**. Only a positive success reading clears, so a
+  failed `gh` call, a PR whose checks have not reported, and a PR with no checks at all are all unknown.
+  Checks are read as `.conclusion // .state` so a red legacy commit status counts, and the close is
+  scoped to the alarm's own title rather than to everything wearing the label, since the healthy path is
+  now the frequently taken one and a human's issue could wear it too. The workflow invokes the script as
+  `bash <path> || true`, because a `run:` runs under `bash -e` and a lost exec bit must not fail a
+  refresh whose real work succeeded.
 
   The step was inline shell in `vendor-snapshot.yml`, which is why nothing tested it and why the defect
   survived. It now lives in `.github/scripts/vendor-queue-alarm.sh` and all four of its branches are

--- a/plugins/actian-design-system/.claude-plugin/plugin.json
+++ b/plugins/actian-design-system/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "actian-design-system",
   "description": "Actian Design System toolkit — generate wireframe flows with prototype wiring, create component briefs, audit designs, compare flows, and build presentations. 8 skills (with tiered generation: recognized / adapted / improvised), 9 agents, 155 tokens (3 themes, 8 collections), WCAG 2.2 AA. DS knowledge vendored from volivarii/actian-ds-knowledge.",
-  "version": "2026.8.1",
+  "version": "2026.8.2",
   "author": {
     "name": "Actian UX Team"
   },

--- a/plugins/actian-design-system/tests/vendor/vendor-queue-alarm.test.js
+++ b/plugins/actian-design-system/tests/vendor/vendor-queue-alarm.test.js
@@ -20,38 +20,60 @@ var ALARM = path.join(REPO_ROOT, ".github", "scripts", "vendor-queue-alarm.sh");
 // reader to ignore the label, which is the exact failure the queue alarm was
 // written to prevent.
 //
+// THE SECOND LESSON, from the review of the first fix: an affirmative clear is
+// far more dangerous than a no-op. The first fix read "gh told me nothing is
+// stuck" and "gh could not tell me" as the same state, so an expired token or a
+// rate limit closed a real alarm claiming the plugin was consuming knowledge
+// again. This ecosystem had just lost 11 nights to an expired PAT. So the script
+// is now explicitly three-state:
+//
+//   stuck    -> raise or update the alarm
+//   healthy  -> clear it
+//   unknown  -> touch nothing, and say why
+//
+// Only a positive healthy reading clears. Everything the API could not answer
+// is unknown, never healthy.
+//
 // The step used to be inline shell in vendor-snapshot.yml, which is why nothing
 // tested it. It is a script now so these branches can actually be exercised.
 
-function stubGh(dir, fixtures) {
+// A stub gh. It answers on the subcommand and records every invocation, so the
+// tests can assert both the DECISION the script reached and the QUESTIONS it
+// asked. Asserting the questions matters because a stub that answers on the
+// subcommand alone would stay green if the real --json fields or --jq filters
+// were wrong, which would silence the alarm with no red test.
+function stubGh(dir, fx) {
   var log = path.join(dir, "gh.log");
-  // `%b` and not `%s`: the PR-list fixture is TSV, and with `%s` the \t and \n
-  // reach the script as literal backslash-t, so the production loop's
-  // `IFS=$'\t' read` sees one unsplittable field. The first version of this
-  // stub did exactly that and made a correct script look broken.
-  var script = [
+  var lines = [
     "#!/usr/bin/env bash",
     'printf "%s\\n" "$*" >> ' + JSON.stringify(log),
     'case "$1 $2" in',
     '  "pr list")',
-    "    printf '%b' " + JSON.stringify(fixtures.openPrs || ""),
+    "    " + (fx.prListFails ? 'echo "HTTP 502" >&2; exit 1' : ""),
+    "    printf '%b' " + JSON.stringify(fx.openPrs || ""),
     "    ;;",
     '  "issue list")',
-    "    printf '%b' " + JSON.stringify(fixtures.blockedIssues || ""),
+    "    printf '%b' " + JSON.stringify(fx.blockedIssues || ""),
     "    ;;",
     '  "pr view")',
-    // Which of the two `pr view` calls this is, by the field asked for.
     '    if [[ "$*" == *statusCheckRollup* ]]; then',
-    "      printf '%b' " + JSON.stringify(String(fixtures.failedChecks || 0)),
+    "      " + (fx.prViewFails ? 'echo "HTTP 502" >&2; exit 1' : ""),
+    "      printf '%b' " +
+      JSON.stringify(fx.checks === undefined ? "SUCCESS" : fx.checks),
+    // Printed a plausible answer, then failed. Only the exit code distinguishes
+    // this from a healthy read.
+    "      " + (fx.prViewFailsAfterPrinting ? "exit 1" : ""),
     "    else",
-    "      printf '%b' " + JSON.stringify(fixtures.dirty || ""),
+    "      " + (fx.prViewFails ? "exit 1" : ""),
+    "      printf '%b' " + JSON.stringify(fx.dirty || ""),
+    "      " + (fx.prViewFailsAfterPrinting ? "exit 1" : ""),
     "    fi",
     "    ;;",
     "esac",
     "exit 0",
     "",
-  ].join("\n");
-  fs.writeFileSync(path.join(dir, "gh"), script, { mode: 0o755 });
+  ];
+  fs.writeFileSync(path.join(dir, "gh"), lines.join("\n"), { mode: 0o755 });
   return log;
 }
 
@@ -60,9 +82,9 @@ function stubGh(dir, fixtures) {
 // not a call.
 var CLOSE_CALL = /issue close [0-9]/;
 
-function runAlarm(fixtures) {
+function runAlarm(fx) {
   var dir = fs.mkdtempSync(path.join(os.tmpdir(), "vqa-"));
-  var log = stubGh(dir, fixtures);
+  var log = stubGh(dir, fx || {});
   var res = spawnSync("bash", [ALARM], {
     encoding: "utf8",
     env: Object.assign({}, process.env, { PATH: dir + ":" + process.env.PATH }),
@@ -75,6 +97,10 @@ function runAlarm(fixtures) {
   };
 }
 
+var ONE_HEALTHY_PR =
+  "274\t2026-08-11\tvendor(knowledge): refresh to v0.34.122\n";
+var ONE_PR = "271\t2026-07-25\tvendor(knowledge): refresh to v0.34.122\n";
+
 test("alarm: an empty vendor queue closes the open blocked issue", function () {
   var r = runAlarm({ openPrs: "", blockedIssues: "272\n" });
   assert.match(r.calls, CLOSE_CALL);
@@ -82,26 +108,21 @@ test("alarm: an empty vendor queue closes the open blocked issue", function () {
 });
 
 test("alarm: a queue whose PRs are all healthy ALSO closes the open blocked issue", function () {
-  // The defect. There is an open vendor PR, because this very workflow just
-  // opened tonight's, and nothing about it is stuck. The plugin IS consuming
-  // knowledge again, so the alarm must clear. Before the fix this branch
-  // exited without touching the issue, and #272 outlived its own cause by
-  // eight days.
+  // The original defect. There is an open vendor PR, because this very
+  // workflow just opened tonight's, and nothing about it is stuck. The plugin
+  // IS consuming knowledge again, so the alarm must clear. Before the fix this
+  // branch exited without touching the issue, and #272 outlived its own cause
+  // by eight days.
   var r = runAlarm({
-    openPrs: "274\t2026-08-11\tvendor(knowledge): refresh to v0.34.122\n",
+    openPrs: ONE_HEALTHY_PR,
     blockedIssues: "272\n",
-    failedChecks: 0,
+    checks: "SUCCESS,SUCCESS",
   });
-  assert.match(r.calls, CLOSE_CALL);
   assert.match(r.calls, /issue close 272/);
 });
 
 test("alarm: a genuinely stuck PR still raises a new alarm", function () {
-  var r = runAlarm({
-    openPrs: "271\t2026-07-25\tvendor(knowledge): refresh to v0.34.122\n",
-    blockedIssues: "",
-    failedChecks: 1,
-  });
+  var r = runAlarm({ openPrs: ONE_PR, blockedIssues: "", checks: "FAILURE" });
   assert.match(r.calls, /issue create/);
   assert.match(r.calls, /vendor-blocked/);
   assert.doesNotMatch(r.calls, CLOSE_CALL);
@@ -109,9 +130,9 @@ test("alarm: a genuinely stuck PR still raises a new alarm", function () {
 
 test("alarm: a stuck PR with the alarm already open comments instead of duplicating it", function () {
   var r = runAlarm({
-    openPrs: "271\t2026-07-25\tvendor(knowledge): refresh to v0.34.122\n",
+    openPrs: ONE_PR,
     blockedIssues: "272\n",
-    failedChecks: 1,
+    checks: "FAILURE",
   });
   assert.match(r.calls, /issue comment 272/);
   assert.doesNotMatch(r.calls, /issue create/);
@@ -119,12 +140,142 @@ test("alarm: a stuck PR with the alarm already open comments instead of duplicat
 });
 
 test("alarm: never fails the refresh it runs inside", function () {
-  // It is a best-effort reporter attached to a job that has real work to
-  // protect. Whatever it finds, it exits 0.
-  var r = runAlarm({
-    openPrs: "271\t2026-07-25\tsomething\n",
-    blockedIssues: "",
-    failedChecks: 1,
-  });
+  var r = runAlarm({ openPrs: ONE_PR, blockedIssues: "", checks: "FAILURE" });
   assert.equal(r.status, 0, r.stderr);
+});
+
+// --- the review findings -----------------------------------------------------
+
+test("alarm: a gh API error while reading a PR leaves the alarm exactly as it was", function () {
+  // The worst finding. gh failing is NOT evidence that nothing is stuck, and
+  // this is the precise state of an expired token, which cost this ecosystem 11
+  // nights. Closing here would be a false all-clear the script never measured.
+  var r = runAlarm({
+    openPrs: ONE_PR,
+    blockedIssues: "272\n",
+    prViewFails: true,
+  });
+  assert.doesNotMatch(r.calls, CLOSE_CALL, "must not clear on an API error");
+  assert.doesNotMatch(r.calls, /issue create/, "must not cry wolf either");
+  assert.match(
+    r.stdout + r.stderr,
+    /could not|unknown/i,
+    "must say why it did nothing",
+  );
+});
+
+test("alarm: gh printing a plausible answer AND failing is unknown, not healthy", function () {
+  // This test exists because a mutation check caught a gap in the one above it:
+  // deleting the exit-code guard entirely left the whole suite green, since a
+  // failing `gh` that prints NOTHING is already caught by the no-checks branch.
+  // So the exit code was being read by unverified code. A partial or cached
+  // answer alongside a non-zero exit is the case only the exit code can catch,
+  // and misreading it clears a real alarm.
+  var r = runAlarm({
+    openPrs: ONE_HEALTHY_PR,
+    blockedIssues: "272\n",
+    checks: "SUCCESS",
+    prViewFailsAfterPrinting: true,
+  });
+  assert.doesNotMatch(
+    r.calls,
+    CLOSE_CALL,
+    "a non-zero gh exit is unknown even when it printed something that parses",
+  );
+});
+
+test("alarm: a gh API error while listing the queue leaves the alarm exactly as it was", function () {
+  // An empty PR list and a failed PR list are the same empty string.
+  var r = runAlarm({ prListFails: true, blockedIssues: "272\n" });
+  assert.doesNotMatch(r.calls, CLOSE_CALL);
+  assert.doesNotMatch(r.calls, /issue create/);
+});
+
+test("alarm: a PR whose checks have not reported yet is unknown, not healthy", function () {
+  // This step runs in the same workflow that just opened tonight's PR, so
+  // pending is the NORMAL state moments after opening. Reading it as healthy
+  // would clear a real alarm on nothing more than timing.
+  var r = runAlarm({
+    openPrs: ONE_HEALTHY_PR,
+    blockedIssues: "272\n",
+    checks: "PENDING,SUCCESS",
+  });
+  assert.doesNotMatch(r.calls, CLOSE_CALL);
+});
+
+test("alarm: a PR with no checks at all is unknown, not healthy", function () {
+  var r = runAlarm({
+    openPrs: ONE_HEALTHY_PR,
+    blockedIssues: "272\n",
+    checks: "",
+  });
+  assert.doesNotMatch(r.calls, CLOSE_CALL);
+});
+
+test("alarm: a failing legacy commit status counts as stuck", function () {
+  // A StatusContext carries `.state`, not `.conclusion`. Reading conclusion
+  // alone let a red legacy status read as healthy.
+  var r = runAlarm({ openPrs: ONE_PR, blockedIssues: "", checks: "FAILURE" });
+  assert.match(r.calls, /issue create/);
+});
+
+test("alarm: merge conflicts are stuck even when every check passed", function () {
+  var r = runAlarm({
+    openPrs: ONE_PR,
+    blockedIssues: "",
+    checks: "SUCCESS",
+    dirty: "conflicts",
+  });
+  assert.match(r.calls, /issue create/);
+});
+
+test("alarm: it asks the right questions, not just reaches the right verdict", function () {
+  // A stub answers whatever it is asked, so the decision tests above would all
+  // stay green if the queries themselves were wrong. These assertions pin the
+  // queries, which is the part a stub cannot validate on its own.
+  var r = runAlarm({
+    openPrs: ONE_HEALTHY_PR,
+    blockedIssues: "",
+    checks: "SUCCESS",
+  });
+  assert.match(
+    r.calls,
+    /pr list .*--state open .*--label vendor/,
+    "the queue query must be open vendor-labelled PRs",
+  );
+  assert.match(
+    r.calls,
+    /statusCheckRollup/,
+    "check state must come from the rollup",
+  );
+  assert.match(
+    r.calls,
+    /\.state/,
+    "the rollup filter must fall back to .state so a legacy commit status counts",
+  );
+  assert.match(
+    r.calls,
+    /mergeStateStatus/,
+    "conflicts must still be consulted",
+  );
+});
+
+test("alarm: it only closes its own tracking issue, not every issue wearing the label", function () {
+  // clear_alarm is now reached on the frequently-taken healthy path, so closing
+  // everything with the label would auto-close a human's issue with a claim the
+  // script never measured about it.
+  var r = runAlarm({ openPrs: "", blockedIssues: "272\n" });
+  assert.match(
+    r.calls,
+    /issue list .*--json number,title/,
+    "it must read titles so the close can be scoped to its own tracking issue",
+  );
+  assert.match(
+    r.calls,
+    /issue list .*Vendor refresh is blocked/,
+    "the close is scoped by the alarm's own title rather than by the label alone. " +
+      "An identity filter is deliberately avoided: if --author @me failed to " +
+      "resolve under a CI token, the alarm would silently stop clearing again, " +
+      "which is the bug this file exists for.",
+  );
 });

--- a/plugins/actian-design-system/tests/vendor/vendor-queue-alarm.test.js
+++ b/plugins/actian-design-system/tests/vendor/vendor-queue-alarm.test.js
@@ -1,0 +1,130 @@
+"use strict";
+var test = require("node:test");
+var assert = require("node:assert/strict");
+var fs = require("node:fs");
+var os = require("node:os");
+var path = require("node:path");
+var spawnSync = require("node:child_process").spawnSync;
+
+var REPO_ROOT = path.resolve(__dirname, "../../../..");
+var ALARM = path.join(REPO_ROOT, ".github", "scripts", "vendor-queue-alarm.sh");
+
+// This alarm tells a human that the plugin has stopped consuming knowledge. It
+// spent 2026-08-03 to 2026-08-11 saying so about a queue that had already
+// drained, because its body claims "this issue auto-closes when the queue
+// drains" and the only close path required ZERO open vendor PRs. The same
+// workflow opens a fresh vendor PR every night, so at the moment this step runs
+// the queue is almost never empty, and a stale alarm could survive forever.
+//
+// An alarm that cannot clear itself is worse than no alarm: it trains the
+// reader to ignore the label, which is the exact failure the queue alarm was
+// written to prevent.
+//
+// The step used to be inline shell in vendor-snapshot.yml, which is why nothing
+// tested it. It is a script now so these branches can actually be exercised.
+
+function stubGh(dir, fixtures) {
+  var log = path.join(dir, "gh.log");
+  // `%b` and not `%s`: the PR-list fixture is TSV, and with `%s` the \t and \n
+  // reach the script as literal backslash-t, so the production loop's
+  // `IFS=$'\t' read` sees one unsplittable field. The first version of this
+  // stub did exactly that and made a correct script look broken.
+  var script = [
+    "#!/usr/bin/env bash",
+    'printf "%s\\n" "$*" >> ' + JSON.stringify(log),
+    'case "$1 $2" in',
+    '  "pr list")',
+    "    printf '%b' " + JSON.stringify(fixtures.openPrs || ""),
+    "    ;;",
+    '  "issue list")',
+    "    printf '%b' " + JSON.stringify(fixtures.blockedIssues || ""),
+    "    ;;",
+    '  "pr view")',
+    // Which of the two `pr view` calls this is, by the field asked for.
+    '    if [[ "$*" == *statusCheckRollup* ]]; then',
+    "      printf '%b' " + JSON.stringify(String(fixtures.failedChecks || 0)),
+    "    else",
+    "      printf '%b' " + JSON.stringify(fixtures.dirty || ""),
+    "    fi",
+    "    ;;",
+    "esac",
+    "exit 0",
+    "",
+  ].join("\n");
+  fs.writeFileSync(path.join(dir, "gh"), script, { mode: 0o755 });
+  return log;
+}
+
+// A close is `gh issue close <number>`. Matching the bare words would also hit
+// the alarm body's own sentence about closing automatically, which is prose,
+// not a call.
+var CLOSE_CALL = /issue close [0-9]/;
+
+function runAlarm(fixtures) {
+  var dir = fs.mkdtempSync(path.join(os.tmpdir(), "vqa-"));
+  var log = stubGh(dir, fixtures);
+  var res = spawnSync("bash", [ALARM], {
+    encoding: "utf8",
+    env: Object.assign({}, process.env, { PATH: dir + ":" + process.env.PATH }),
+  });
+  return {
+    status: res.status,
+    calls: fs.existsSync(log) ? fs.readFileSync(log, "utf8") : "",
+    stdout: String(res.stdout || ""),
+    stderr: String(res.stderr || ""),
+  };
+}
+
+test("alarm: an empty vendor queue closes the open blocked issue", function () {
+  var r = runAlarm({ openPrs: "", blockedIssues: "272\n" });
+  assert.match(r.calls, CLOSE_CALL);
+  assert.match(r.calls, /issue close 272/);
+});
+
+test("alarm: a queue whose PRs are all healthy ALSO closes the open blocked issue", function () {
+  // The defect. There is an open vendor PR, because this very workflow just
+  // opened tonight's, and nothing about it is stuck. The plugin IS consuming
+  // knowledge again, so the alarm must clear. Before the fix this branch
+  // exited without touching the issue, and #272 outlived its own cause by
+  // eight days.
+  var r = runAlarm({
+    openPrs: "274\t2026-08-11\tvendor(knowledge): refresh to v0.34.122\n",
+    blockedIssues: "272\n",
+    failedChecks: 0,
+  });
+  assert.match(r.calls, CLOSE_CALL);
+  assert.match(r.calls, /issue close 272/);
+});
+
+test("alarm: a genuinely stuck PR still raises a new alarm", function () {
+  var r = runAlarm({
+    openPrs: "271\t2026-07-25\tvendor(knowledge): refresh to v0.34.122\n",
+    blockedIssues: "",
+    failedChecks: 1,
+  });
+  assert.match(r.calls, /issue create/);
+  assert.match(r.calls, /vendor-blocked/);
+  assert.doesNotMatch(r.calls, CLOSE_CALL);
+});
+
+test("alarm: a stuck PR with the alarm already open comments instead of duplicating it", function () {
+  var r = runAlarm({
+    openPrs: "271\t2026-07-25\tvendor(knowledge): refresh to v0.34.122\n",
+    blockedIssues: "272\n",
+    failedChecks: 1,
+  });
+  assert.match(r.calls, /issue comment 272/);
+  assert.doesNotMatch(r.calls, /issue create/);
+  assert.doesNotMatch(r.calls, CLOSE_CALL);
+});
+
+test("alarm: never fails the refresh it runs inside", function () {
+  // It is a best-effort reporter attached to a job that has real work to
+  // protect. Whatever it finds, it exits 0.
+  var r = runAlarm({
+    openPrs: "271\t2026-07-25\tsomething\n",
+    blockedIssues: "",
+    failedChecks: 1,
+  });
+  assert.equal(r.status, 0, r.stderr);
+});


### PR DESCRIPTION
## What this is

Part of roadmap item 5. While closing #272 I found it **could never have closed itself**, which makes it a defect rather than an oversight.

Its own body promised "this issue auto-closes when the queue drains". It could not: the only close path required **zero** open vendor PRs, and this same workflow opens tonight's vendor PR moments before the alarm step runs, so the queue is almost never empty at that point. When there were open PRs and none was stuck, the step simply exited. That is why #272 said the plugin was not consuming knowledge for **eight days** after the refresh had resumed.

An alarm that cannot clear itself is worse than no alarm: it trains the reader to ignore the label, which is the exact failure this alarm was written to prevent.

## My first fix was worse than the bug, and the review caught it

It read "gh told me nothing is stuck" and "gh could not tell me" as the same state. Verified by running the real script with a stub whose `pr view` exits 1: it emitted `gh issue close 272` claiming the plugin was consuming knowledge again. On a repo that had just lost **11 nights to an expired PAT**, that is the worst available failure mode, and the state it replaced was a harmless no-op. A silent no-op became an affirmative false all-clear.

## What it does now

Three explicit states:

| state | meaning | action |
|---|---|---|
| `stuck` | a failed check or merge conflicts | raise or update the alarm |
| `healthy` | every open PR positively reported success | clear the alarm |
| `unknown` | gh could not say, or checks have not reported | **touch nothing**, and say why |

Only a positive success reading clears. A failed `gh` call, a PR whose checks are still running, and a PR with no checks at all are all unknown. Pending matters because this step runs in the same workflow that just opened tonight's PR, so pending is the normal state moments after opening, and clearing on it would drop a real alarm on nothing but timing.

Also from the review:

- checks read as `.conclusion // .state`, so a red **legacy commit status** counts as stuck instead of passing as healthy
- a failed `gh pr list` no longer reads as a drained queue (an empty list and a failed list are the same empty string)
- the close is scoped to the alarm's **own title**, not to everything wearing the label, because the healthy path is now the frequently taken one and a human's issue can wear the label to be findable. Scoped by title rather than `--author @me` on purpose: an identity filter that failed to resolve under a CI token would silently stop the alarm clearing, which is the original bug again
- the workflow calls it as `bash <path> || true`, since a `run:` executes under `bash -e` and a lost exec bit must not fail a refresh whose real work succeeded

## Why it moved to a script

The step was inline shell in `vendor-snapshot.yml`, which is why nothing tested it and why the defect survived. It is now `.github/scripts/vendor-queue-alarm.sh` with all branches exercised against a stubbed `gh`. The tests pin the **queries** as well as the verdicts, because a stub answers whatever it is asked and would stay green if the `--json` fields or `--jq` filters were wrong.

A mutation check then found a gap in my own tests: deleting the exit-code guard left the whole suite green, because a `gh` that fails while printing nothing is already caught by the no-checks branch. So the exit code was being read by unverified code. Added the case only it can catch (gh printing a plausible answer, then failing) and confirmed removing the guard now reds exactly that test.

Suite **1971/1971**.