### PR TITLE
fix(tests): derive the tag specimen and drop the non-invariant category relation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,31 @@ are summarized at the release level.
 ## [Unreleased]
 
 ### Fixed
+- **Two tests hardcoded facts that a Figma redesign was about to invalidate, and one of them would have
+  kept passing while asserting nothing.** ([#280](https://github.com/volivarii/Actian-DS-Claude-plugin/pull/280)) Both were filed as
+  #275 when they were found by running the next sync locally rather than by CI, and both went live when
+  the knowledge repo merged its tag fold-in (knowledge #522, v0.34.124).
+
+  `categories.test.js` asserted that a non-COMPONENTS category equals its Figma page clean-name,
+  verified 252/252 when it shipped. That is not an invariant: knowledge's `preserveKnownCategories`
+  deliberately carries a component's last-known category forward when Figma's page attribution churns,
+  which decouples the two by design. The assertion was also redundant, because the relation that does
+  hold, `categories.json` against `registry.category`, is already asserted a few tests further down.
+  The page-name half is gone; the curated closed-set half, which encodes a real decision, stays.
+
+  The tag deliverable test drove `parseVariant("Color=Purple")`. The fold-in replaced `tag-default`'s
+  `Color` axis with a `Type` axis, so that resolves to nothing, the variant appearance silently equals
+  the base, and the test's own precondition stops meaning anything while still reporting green. It now
+  picks its specimen at run time from whatever axis the anatomy publishes, naming neither `Color` nor
+  `Type`, the way `tests/helpers/appearance-specimen.js` picks a slug instead of naming one. Verified
+  on both snapshots (it selects `Color=Indigo` on the vendored v0.34.122 and `Type=Catalog` on
+  v0.34.124), and it can no longer pass vacuously: an empty axis, a missing axis, or a first value
+  matching the base all raise rather than skip.
+
+  The lesson is the one already written into `tests/helpers/appearance-specimen.js`: a test that names
+  a specimen rots the moment the design system reorganizes, and it rots quietly, because the assertion
+  survives while its subject disappears.
+
 - **The blank-box gate was carrying 91 boxes of silent headroom, so the gray-box programme's real
   progress was invisible inside the gate built to track it.** ([#277](https://github.com/volivarii/Actian-DS-Claude-plugin/pull/277)) The gate
   shipped on 2026-07-13 with two literals in its test file, `BUDGET = 136` and `CHIP_BUDGET = 4`, both

--- a/plugins/actian-design-system/.claude-plugin/plugin.json
+++ b/plugins/actian-design-system/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "actian-design-system",
   "description": "Actian Design System toolkit — generate wireframe flows with prototype wiring, create component briefs, audit designs, compare flows, and build presentations. 8 skills (with tiered generation: recognized / adapted / improvised), 9 agents, 155 tokens (3 themes, 8 collections), WCAG 2.2 AA. DS knowledge vendored from volivarii/actian-ds-knowledge.",
-  "version": "2026.8.4",
+  "version": "2026.8.5",
   "author": {
     "name": "Actian UX Team"
   },

--- a/plugins/actian-design-system/.claude-plugin/plugin.json
+++ b/plugins/actian-design-system/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "actian-design-system",
   "description": "Actian Design System toolkit — generate wireframe flows with prototype wiring, create component briefs, audit designs, compare flows, and build presentations. 8 skills (with tiered generation: recognized / adapted / improvised), 9 agents, 155 tokens (3 themes, 8 collections), WCAG 2.2 AA. DS knowledge vendored from volivarii/actian-ds-knowledge.",
-  "version": "2026.8.3",
+  "version": "2026.8.4",
   "author": {
     "name": "Actian UX Team"
   },

--- a/plugins/actian-design-system/tests/integration/categories.test.js
+++ b/plugins/actian-design-system/tests/integration/categories.test.js
@@ -5,8 +5,7 @@
 //
 // Asserts:
 //   1. categories.json structure is valid and matches the known shape.
-//   2. Every COMPONENTS-section category is in the curated closed set, and
-//      every other category equals its Figma page clean-name.
+//   2. Every COMPONENTS-section category is in the curated closed set.
 //   3. Every component slug listed in categories.json exists in the
 //      DS Kit registry.
 //   4. Every DS Kit registry entry with a `category` field is
@@ -57,28 +56,21 @@ const COMPONENTS_CATEGORIES = new Set([
 // The old failure message compounded it by advising an update to
 // transform-categories.js, which for a Foundations page has nothing to update.
 //
-// What replaced it asserts the relation instead of the membership: a
-// non-COMPONENTS category must equal the clean page name of every component
-// filed under it. That still catches the drift this file exists to catch (a hand
-// edit to categories.json, or a vendor snapshot that pulled one file and not the
-// other, which would break the relation), and it cannot rot when Figma gains a
-// page. Verified against v0.34.122: 252/252 non-COMPONENTS members match, and
-// 0/71 COMPONENTS members do, since those categories are curated groupings
-// spanning many pages.
-
-// Mirrors LEADING_EMOJI_RE + extractStatus() in the knowledge repo's
-// scripts/transformers/component-status-emoji.js, which is what produces the
-// `category` value in the first place. Mirroring the rule (rather than
-// stripping any leading symbol) keeps the two in agreement even for a page
-// prefixed with an emoji outside the status map, e.g. "⚪️ Calendar": knowledge
-// leaves that one intact, and so does this.
-const LEADING_STATUS_EMOJI_RE = /^\s*(✅|✍️|⛔️|⚠️)\s+(.*?)\s*$/;
-
-function pageCleanName(page) {
-  const raw = String(page == null ? "" : page);
-  const m = LEADING_STATUS_EMOJI_RE.exec(raw);
-  return m ? m[2] : raw.trim();
-}
+// #275 (2026-08-12): what replaced NON_COMPONENTS_CATEGORIES in turn (a
+// "non-COMPONENTS category must equal the clean page name of every component
+// filed under it" relation) was ALSO wrong, for a different reason: knowledge's
+// preserveKnownCategories (knowledge #426) deliberately carries a component's
+// last-known category forward when Figma's page attribution churns, which
+// decouples the two by design. The 2026-08-12 sync did exactly that -- a page
+// was renamed while the category stayed put -- and 4 components mismatched for
+// a reason that was never a defect either. That check is gone; there is no
+// replacement, because the relation it was reaching for (categories.json
+// against registry.category) already has an assertion below ("DS Kit registry
+// — every component with a category is cross-referenced in categories.json"),
+// verified at 327/327 on the 2026-08-12 data since the sync writes both from
+// the same computed value. The only thing this file still asserts about
+// non-COMPONENTS categories is nothing: there is deliberately no invariant to
+// check beyond "every category-bearing component is cross-referenced."
 
 function loadJSON(p) {
   return JSON.parse(require("fs").readFileSync(p, "utf8"));
@@ -98,7 +90,7 @@ test("categories.json — structure", () => {
   );
 });
 
-test("categories.json — COMPONENTS categories are the curated closed set; every other category is its page clean-name", () => {
+test("categories.json — every COMPONENTS-section category is in the curated closed set", () => {
   const c = loadJSON(PATHS.components.categories);
   const reg = loadJSON(PATHS.components.registries.dskit);
 
@@ -107,7 +99,6 @@ test("categories.json — COMPONENTS categories are the curated closed set; ever
   // more. A gate that reveals its findings one nightly at a time is a gate that
   // takes four nights to read.
   const unknownComponentsCategories = [];
-  const nameMismatches = [];
 
   for (const [name, entry] of Object.entries(c.categories)) {
     for (const slug of entry.components) {
@@ -116,18 +107,8 @@ test("categories.json — COMPONENTS categories are the curated closed set; ever
       // "every listed slug exists in DS Kit registry" test below.
       if (!comp) continue;
 
-      if (comp.section === "Components") {
-        if (!COMPONENTS_CATEGORIES.has(name)) {
-          unknownComponentsCategories.push(`${name} (via ${slug})`);
-        }
-        continue;
-      }
-
-      const expected = pageCleanName(comp.page);
-      if (expected !== name) {
-        nameMismatches.push(
-          `${slug}: category '${name}' != page clean-name '${expected}'`,
-        );
+      if (comp.section === "Components" && !COMPONENTS_CATEGORIES.has(name)) {
+        unknownComponentsCategories.push(`${name} (via ${slug})`);
       }
     }
   }
@@ -139,14 +120,6 @@ test("categories.json — COMPONENTS categories are the curated closed set; ever
       "This one IS a decision: each curated category needs a *-defaults.json under " +
       "vendor/components/dist/categories/, so add it here AND in the knowledge repo's " +
       "transform-categories.js KNOWN_CATEGORIES, or fix the Figma page's category header",
-  );
-
-  assert.deepEqual(
-    nameMismatches.sort(),
-    [],
-    "outside the COMPONENTS section a category is defined as the Figma page clean-name, " +
-      "so a mismatch means categories.json and the registry disagree: a hand edit, or a " +
-      "vendor snapshot that pulled one file and not the other",
   );
 });
 

--- a/plugins/actian-design-system/tests/integration/flow-share-variant-tag-deliverable.test.js
+++ b/plugins/actian-design-system/tests/integration/flow-share-variant-tag-deliverable.test.js
@@ -50,6 +50,55 @@ const { parseVariant } = require("../../scripts/lib/renderer.js").dsHtmlMap;
 // carries one, and its absence is asserted too: if the substrate has no border,
 // the deliverable must not invent one. That turns the stale expectation into a
 // fidelity guard that can fail in both directions.
+//
+// #275 (2026-08-12): the SPECIMEN itself rotted the same way a hardcoded slug
+// does in tests/helpers/appearance-specimen.js. This test drove
+// parseVariant("Color=Purple"); the 2026-08-12 fold-in (knowledge v0.34.124)
+// replaced tag-default's `Color` axis (7 values) with a `Type` axis (14
+// values: Default, Catalog, Shared, Stage-1..8, Status-error/-warning/
+// -success), so "Color=Purple" resolves to nothing against the new data --
+// no matching entry in appearance.variants, so resolveNodeAppearance returns
+// the base unchanged, and the "must differ from the base appearance"
+// precondition below fails. pickColoredVariant() below applies
+// appearance-specimen.js's pattern to this problem instead: read the axis
+// name and a value straight off the anatomy doc's own appearance.variants
+// array (the same structure resolveNodeAppearance itself walks), and pick
+// whichever entry's resolved background actually differs from the base. No
+// axis name or value is named here, so it is correct whether the doc's axis
+// is `Color`, `Type`, or something else entirely next time it is redesigned.
+
+// Pick a `<prop>=<value>` variant string straight from tag-default's own
+// anatomy doc rather than naming one. Mirrors pickSpecimen() in
+// tests/helpers/appearance-specimen.js: walk real candidates in a
+// deterministic order (the array order the anatomy doc itself carries) and
+// return the first one that satisfies the caller's predicate, throwing
+// loudly -- not silently returning the base -- if none do.
+function pickColoredVariant(doc, base) {
+  const deltas = (doc.root.appearance && doc.root.appearance.variants) || [];
+  for (const entry of deltas) {
+    if (!entry || !entry.prop || !Array.isArray(entry.values)) continue;
+    for (const value of entry.values) {
+      const variantString = `${entry.prop}=${value}`;
+      const resolved = appearanceRender.resolveNodeAppearance(
+        doc.root,
+        parseVariant(variantString),
+      );
+      if (
+        resolved &&
+        resolved.background &&
+        resolved.background !== base.background
+      ) {
+        return { variantString, appearance: resolved };
+      }
+    }
+  }
+  throw new Error(
+    "tag-default's anatomy doc carries no appearance.variants entry whose " +
+      "background differs from the base -- this test has no colored " +
+      "specimen left; retire or repoint it rather than letting it pass " +
+      "vacuously against an empty/uniform population",
+  );
+}
 
 test("flow-share deliverable: tag-default renders per-variant colors from the appearance layer, keeps its instance label, and never injects a fallback-less var(--token)", () => {
   const doc = anatomyRender.loadAnatomy("tag-default");
@@ -58,29 +107,46 @@ test("flow-share deliverable: tag-default renders per-variant colors from the ap
     "tag-default anatomy doc must load (precondition)",
   );
 
-  const purpleVariant = parseVariant("Color=Purple");
-  const defaultVariant = parseVariant("Color=Default");
-
   const base = appearanceRender.resolveNodeAppearance(doc.root, null);
-  const purple = appearanceRender.resolveNodeAppearance(
-    doc.root,
-    purpleVariant,
+
+  // The axis + value are derived, never named (see pickColoredVariant above
+  // and the #275 header note). "Default" is read from the doc's own
+  // variantDefaults rather than assumed, for the same reason.
+  const { variantString: coloredVariantString, appearance: colored } =
+    pickColoredVariant(doc, base);
+  const [axisProp] = Object.keys(doc.variantDefaults || {});
+  assert.ok(
+    axisProp,
+    "tag-default's anatomy doc must declare variantDefaults (precondition)",
   );
+  const defaultVariantString = `${axisProp}=${doc.variantDefaults[axisProp]}`;
+  // The class modifiers the deliverable's ds-tag spans are expected to carry:
+  // derived from the SAME values picked above, not a second hardcoded name,
+  // so each tracks whichever value its source actually returned.
+  const coloredClassSuffix = String(
+    coloredVariantString.split("=")[1],
+  ).toLowerCase();
+  const defaultClassSuffix = String(
+    defaultVariantString.split("=")[1],
+  ).toLowerCase();
+
+  const defaultVariant = parseVariant(defaultVariantString);
+
   const def = appearanceRender.resolveNodeAppearance(doc.root, defaultVariant);
 
   assert.ok(
-    purple && purple.background,
-    "Color=Purple must resolve a background (precondition)",
+    colored && colored.background,
+    `${coloredVariantString} must resolve a background (precondition)`,
   );
   assert.notStrictEqual(
-    purple.background,
+    colored.background,
     base.background,
-    "Color=Purple must differ from the base appearance (precondition: otherwise nothing to inject)",
+    `${coloredVariantString} must differ from the base appearance (precondition: otherwise nothing to inject)`,
   );
   assert.deepStrictEqual(
     def,
     base,
-    "Color=Default must equal the base appearance (precondition: default renders via ds-base.css, no injection)",
+    `${defaultVariantString} must equal the base appearance (precondition: default renders via ds-base.css, no injection)`,
   );
 
   const flow = {
@@ -93,14 +159,14 @@ test("flow-share deliverable: tag-default renders per-variant colors from the ap
             type: "INSTANCE",
             library: "ds",
             dsSlug: "tag-default",
-            variant: "Color=Purple",
+            variant: coloredVariantString,
             props: { Label: "Tag" },
           },
           {
             type: "INSTANCE",
             library: "ds",
             dsSlug: "tag-default",
-            variant: "Color=Default",
+            variant: defaultVariantString,
             props: { Label: "Draft Items" },
           },
         ],
@@ -115,10 +181,10 @@ test("flow-share deliverable: tag-default renders per-variant colors from the ap
     html.includes('class="ds-tag ds-tag--'),
     "renders the hand-authored ds-tag span, not anatomy divs",
   );
-  assert.ok(html.includes("Tag"), "Purple tag keeps its instance label");
+  assert.ok(html.includes("Tag"), "colored tag keeps its instance label");
   assert.ok(
     html.includes("Draft Items"),
-    "Default tag keeps its instance label",
+    "default tag keeps its instance label",
   );
 
   // The colored variant's span carries an inline style sourced from the
@@ -127,56 +193,62 @@ test("flow-share deliverable: tag-default renders per-variant colors from the ap
   // actually captured, rather than against a fixed background+border shape:
   // the 2026-07-23 tag redesign removed tag borders outright, and hardcoding
   // the old shape is what turned a substrate change into a red vendor PR.
-  const purpleMatch = html.match(
-    /<span class="ds-tag ds-tag--purple" style="([^"]*)">Tag<\/span>/,
+  // The class suffix is the derived value (coloredClassSuffix), not a
+  // hardcoded color name -- see the #275 header note.
+  const coloredMatch = html.match(
+    new RegExp(
+      '<span class="ds-tag ds-tag--' +
+        coloredClassSuffix.replace(/[.*+?^${}()|[\]\\]/g, "\\$&") +
+        '" style="([^"]*)">Tag</span>',
+    ),
   );
   assert.ok(
-    purpleMatch,
-    "Color=Purple must render a ds-tag--purple span with an injected inline style, got: " +
+    coloredMatch,
+    `${coloredVariantString} must render a ds-tag--${coloredClassSuffix} span with an injected inline style, got: ` +
       (html.match(/<span class="ds-tag[^>]*>/g) || []).join(" "),
   );
-  const purpleDecls = purpleMatch[1]
+  const coloredDecls = coloredMatch[1]
     .split(";")
     .map(function (d) {
       return d.trim();
     })
     .filter(Boolean);
   assert.ok(
-    purpleDecls.includes("background:" + purple.background),
-    "Color=Purple's span must inject the appearance layer's real background value (" +
-      purple.background +
+    coloredDecls.includes("background:" + colored.background),
+    `${coloredVariantString}'s span must inject the appearance layer's real background value (` +
+      colored.background +
       "), got: " +
-      purpleDecls.join(";"),
+      coloredDecls.join(";"),
   );
-  if (purple.border && purple.border.color) {
+  if (colored.border && colored.border.color) {
     assert.ok(
-      purpleDecls.includes("border-color:" + purple.border.color),
+      coloredDecls.includes("border-color:" + colored.border.color),
       "the appearance layer captured a border, so the span must inject its real value (" +
-        purple.border.color +
+        colored.border.color +
         "), got: " +
-        purpleDecls.join(";"),
+        coloredDecls.join(";"),
     );
   } else {
     // Fidelity guard, and the reason this branch is an assertion rather than a
     // skip: Figma draws no border on tags any more, so a border in the
     // deliverable would be the renderer inventing one.
     assert.ok(
-      !purpleDecls.some(function (d) {
+      !coloredDecls.some(function (d) {
         return d.startsWith("border");
       }),
       "the appearance layer captured no border for tag-default, so the deliverable " +
         "must not invent one, got: " +
-        purpleDecls.join(";"),
+        coloredDecls.join(";"),
     );
   }
 
   // The DEFAULT variant equals the base appearance, so buildDsVariantStyleMap
   // emits no map entry for it: no injected style at all, ds-base.css owns
   // the default pill's background/border.
-  const defaultSpan = '<span class="ds-tag ds-tag--default">Draft Items</span>';
+  const defaultSpan = `<span class="ds-tag ds-tag--${defaultClassSuffix}">Draft Items</span>`;
   assert.ok(
     html.includes(defaultSpan),
-    "Color=Default's ds-tag span must carry NO injected inline style (ds-base.css owns the default), got no match for: " +
+    `${defaultVariantString}'s ds-tag span must carry NO injected inline style (ds-base.css owns the default), got no match for: ` +
       defaultSpan,
   );
 
@@ -198,11 +270,15 @@ test("flow-share deliverable: tag-default renders per-variant colors from the ap
   });
 
   // Phase 2: the colour class must not dangle. Before the plugin consumed the
-  // vendored styling source it emitted ds-tag--purple with no backing rule,
-  // because the plugin's own ds-base.css predated phase 1b.
+  // vendored styling source it emitted a color modifier class with no
+  // backing rule, because the plugin's own ds-base.css predated phase 1b.
   assert.ok(
-    /\.ds-tag--purple\s*\{/.test(html),
-    "the emitted ds-tag--purple class has no rule in the deliverable CSS: " +
+    new RegExp(
+      "\\.ds-tag--" +
+        coloredClassSuffix.replace(/[.*+?^${}()|[\]\\]/g, "\\$&") +
+        "\\s*\\{",
+    ).test(html),
+    `the emitted ds-tag--${coloredClassSuffix} class has no rule in the deliverable CSS: ` +
       "FLOW_CSS is not reading the vendored ds-base.css",
   );
 });


### PR DESCRIPTION
Closes #275. Both defects are the ones that issue named, and both have just become live: knowledge merged its tag fold-in yesterday (knowledge #522, v0.34.124), so the next vendor refresh brings the data that trips them.

## The requirement these fixes had to meet

Each fix has to be correct on **both** snapshots: the currently vendored v0.34.122 (where `tag-default` publishes a `Color` axis) and the incoming v0.34.124 (where that axis is replaced by `Type`, 14 values). A change that merely passes today, or merely passes tomorrow, would be the same class of defect as the one being fixed.

## 1. `categories.test.js`: the page-clean-name relation is not invariant

#273 asserted that a non-COMPONENTS category equals its Figma page clean-name, verified 252/252 on that snapshot. It is not an invariant: knowledge's `preserveKnownCategories` deliberately carries a component's last-known category forward when Figma's page attribution churns, which decouples the two by design. On the new capture a page was renamed while the category stayed, so four components mismatch.

The half that was deleted was also **redundant**: the relation that does hold is `categories.json` against `registry.category`, and `categories.test.js:146` already asserts exactly that. `pageCleanName` and `LEADING_STATUS_EMOJI_RE` go with it.

The surviving COMPONENTS closed-set assertion still encodes a real decision (a curated category needs a `*-defaults.json`), and review confirmed it is not tautological by feeding it a synthetic component filed under an uncurated category, which threw as expected.

## 2. The tag deliverable test hardcoded `Color=Purple`

`parseVariant("Color=Purple")` resolves to nothing once the axis is `Type`, so the variant appearance equals the base and the test's own precondition silently stops meaning anything.

It now picks the specimen at run time from whatever axis the anatomy publishes, the way `tests/helpers/appearance-specimen.js` picks a slug rather than naming one. It never mentions `Color` or `Type`.

**Verified on both snapshots, independently by the reviewer:** picks `Color=Indigo` on vendored v0.34.122, and `Type=Catalog` on knowledge's v0.34.124. It also handles the new data's grouped-value shape (`values: ["Catalog","Stage-5"]`) correctly.

**It cannot pass vacuously**, which was the original failure mode. Three degenerate cases were simulated (empty `variants`, missing `variants`, and a first entry whose background equals the base) and all three **throw** rather than skipping or passing. The selection loops until it finds a value that actually differs from the base.

The border half of the test is untouched: #273 rewrote it to assert against whatever the appearance layer carries, and it handles this redesign correctly in both directions.

## Verification

Full suite `1963 pass / 0 fail`, plus the two pre-existing sandbox timeouts (`pilot-fidelity.integration.test.js`, `quality-gates-cli.test.js`) that hang on subprocess launches regardless of this diff. Mutation-checked: forcing the derivation to return an unpublished value reds the test.

## Known minors, named rather than quietly carried

- `const [axisProp] = Object.keys(doc.variantDefaults || {})` takes the first key without confirming it is the axis the specimen was picked from. Harmless while `tag-default` has exactly one axis on both snapshots, would mismatch if it ever grew a second.
- The test's class-suffix helpers use plain `.toLowerCase()` where production also does `.replace(/\s+/g, "-")`. Fine because no `Type` value contains a space, but not a byte-for-byte mirror of production.

## What this PR deliberately does NOT do

The vendor refresh to v0.34.124 is not included. When it lands, **11 further tests fail**, all because the plugin's own renderer, its four tag golden snapshots, and its vendored-styling assertion still encode the retired `Color` axis. That is a separate slice, and one of those failures is caused by a rule-less `ds-tag--with-icon` class in knowledge's render output that is being removed upstream first, so this repo does not adapt to something about to disappear.