### PR TITLE
fix(render): the blank-box ceiling never ratcheted, so it hid the real progress

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@ are summarized at the release level.
 
 ### Fixed
 - **The blank-box gate was carrying 91 boxes of silent headroom, so the gray-box programme's real
-  progress was invisible inside the gate built to track it.** ([#PR](_PR link added at open_)) The gate
+  progress was invisible inside the gate built to track it.** ([#277](https://github.com/volivarii/Actian-DS-Claude-plugin/pull/277)) The gate
   shipped on 2026-07-13 with two literals in its test file, `BUDGET = 136` and `CHIP_BUDGET = 4`, both
   documented as ceilings that "RATCHET DOWN". Neither was ever lowered. Measured on 2026-08-11 the
   renderer emits **45 boxes and 2 chips**, so output could have tripled and still passed CI, while the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,24 @@ are summarized at the release level.
   `radio-button-card` at 1 accounting for the rest. Mutation-verified in three directions: a regression,
   an unbanked improvement, and a chip demotion each red the gate with the right classification.
 
+  An independent review then found that swapping a crude total for a name-keyed record gave up three
+  things the crude number had, all now restored. **The total bound is back alongside the per-slug
+  detail**, because it is the one assertion that does not depend on slug identity: keying only on names
+  let a box-count increase hide inside a rename (`radio-button-card` 1 becomes `radio-card` 8 was
+  classified as zero regressions, and the held knowledge tag sync performs exactly that rename) and let
+  a newly authorable unbuilt slug raise the count with nothing objecting. **`--write-baseline` now
+  refuses** while any slug has regressed or demoted to a chip, since the failure messages print that
+  command and an author following it would otherwise bank a regression riding along in the same change,
+  which is the laundering path the pinned ceilings could not take quietly. And **a bare chip that gains
+  real anatomy is classified as a promotion, not a regression**: it went from rendering nothing real to
+  rendering something, so the old classification had the one assertion that refuses to be banked
+  blocking a genuine improvement and telling the author to revert it.
+
+  Two smaller ones from the same pass: the false-zero control was gated on the baseline's own `total`,
+  a value the bank command can zero, so it is now a structural assertion about the detector against
+  synthetic markup that cannot be banked away or go stale; and the record's `total` is checked against
+  its own `perSlug` sum, so a hand edit cannot leave the two halves disagreeing in silence.
+
 - **The nightly vendor snapshot flows again, and four of the gates that blocked it no longer rot on
   normal Figma activity.** ([#PR](_PR link added at open_)) The knowledge v0.34.122 refresh PR had
   been red every night since 2026-07-25 (15 consecutive runs), so `main` stayed pinned at v0.34.117,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,27 @@ are summarized at the release level.
 ## [Unreleased]
 
 ### Fixed
+- **The blank-box gate was carrying 91 boxes of silent headroom, so the gray-box programme's real
+  progress was invisible inside the gate built to track it.** ([#PR](_PR link added at open_)) The gate
+  shipped on 2026-07-13 with two literals in its test file, `BUDGET = 136` and `CHIP_BUDGET = 4`, both
+  documented as ceilings that "RATCHET DOWN". Neither was ever lowered. Measured on 2026-08-11 the
+  renderer emits **45 boxes and 2 chips**, so output could have tripled and still passed CI, while the
+  drop from 136 to 45 appeared nowhere.
+
+  A hand-maintained number standing in for a fact the data already knows is the same defect class as the
+  hand-kept lists behind the 2026-07-25 outage. The baseline is now a generated per-slug record,
+  `tests/renderers/blank-box-baseline.json`, written by
+  `node scripts/renderers/ds-coverage-report.js --write-baseline`, and the rule is exact equality rather
+  than a ceiling. A regression becomes a reviewable diff line (`bar-graph: 25 -> 30`), which is louder
+  than a total creeping from 136 to 137, and an improvement also fails until it is banked, which is what
+  stops the number going stale a second time. A regression is deliberately **not** offered the
+  regenerate command, since that is how one would get laundered into a green check.
+
+  Per-slug rather than a total, because the total hides the shape of the remaining work: **42 of the 45
+  boxes are two chart components** (`bar-graph` 25, `line-graph` 17), with `checkbox-card` at 2 and
+  `radio-button-card` at 1 accounting for the rest. Mutation-verified in three directions: a regression,
+  an unbanked improvement, and a chip demotion each red the gate with the right classification.
+
 - **The nightly vendor snapshot flows again, and four of the gates that blocked it no longer rot on
   normal Figma activity.** ([#PR](_PR link added at open_)) The knowledge v0.34.122 refresh PR had
   been red every night since 2026-07-25 (15 consecutive runs), so `main` stayed pinned at v0.34.117,

--- a/plugins/actian-design-system/.claude-plugin/plugin.json
+++ b/plugins/actian-design-system/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "actian-design-system",
   "description": "Actian Design System toolkit — generate wireframe flows with prototype wiring, create component briefs, audit designs, compare flows, and build presentations. 8 skills (with tiered generation: recognized / adapted / improvised), 9 agents, 155 tokens (3 themes, 8 collections), WCAG 2.2 AA. DS knowledge vendored from volivarii/actian-ds-knowledge.",
-  "version": "2026.8.1",
+  "version": "2026.8.3",
   "author": {
     "name": "Actian UX Team"
   },

--- a/plugins/actian-design-system/scripts/renderers/ds-coverage-report.js
+++ b/plugins/actian-design-system/scripts/renderers/ds-coverage-report.js
@@ -148,16 +148,143 @@ function measureBlankBoxes(opts) {
   };
 }
 
+// Compare a measurement against the committed baseline record.
+//
+// The rule is exact equality, not a ceiling. The two literal ceilings this
+// replaces (BUDGET = 136, CHIP_BUDGET = 4, both dated 2026-07-13) were never
+// ratcheted, so by 2026-08-11 they allowed 136 boxes against an actual 45: the
+// gate would have passed a tripling of the output, and the programme's real
+// progress was invisible inside it. Equality against a generated per-slug
+// record cannot drift that way, and it turns a regression into a reviewable
+// diff line (25 became 30) instead of a total creeping by one.
+//
+// Every difference is classified rather than merely counted, because
+// "the number moved" is the advice that launders a regression: an improvement
+// and a regression need opposite responses, and a rename needs a third one.
+function compareBlankBoxes(baselineRecord, measured) {
+  var base = (baselineRecord && baselineRecord.perSlug) || {};
+  var now = (measured && measured.perSlug) || {};
+  var baseChips = ((baselineRecord && baselineRecord.chipSlugs) || []).slice();
+  var nowChips = ((measured && measured.chipSlugs) || []).slice();
+
+  var regressions = [];
+  var improvements = [];
+  var unlisted = [];
+  var disappeared = [];
+
+  Object.keys(base).forEach(function (slug) {
+    if (!Object.prototype.hasOwnProperty.call(now, slug)) {
+      disappeared.push({ slug: slug, from: base[slug] });
+      return;
+    }
+    if (now[slug] > base[slug]) {
+      regressions.push({ slug: slug, from: base[slug], to: now[slug] });
+    } else if (now[slug] < base[slug]) {
+      improvements.push({ slug: slug, from: base[slug], to: now[slug] });
+    }
+  });
+  Object.keys(now).forEach(function (slug) {
+    if (!Object.prototype.hasOwnProperty.call(base, slug)) {
+      unlisted.push({ slug: slug, to: now[slug] });
+    }
+  });
+
+  var newChips = nowChips.filter(function (s) {
+    return baseChips.indexOf(s) === -1;
+  });
+  var retiredChips = baseChips.filter(function (s) {
+    return nowChips.indexOf(s) === -1;
+  });
+
+  function sum(o) {
+    return Object.keys(o).reduce(function (t, k) {
+      return t + o[k];
+    }, 0);
+  }
+
+  return {
+    clean:
+      regressions.length === 0 &&
+      improvements.length === 0 &&
+      unlisted.length === 0 &&
+      disappeared.length === 0 &&
+      newChips.length === 0 &&
+      retiredChips.length === 0,
+    regressions: regressions,
+    improvements: improvements,
+    unlisted: unlisted,
+    disappeared: disappeared,
+    newChips: newChips,
+    retiredChips: retiredChips,
+    totalFrom: sum(base),
+    totalTo: sum(now),
+  };
+}
+
 module.exports = {
   coverage: coverage,
   authorableSlugs: authorableSlugs,
   measureBlankBoxes: measureBlankBoxes,
+  compareBlankBoxes: compareBlankBoxes,
 };
 
 if (require.main === module) {
   // Same lazy require as measureBlankBoxes(): the render stack is only needed
   // when this file runs as a CLI, never when it is imported for coverage().
   var BUILT_SLUGS = require("../lib/renderer.js").dsHtmlMap.BUILT_SLUGS;
+
+  // `--write-baseline` records what the renderer emits right now, which is how
+  // an improvement is banked. The gate compares against this file, so the file
+  // is the only place the number lives: nothing restates it in a test.
+  if (process.argv.indexOf("--write-baseline") !== -1) {
+    var fsW = require("fs");
+    var pathW = require("path");
+    var m = measureBlankBoxes();
+    var out = pathW.resolve(
+      __dirname,
+      "..",
+      "..",
+      "tests",
+      "renderers",
+      "blank-box-baseline.json",
+    );
+    var ordered = {};
+    Object.keys(m.perSlug)
+      .sort()
+      .forEach(function (k) {
+        ordered[k] = m.perSlug[k];
+      });
+    fsW.writeFileSync(
+      out,
+      JSON.stringify(
+        {
+          _meta: {
+            auto_generated: true,
+            source: "scripts/renderers/ds-coverage-report.js --write-baseline",
+            do_not_edit:
+              "Regenerate with `node scripts/renderers/ds-coverage-report.js --write-baseline`. Hand-editing this file is how the old pinned ceilings went stale.",
+          },
+          total: m.total,
+          perSlug: ordered,
+          chipSlugs: m.chipSlugs.slice().sort(),
+        },
+        null,
+        2,
+      ) + "\n",
+    );
+    process.stdout.write(
+      "wrote " +
+        out +
+        ": " +
+        m.total +
+        " blank boxes across " +
+        Object.keys(m.perSlug).length +
+        " unbuilt slugs, " +
+        m.chipSlugs.length +
+        " chip(s)\n",
+    );
+    process.exit(0);
+  }
 
   var slugs = authorableSlugs();
   var rows = coverage(slugs, { builtSlugs: BUILT_SLUGS });

--- a/plugins/actian-design-system/scripts/renderers/ds-coverage-report.js
+++ b/plugins/actian-design-system/scripts/renderers/ds-coverage-report.js
@@ -171,6 +171,7 @@ function compareBlankBoxes(baselineRecord, measured) {
   var improvements = [];
   var unlisted = [];
   var disappeared = [];
+  var chipPromotions = [];
 
   Object.keys(base).forEach(function (slug) {
     if (!Object.prototype.hasOwnProperty.call(now, slug)) {
@@ -178,7 +179,17 @@ function compareBlankBoxes(baselineRecord, measured) {
       return;
     }
     if (now[slug] > base[slug]) {
-      regressions.push({ slug: slug, from: base[slug], to: now[slug] });
+      // A slug that WAS a bare chip and is not one any more went from
+      // rendering nothing real to rendering something real, so its boxes went
+      // up because it started rendering at all. That is a promotion, not a
+      // regression. Classifying it as a regression made the one assertion that
+      // refuses to be banked block a genuine improvement and instruct the
+      // author to revert it.
+      if (baseChips.indexOf(slug) !== -1 && nowChips.indexOf(slug) === -1) {
+        chipPromotions.push({ slug: slug, from: base[slug], to: now[slug] });
+      } else {
+        regressions.push({ slug: slug, from: base[slug], to: now[slug] });
+      }
     } else if (now[slug] < base[slug]) {
       improvements.push({ slug: slug, from: base[slug], to: now[slug] });
     }
@@ -202,6 +213,9 @@ function compareBlankBoxes(baselineRecord, measured) {
     }, 0);
   }
 
+  var totalFrom = sum(base);
+  var totalTo = sum(now);
+
   return {
     clean:
       regressions.length === 0 &&
@@ -209,16 +223,56 @@ function compareBlankBoxes(baselineRecord, measured) {
       unlisted.length === 0 &&
       disappeared.length === 0 &&
       newChips.length === 0 &&
-      retiredChips.length === 0,
+      retiredChips.length === 0 &&
+      chipPromotions.length === 0,
     regressions: regressions,
     improvements: improvements,
     unlisted: unlisted,
     disappeared: disappeared,
     newChips: newChips,
     retiredChips: retiredChips,
-    totalFrom: sum(base),
-    totalTo: sum(now),
+    chipPromotions: chipPromotions,
+    totalFrom: totalFrom,
+    totalTo: totalTo,
+    // Reported on its own because it is the one bound that does NOT depend on
+    // slug identity. The ceiling this comparison replaced was crude but
+    // rename-immune; keying only on names let a box-count increase hide inside
+    // a rename (radio-button-card 1 -> radio-card 8 classified as zero
+    // regressions) and let a newly authorable unbuilt slug raise the count with
+    // nothing objecting.
+    totalRose: totalTo > totalFrom,
   };
+}
+
+// Which differences may be written into the baseline, and which must be fixed.
+//
+// The drift failure prints the bank command, so without a refusal an author
+// following that instruction banks any regression or chip demotion that happens
+// to ride along in the same change. The hand-edited ceilings this replaced could
+// not be raised silently: someone had to type a bigger number and say why.
+function bankable(diff) {
+  if (diff.regressions.length) {
+    return {
+      ok: false,
+      why:
+        "these slugs regressed and must be fixed, not recorded: " +
+        diff.regressions
+          .map(function (r) {
+            return r.slug + " " + r.from + " -> " + r.to;
+          })
+          .join(", "),
+    };
+  }
+  if (diff.newChips.length) {
+    return {
+      ok: false,
+      why:
+        "these slugs demoted to a bare chip and render nothing real, so this is " +
+        "not a state to record: " +
+        diff.newChips.join(", "),
+    };
+  }
+  return { ok: true, why: "" };
 }
 
 module.exports = {
@@ -226,6 +280,7 @@ module.exports = {
   authorableSlugs: authorableSlugs,
   measureBlankBoxes: measureBlankBoxes,
   compareBlankBoxes: compareBlankBoxes,
+  bankable: bankable,
 };
 
 if (require.main === module) {
@@ -248,6 +303,34 @@ if (require.main === module) {
       "renderers",
       "blank-box-baseline.json",
     );
+
+    // REFUSE to bank a regression.
+    //
+    // The gate's failure messages print this command, so without a refusal an
+    // author following that instruction would write any regression or chip
+    // demotion riding along in the same change into the record as the new
+    // truth. The hand-edited ceilings this replaced could not be raised
+    // silently: someone had to type a bigger number. A review found that
+    // banking freely gave back exactly the laundering path the change removed.
+    var current = null;
+    try {
+      current = JSON.parse(fsW.readFileSync(out, "utf8"));
+    } catch (e) {
+      current = null;
+    }
+    if (current) {
+      var verdict = bankable(compareBlankBoxes(current, m));
+      if (!verdict.ok) {
+        process.stderr.write(
+          "REFUSING to write the baseline: " +
+            verdict.why +
+            "\n\nFix the renderer. Recording this would make the regression the " +
+            "new normal, which is what the pinned ceilings could not do quietly " +
+            "either.\n",
+        );
+        process.exit(1);
+      }
+    }
     var ordered = {};
     Object.keys(m.perSlug)
       .sort()

--- a/plugins/actian-design-system/tests/renderers/blank-box-baseline.json
+++ b/plugins/actian-design-system/tests/renderers/blank-box-baseline.json
@@ -1,0 +1,22 @@
+{
+  "_meta": {
+    "auto_generated": true,
+    "source": "scripts/renderers/ds-coverage-report.js --write-baseline",
+    "do_not_edit": "Regenerate with `node scripts/renderers/ds-coverage-report.js --write-baseline`. Hand-editing this file is how the old pinned ceilings went stale."
+  },
+  "total": 45,
+  "perSlug": {
+    "alert-inline": 0,
+    "bar-graph": 25,
+    "checkbox-card": 2,
+    "glossary-item-hierarchy-diagram": 0,
+    "identification-key": 0,
+    "line-graph": 17,
+    "lineage-connecting-line": 0,
+    "radio-button-card": 1
+  },
+  "chipSlugs": [
+    "glossary-item-hierarchy-diagram",
+    "lineage-connecting-line"
+  ]
+}

--- a/plugins/actian-design-system/tests/renderers/blank-box-budget.test.js
+++ b/plugins/actian-design-system/tests/renderers/blank-box-budget.test.js
@@ -4,7 +4,7 @@ var { describe, it } = require("node:test");
 var assert = require("node:assert");
 var path = require("path");
 
-var { measureBlankBoxes } = require(
+var { measureBlankBoxes, compareBlankBoxes } = require(
   path.resolve(
     __dirname,
     "..",
@@ -15,35 +15,50 @@ var { measureBlankBoxes } = require(
   ),
 );
 
-// The number of empty grey placeholder boxes the DS HTML renderer emits across
-// the whole authorable vocabulary. This is a CEILING, and it RATCHETS DOWN:
+// The empty grey placeholder boxes the DS HTML renderer emits across the whole
+// authorable vocabulary. For most of this plugin's audience, PMs and others with
+// no Figma seat, that HTML render IS the product, so this count is a real
+// quality number and not bookkeeping.
 //
-//   2026-07-13  136  baseline (knowledge v0.34.96, 25 of 37 non-override slugs)
+// It used to be guarded by two literals in this file, BUDGET = 136 and
+// CHIP_BUDGET = 4, both baselined 2026-07-13 and described as ceilings that
+// "RATCHET DOWN". Neither was ever lowered. By 2026-08-11 the renderer emitted
+// 45 boxes and 2 chips, so the gate was carrying 91 boxes of silent headroom:
+// the output could have tripled and still passed, and the gray-box programme's
+// real win from 136 to 45 was invisible inside the very gate built to track it.
+// A hand-maintained number standing in for a fact the data already knows is the
+// same defect class as the hand-kept lists behind the 2026-07-25 outage.
 //
-// Lower it as each lane lands. NEVER raise it without saying, in the commit
-// message, which slugs regressed and why.
-var BUDGET = 136;
-
-// The number of authorable slugs that render a bare graceful-degradation chip
-// (ds-html-map.js's gracefulChip(), a `<span class="ds-component" ...>` with
-// no real anatomy). This is a SEPARATE ceiling from BUDGET, and it exists to
-// close a loophole: if the anatomy doc map partially collapses, slugs that
-// used to render real markup (and blank boxes) demote to chips instead. That
-// makes BUDGET look like it improved while the actual output got worse. This
-// ceiling also RATCHETS DOWN, never up, as slugs get real anatomy authored.
+// So the baseline is a GENERATED record, blank-box-baseline.json, and the rule
+// is exact equality rather than a ceiling:
 //
-//   2026-07-13  4  baseline (glossary-item-hierarchy-diagram, lineage-connecting-line,
-//                  notification-dropdown, scroll-bar)
-var CHIP_BUDGET = 4;
+//   * a regression is a reviewable diff line (bar-graph 25 became 30), which is
+//     louder than a total creeping from 136 to 137
+//   * an improvement also fails, until it is banked with
+//     `node scripts/renderers/ds-coverage-report.js --write-baseline`, which is
+//     what stops the number going stale a second time
+//
+// The count is deliberately per slug. Today 42 of the 45 boxes are two chart
+// components (bar-graph 25, line-graph 17), which a single total hides.
+var BASELINE = require("./blank-box-baseline.json");
 
 // measureBlankBoxes() re-parses the authoring markdown, rebuilds the doc map
-// over ~72 slugs, and re-renders 37 components: expensive to repeat, and
+// over ~72 slugs, and re-renders the unbuilt ones: expensive to repeat, and
 // every assertion below wants the identical measurement anyway. Compute once
 // and share it instead of calling it fresh from each `it` block.
 var cached = null;
 function renderAll() {
   if (!cached) cached = measureBlankBoxes();
   return cached;
+}
+
+function ratchetHint() {
+  return (
+    "\n\nIf this change is correct, bank it:\n" +
+    "  node scripts/renderers/ds-coverage-report.js --write-baseline\n" +
+    "and commit tests/renderers/blank-box-baseline.json, so the diff records " +
+    "which slugs moved and in which direction."
+  );
 }
 
 describe("blank-box budget", function () {
@@ -68,63 +83,117 @@ describe("blank-box budget", function () {
     );
   });
 
-  it("emits no more blank grey boxes than the budget", function () {
-    var r = renderAll();
-    var worst = Object.keys(r.perSlug)
-      .filter(function (s) {
-        return r.perSlug[s] > 0;
-      })
-      .sort(function (a, b) {
-        return r.perSlug[b] - r.perSlug[a];
-      })
-      .slice(0, 8)
-      .map(function (s) {
-        return s + ":" + r.perSlug[s];
-      })
-      .join(", ");
-    assert.ok(
-      r.total <= BUDGET,
-      "blank-box count regressed to " +
-        r.total +
-        " (budget " +
-        BUDGET +
-        "). " +
-        "Worst offenders: " +
-        worst,
+  it("no slug emits more blank grey boxes than the recorded baseline", function () {
+    var d = compareBlankBoxes(BASELINE, renderAll());
+    assert.deepEqual(
+      d.regressions,
+      [],
+      "blank-box count REGRESSED (total " +
+        d.totalFrom +
+        " -> " +
+        d.totalTo +
+        "). These slugs emit more empty boxes than they did:\n" +
+        d.regressions
+          .map(function (x) {
+            return "  " + x.slug + ": " + x.from + " -> " + x.to;
+          })
+          .join("\n") +
+        "\nFix the renderer. This one does not get banked: offering to " +
+        "regenerate the baseline here is exactly how a regression would be " +
+        "laundered into a green check.",
+    );
+  });
+
+  it("the recorded baseline still describes the real output, in both directions", function () {
+    var d = compareBlankBoxes(BASELINE, renderAll());
+    var parts = [];
+    if (d.improvements.length) {
+      parts.push(
+        "IMPROVED (record it):\n" +
+          d.improvements
+            .map(function (x) {
+              return "  " + x.slug + ": " + x.from + " -> " + x.to;
+            })
+            .join("\n"),
+      );
+    }
+    if (d.unlisted.length) {
+      parts.push(
+        "NOT IN THE BASELINE (a new or renamed slug):\n" +
+          d.unlisted
+            .map(function (x) {
+              return "  " + x.slug + ": " + x.to;
+            })
+            .join("\n"),
+      );
+    }
+    if (d.disappeared.length) {
+      parts.push(
+        "GONE FROM THE OUTPUT (removed, renamed, or newly built):\n" +
+          d.disappeared
+            .map(function (x) {
+              return "  " + x.slug + ": was " + x.from;
+            })
+            .join("\n"),
+      );
+    }
+    assert.equal(
+      parts.length,
+      0,
+      "the baseline no longer matches what the renderer emits (total " +
+        d.totalFrom +
+        " -> " +
+        d.totalTo +
+        ").\n" +
+        parts.join("\n") +
+        ratchetHint(),
     );
   });
 
   it("SANITY: the blank-box detector is not silently reading zero", function () {
-    // We know today's total is 136, not 0. If countBlankBoxes ever drifts out
-    // of sync with the markup shape it's matching against, it can silently
-    // return 0 for everything, and the budget assertion above passes
-    // vacuously (0 <= BUDGET is always true). This control forces a failure
-    // in that case instead of a false green.
-    //
-    // Self-retiring: when the blank-box count legitimately reaches 0, the
-    // fidelity job is done. At that point delete this control AND the
-    // BUDGET assertion above deliberately, rather than letting either rot.
+    // If countBlankBoxes drifts out of sync with the markup shape it matches
+    // against, it can silently return 0 for everything, and a comparison
+    // against a baseline of zeroes would pass vacuously. The expectation is
+    // derived from the record rather than written here as prose, so it cannot
+    // go stale, and it self-retires: when the real count legitimately reaches
+    // 0 the recorded total is 0 too and this control stops asserting.
     var r = renderAll();
-    assert.ok(
-      r.total > 0,
-      "expected a positive blank-box count (today's baseline is 136), got 0. " +
-        "This likely means countBlankBoxes stopped matching the emitted markup " +
-        "shape and is silently reading zero, not that the renderer got fixed.",
+    if (BASELINE.total > 0) {
+      assert.ok(
+        r.total > 0,
+        "the baseline records " +
+          BASELINE.total +
+          " blank boxes but this run measured 0. That is far more likely to " +
+          "mean countBlankBoxes stopped matching the emitted markup shape " +
+          "than that the renderer was fixed.",
+      );
+    }
+  });
+
+  it("emits no new bare graceful-degradation chips", function () {
+    // A bare chip means the slug renders nothing real, so a LOWER blank-box
+    // total from that slug is a demotion, not an improvement. This is the
+    // loophole the separate chip ceiling existed to close, kept as its own
+    // assertion because its failure reads differently from a box count.
+    var d = compareBlankBoxes(BASELINE, renderAll());
+    assert.deepEqual(
+      d.newChips,
+      [],
+      "these slugs demoted to a bare chip: " +
+        d.newChips.join(", ") +
+        ". They render nothing real now, so fix the renderer rather than " +
+        "recording it.",
     );
   });
 
-  it("emits no more bare graceful-degradation chips than the chip budget", function () {
-    var r = renderAll();
-    assert.ok(
-      r.chipSlugs.length <= CHIP_BUDGET,
-      "bare-chip count regressed to " +
-        r.chipSlugs.length +
-        " (budget " +
-        CHIP_BUDGET +
-        "). A bare chip means the slug renders nothing real, so a lower " +
-        "blank-box total from this slug is a demotion, not an improvement. " +
-        "Chip slugs: " +
-        r.chipSlugs.join(", "),
+  it("records a chip that gained real anatomy", function () {
+    var d = compareBlankBoxes(BASELINE, renderAll());
+    assert.deepEqual(
+      d.retiredChips,
+      [],
+      "these slugs are no longer bare chips, which is progress: " +
+        d.retiredChips.join(", ") +
+        ratchetHint(),
     );
   });
 });

--- a/plugins/actian-design-system/tests/renderers/blank-box-budget.test.js
+++ b/plugins/actian-design-system/tests/renderers/blank-box-budget.test.js
@@ -41,6 +41,9 @@ var { measureBlankBoxes, compareBlankBoxes } = require(
 // The count is deliberately per slug. Today 42 of the 45 boxes are two chart
 // components (bar-graph 25, line-graph 17), which a single total hides.
 var BASELINE = require("./blank-box-baseline.json");
+var { countBlankBoxes } = require(
+  path.resolve(__dirname, "..", "..", "scripts", "renderers", "renderability.js"),
+);
 
 // measureBlankBoxes() re-parses the authoring markdown, rebuilds the doc map
 // over ~72 slugs, and re-renders the unbuilt ones: expensive to repeat, and
@@ -53,11 +56,16 @@ function renderAll() {
 }
 
 function ratchetHint() {
+  // Written as a cd + relative path on purpose: the bare invocation printed by
+  // the first version failed when pasted from the repository root, and the one
+  // instruction a failure gives has to work as written.
   return (
     "\n\nIf this change is correct, bank it:\n" +
-    "  node scripts/renderers/ds-coverage-report.js --write-baseline\n" +
-    "and commit tests/renderers/blank-box-baseline.json, so the diff records " +
-    "which slugs moved and in which direction."
+    "  cd plugins/actian-design-system && \\\n" +
+    "    node scripts/renderers/ds-coverage-report.js --write-baseline\n" +
+    "then commit tests/renderers/blank-box-baseline.json, so the diff records " +
+    "which slugs moved and in which direction. It refuses to write while any " +
+    "slug has regressed or demoted to a chip."
   );
 }
 
@@ -127,6 +135,16 @@ describe("blank-box budget", function () {
             .join("\n"),
       );
     }
+    if (d.chipPromotions.length) {
+      parts.push(
+        "PROMOTED from a bare chip to real markup (progress, record it):\n" +
+          d.chipPromotions
+            .map(function (x) {
+              return "  " + x.slug + ": " + x.from + " -> " + x.to;
+            })
+            .join("\n"),
+      );
+    }
     if (d.disappeared.length) {
       parts.push(
         "GONE FROM THE OUTPUT (removed, renamed, or newly built):\n" +
@@ -150,24 +168,67 @@ describe("blank-box budget", function () {
     );
   });
 
-  it("SANITY: the blank-box detector is not silently reading zero", function () {
-    // If countBlankBoxes drifts out of sync with the markup shape it matches
-    // against, it can silently return 0 for everything, and a comparison
-    // against a baseline of zeroes would pass vacuously. The expectation is
-    // derived from the record rather than written here as prose, so it cannot
-    // go stale, and it self-retires: when the real count legitimately reaches
-    // 0 the recorded total is 0 too and this control stops asserting.
-    var r = renderAll();
-    if (BASELINE.total > 0) {
-      assert.ok(
-        r.total > 0,
-        "the baseline records " +
-          BASELINE.total +
-          " blank boxes but this run measured 0. That is far more likely to " +
-          "mean countBlankBoxes stopped matching the emitted markup shape " +
-          "than that the renderer was fixed.",
-      );
-    }
+  it("SANITY: the blank-box detector still recognises a blank box", function () {
+    // The false-zero control used to be `r.total > 0`, then briefly
+    // `BASELINE.total > 0` gating that same check. A review found the second
+    // form self-disarming: BASELINE.total is written by the very bank command
+    // the sibling failures print, so banking one broken measurement would zero
+    // it and skip this control for good.
+    //
+    // Assert the detector against markup instead of against the corpus. This
+    // cannot be banked away, cannot go stale, and does not need retiring when
+    // the real count legitimately reaches zero.
+    var blank = '<div class="ds-appearance__vector" style="width:8px"></div>';
+    assert.equal(countBlankBoxes(blank), 1, "a blank vector box must count");
+    assert.equal(
+      countBlankBoxes('<div class="ds-appearance__vector">real content</div>'),
+      0,
+      "a box with content in it is not blank",
+    );
+    assert.equal(countBlankBoxes(blank + blank), 2, "counts every occurrence");
+  });
+
+  it("the committed baseline is internally consistent", function () {
+    // total is a separate field from perSlug, so a hand edit or a bad merge can
+    // leave the two halves of the record disagreeing with each other while
+    // nothing says so.
+    var summed = Object.keys(BASELINE.perSlug).reduce(function (t, k) {
+      return t + BASELINE.perSlug[k];
+    }, 0);
+    assert.equal(
+      BASELINE.total,
+      summed,
+      "blank-box-baseline.json's total does not match its own perSlug sum, so " +
+        "it was edited by hand rather than regenerated",
+    );
+  });
+
+  it("the total number of blank boxes never rises, whatever the slugs are called", function () {
+    // The rename-immune bound. The crude ceiling this replaced could not be
+    // dodged by renaming a slug; a name-keyed comparison can be, and the held
+    // knowledge tag sync renames radio-button-card to radio-card. A newly
+    // authorable unbuilt slug lands here too.
+    var d = compareBlankBoxes(BASELINE, renderAll());
+    assert.equal(
+      d.totalRose,
+      false,
+      "blank boxes rose from " +
+        d.totalFrom +
+        " to " +
+        d.totalTo +
+        ". Contributors:\n" +
+        d.regressions
+          .concat(d.unlisted.map(function (u) {
+            return { slug: u.slug + " (new)", from: 0, to: u.to };
+          }))
+          .map(function (x) {
+            return "  " + x.slug + ": " + x.from + " -> " + x.to;
+          })
+          .join("\n") +
+        "\nA slug rename cannot hide inside this assertion, which is why it is " +
+        "kept alongside the per-slug ones." +
+        ratchetHint(),
+    );
   });
 
   it("emits no new bare graceful-degradation chips", function () {

--- a/plugins/actian-design-system/tests/renderers/blank-box-compare.test.js
+++ b/plugins/actian-design-system/tests/renderers/blank-box-compare.test.js
@@ -114,3 +114,103 @@ test("compareBlankBoxes: the totals both ways are reported, so the message can s
   assert.equal(d.totalFrom, 15);
   assert.equal(d.totalTo, 11);
 });
+
+// ---------------------------------------------------------------------------
+// Review findings, 2026-08-11. The first version of this comparison replaced a
+// total-based ceiling with a name-keyed one, and a review found that trade let
+// three things through that the crude old number caught.
+// ---------------------------------------------------------------------------
+
+test("compareBlankBoxes: a rename is not a hiding place for a box-count increase", function () {
+  // The old total ceiling was rename-immune; keying on slug names alone was not.
+  // radio-button-card becomes radio-card in the held knowledge tag sync, so this
+  // is the live case: 1 box becomes 8 and nothing was classified a regression.
+  var d = R.compareBlankBoxes(baseline({ "radio-button-card": 1 }), {
+    perSlug: { "radio-card": 8 },
+    chipSlugs: [],
+  });
+  assert.equal(
+    d.totalRose,
+    true,
+    "the total rising must be reported on its own, independent of slug identity",
+  );
+  assert.equal(d.totalFrom, 1);
+  assert.equal(d.totalTo, 8);
+});
+
+test("compareBlankBoxes: a newly authorable slug that emits boxes makes the total rise", function () {
+  var d = R.compareBlankBoxes(baseline({ "bar-graph": 25 }), {
+    perSlug: { "bar-graph": 25, "pie-graph": 9 },
+    chipSlugs: [],
+  });
+  assert.equal(d.totalRose, true);
+  assert.deepEqual(d.unlisted, [{ slug: "pie-graph", to: 9 }]);
+});
+
+test("compareBlankBoxes: a chip that gained real anatomy is progress, not a regression", function () {
+  // A bare chip renders NOTHING real, so going from 0 boxes to some boxes is a
+  // promotion. Classifying it as a regression made the one assertion that
+  // refuses to be banked block a genuine improvement and tell the author to
+  // revert it.
+  var d = R.compareBlankBoxes(
+    baseline({ "lineage-connecting-line": 0 }, ["lineage-connecting-line"]),
+    { perSlug: { "lineage-connecting-line": 3 }, chipSlugs: [] },
+  );
+  assert.deepEqual(d.regressions, [], "not a regression");
+  assert.deepEqual(d.chipPromotions, [
+    { slug: "lineage-connecting-line", from: 0, to: 3 },
+  ]);
+  assert.deepEqual(d.retiredChips, ["lineage-connecting-line"]);
+});
+
+test("compareBlankBoxes: a real regression on a slug that is still a chip is still a regression", function () {
+  var d = R.compareBlankBoxes(baseline({ x: 2 }, ["x"]), {
+    perSlug: { x: 9 },
+    chipSlugs: ["x"],
+  });
+  assert.deepEqual(d.regressions, [{ slug: "x", from: 2, to: 9 }]);
+  assert.deepEqual(d.chipPromotions, []);
+});
+
+test("compareBlankBoxes: a falling total is not flagged as a rise", function () {
+  var d = R.compareBlankBoxes(baseline({ a: 10 }), {
+    perSlug: { a: 2 },
+    chipSlugs: [],
+  });
+  assert.equal(d.totalRose, false);
+});
+
+test("bankable: a regression may not be banked, so --write-baseline must refuse", function () {
+  // The drift failure prints the bank command. Without a refusal, an author
+  // following that instruction banks any regression or demotion riding along in
+  // the same change, which the old hand-edited ceilings could not do silently.
+  var withRegression = R.compareBlankBoxes(baseline({ a: 5 }), {
+    perSlug: { a: 9 },
+    chipSlugs: [],
+  });
+  assert.equal(R.bankable(withRegression).ok, false);
+  assert.match(R.bankable(withRegression).why, /regress/i);
+});
+
+test("bankable: a new chip demotion may not be banked either", function () {
+  var withDemotion = R.compareBlankBoxes(baseline({}, []), {
+    perSlug: {},
+    chipSlugs: ["scroll-bar"],
+  });
+  assert.equal(R.bankable(withDemotion).ok, false);
+  assert.match(R.bankable(withDemotion).why, /chip/i);
+});
+
+test("bankable: an improvement, a rename and a chip promotion are all bankable", function () {
+  var improvement = R.compareBlankBoxes(baseline({ a: 10 }), {
+    perSlug: { a: 2 },
+    chipSlugs: [],
+  });
+  assert.equal(R.bankable(improvement).ok, true);
+
+  var promotion = R.compareBlankBoxes(baseline({ c: 0 }, ["c"]), {
+    perSlug: { c: 4 },
+    chipSlugs: [],
+  });
+  assert.equal(R.bankable(promotion).ok, true);
+});

--- a/plugins/actian-design-system/tests/renderers/blank-box-compare.test.js
+++ b/plugins/actian-design-system/tests/renderers/blank-box-compare.test.js
@@ -1,0 +1,116 @@
+"use strict";
+var test = require("node:test");
+var assert = require("node:assert/strict");
+var path = require("path");
+
+var R = require(
+  path.resolve(
+    __dirname,
+    "..",
+    "..",
+    "scripts",
+    "renderers",
+    "ds-coverage-report.js",
+  ),
+);
+
+// Why this comparison exists at all.
+//
+// The blank-box gate shipped on 2026-07-13 with two literals in the test file:
+// BUDGET = 136 and CHIP_BUDGET = 4, described as ceilings that "RATCHET DOWN".
+// Neither was ever lowered. Measured on 2026-08-11 the renderer emits 45 boxes
+// and 2 chips, so the gate carried 91 boxes of silent headroom: output could
+// have tripled and still passed, while the gray-box programme's real win from
+// 136 to 45 was invisible in the very gate built to track it.
+//
+// A hand-maintained number standing in for a fact the data already knows is the
+// same defect class as the hand-kept lists behind the 2026-07-25 outage. So the
+// baseline is now a generated per-slug record, and the rule is exact equality:
+// the committed baseline must equal what the renderer actually emits. A
+// regression shows up as a diff line saying 25 became 30, which is louder than
+// a total creeping from 136 to 137, and an improvement has to be recorded to go
+// green, which is what keeps the number true.
+
+function baseline(perSlug, chipSlugs) {
+  return { perSlug: perSlug, chipSlugs: chipSlugs || [] };
+}
+
+test("compareBlankBoxes: an exact match is clean", function () {
+  var d = R.compareBlankBoxes(
+    baseline({ "bar-graph": 25, "checkbox-card": 2 }, ["scroll-bar"]),
+    { perSlug: { "bar-graph": 25, "checkbox-card": 2 }, chipSlugs: ["scroll-bar"] },
+  );
+  assert.equal(d.clean, true);
+  assert.deepEqual(d.regressions, []);
+  assert.deepEqual(d.improvements, []);
+});
+
+test("compareBlankBoxes: a slug emitting MORE boxes than recorded is a regression", function () {
+  var d = R.compareBlankBoxes(baseline({ "bar-graph": 25 }), {
+    perSlug: { "bar-graph": 30 },
+    chipSlugs: [],
+  });
+  assert.equal(d.clean, false);
+  assert.deepEqual(d.regressions, [
+    { slug: "bar-graph", from: 25, to: 30 },
+  ]);
+});
+
+test("compareBlankBoxes: a slug emitting FEWER boxes is an improvement, and still has to be recorded", function () {
+  var d = R.compareBlankBoxes(baseline({ "bar-graph": 25 }), {
+    perSlug: { "bar-graph": 4 },
+    chipSlugs: [],
+  });
+  assert.equal(d.clean, false, "an unrecorded improvement is not clean");
+  assert.deepEqual(d.improvements, [{ slug: "bar-graph", from: 25, to: 4 }]);
+  assert.deepEqual(d.regressions, []);
+});
+
+test("compareBlankBoxes: a slug the baseline has never seen is reported as unlisted", function () {
+  var d = R.compareBlankBoxes(baseline({ "bar-graph": 25 }), {
+    perSlug: { "bar-graph": 25, "pie-graph": 9 },
+    chipSlugs: [],
+  });
+  assert.deepEqual(d.unlisted, [{ slug: "pie-graph", to: 9 }]);
+});
+
+test("compareBlankBoxes: a recorded slug that vanished is reported, since a rename must not pass silently", function () {
+  // radio-button-card becomes radio-card in the held tag sync, so this is the
+  // live case, not a hypothetical.
+  var d = R.compareBlankBoxes(baseline({ "radio-button-card": 1 }), {
+    perSlug: { "radio-card": 1 },
+    chipSlugs: [],
+  });
+  assert.deepEqual(d.disappeared, [{ slug: "radio-button-card", from: 1 }]);
+  assert.deepEqual(d.unlisted, [{ slug: "radio-card", to: 1 }]);
+});
+
+test("compareBlankBoxes: a new graceful-degradation chip is a regression", function () {
+  // The loophole the separate chip ceiling was written to close: a slug that
+  // used to render real markup can demote to a bare chip, which makes the box
+  // count look better while the output got worse.
+  var d = R.compareBlankBoxes(baseline({}, ["scroll-bar"]), {
+    perSlug: {},
+    chipSlugs: ["scroll-bar", "notification-dropdown"],
+  });
+  assert.equal(d.clean, false);
+  assert.deepEqual(d.newChips, ["notification-dropdown"]);
+});
+
+test("compareBlankBoxes: a chip that gained real anatomy is an improvement", function () {
+  var d = R.compareBlankBoxes(baseline({}, ["scroll-bar", "lineage-connecting-line"]), {
+    perSlug: {},
+    chipSlugs: ["scroll-bar"],
+  });
+  assert.deepEqual(d.retiredChips, ["lineage-connecting-line"]);
+  assert.deepEqual(d.newChips, []);
+});
+
+test("compareBlankBoxes: the totals both ways are reported, so the message can state direction", function () {
+  var d = R.compareBlankBoxes(baseline({ a: 10, b: 5 }), {
+    perSlug: { a: 10, b: 1 },
+    chipSlugs: [],
+  });
+  assert.equal(d.totalFrom, 15);
+  assert.equal(d.totalTo, 11);
+});


### PR DESCRIPTION
## What this is

Roadmap item 3 from the 2026-08-11 assessment. The gate shipped on 2026-07-13 with two literals in its test file, `BUDGET = 136` and `CHIP_BUDGET = 4`, both documented as ceilings that "RATCHET DOWN". **Neither was ever lowered.**

| | CI ceiling | actual today | slack |
|---|---|---|---|
| blank placeholder boxes | 136 | **45** | 91 boxes, ~3x headroom |
| bare fallback chips | 4 | **2** | 2 |

So the output could have tripled and still passed CI, while the gray-box programme's real drop from 136 to 45 appeared nowhere. A hand-maintained number standing in for a fact the data already knows is the same defect class as the hand-kept lists behind the 2026-07-25 outage.

## What it does

The baseline is now a generated per-slug record, `tests/renderers/blank-box-baseline.json`, written by `--write-baseline`, and the rule is exact equality rather than a ceiling. A regression becomes a reviewable diff line (`bar-graph: 25 -> 30`), which is louder than a total creeping from 136 to 137, and an unbanked improvement also fails, which is what stops the number going stale a second time.

**Per slug and not a total, because the total hides the shape of the remaining work:**

```
bar-graph        25
line-graph       17
checkbox-card     2
radio-button-card 1
(4 more at 0)
```

**42 of the 45 boxes are two chart components.** That resizes Wave 3 item 13 in the roadmap: what is left of gray-box-to-zero is essentially the two charts, which are dataviz pictures rather than interactive components, not "8 components' worth of work".

## Review found three properties the crude old number had, now restored

An independent pass found that swapping a total for a name-keyed record gave things up:

1. **The total bound is back**, alongside the per-slug detail. It is the one assertion that does not depend on slug identity: keying only on names let a box-count increase hide inside a rename (`radio-button-card` 1 → `radio-card` 8 was classified as zero regressions), and the held knowledge tag sync performs exactly that rename. A newly authorable unbuilt slug lands here too.
2. **`--write-baseline` now refuses** while any slug has regressed or demoted to a chip. The failure messages print that command, so without a refusal an author following the instruction banks whatever regression rode along in the same change. The pinned ceilings could not be raised that quietly.
3. **A bare chip that gains real anatomy is a promotion, not a regression.** It went from rendering nothing real to rendering something, so the old classification had the one assertion that refuses to be banked blocking a genuine improvement and telling the author to revert it.

Two smaller ones: the false-zero control was gated on the baseline's own `total`, a value the bank command can zero, so one bank of a dead detector would have disarmed it permanently; it is now a structural assertion about `countBlankBoxes` against synthetic markup, which cannot be banked away or go stale. And the record's `total` is checked against its own `perSlug` sum, so a hand edit cannot leave the halves disagreeing in silence.

## Verification

- Mutation-verified in three directions: a regression, an unbanked improvement, and a chip demotion each red the gate with the right classification
- A clean bank is idempotent (no diff); a doctored regression is refused with the slug named
- Suite **1977/1977**

## Note on merge order

Version is `2026.8.3`, not `.2`, because the sibling PR #276 took `.2`. Distinct versions mean either merge order passes `check-version-bump`, which compares against the merge base.