### PR TITLE
Refresh to knowledge v0.34.132, restoring the category guidance 16 components lost

### DIFF
--- a/plugins/actian-design-system/.claude-plugin/plugin.json
+++ b/plugins/actian-design-system/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "actian-design-system",
   "description": "Actian Design System toolkit — generate wireframe flows with prototype wiring, create component briefs, audit designs, compare flows, and build presentations. 8 skills (with tiered generation: recognized / adapted / improvised), 9 agents, 155 tokens (3 themes, 8 collections), WCAG 2.2 AA. DS knowledge vendored from volivarii/actian-ds-knowledge.",
-  "version": "2026.8.7",
+  "version": "2026.8.8",
   "author": {
     "name": "Actian UX Team"
   },

--- a/plugins/actian-design-system/vendor/components/dist/guidelines/calendar.json
+++ b/plugins/actian-design-system/vendor/components/dist/guidelines/calendar.json
@@ -8,7 +8,7 @@
   "slug": "calendar",
   "component": "Calendar",
   "meta": {
-    "category": "form-input-selection",
+    "category": "form",
     "a11y_refs": [
       {
         "ref": "forms"
@@ -164,5 +164,5 @@
       "status": "not-started"
     }
   },
-  "updated_at": "2026-07-12T11:29:30+02:00"
+  "updated_at": "2026-08-14T15:49:03+02:00"
 }

--- a/plugins/actian-design-system/vendor/components/dist/guidelines/checkbox.json
+++ b/plugins/actian-design-system/vendor/components/dist/guidelines/checkbox.json
@@ -8,7 +8,7 @@
   "slug": "checkbox",
   "component": "Checkboxes",
   "meta": {
-    "category": "form-input-selection",
+    "category": "form",
     "a11y_refs": [
       {
         "ref": "forms"
@@ -897,5 +897,5 @@
       ]
     }
   },
-  "updated_at": "2026-07-23T16:24:56+02:00"
+  "updated_at": "2026-08-14T15:49:03+02:00"
 }

--- a/plugins/actian-design-system/vendor/components/dist/guidelines/combo-box.json
+++ b/plugins/actian-design-system/vendor/components/dist/guidelines/combo-box.json
@@ -8,7 +8,7 @@
   "slug": "combo-box",
   "component": "Combo box",
   "meta": {
-    "category": "form-input-selection",
+    "category": "form",
     "a11y_refs": [
       {
         "ref": "forms"
@@ -165,5 +165,5 @@
       "status": "not-started"
     }
   },
-  "updated_at": "2026-07-12T11:29:30+02:00"
+  "updated_at": "2026-08-14T15:49:03+02:00"
 }

--- a/plugins/actian-design-system/vendor/components/dist/guidelines/dropdown-select-default.json
+++ b/plugins/actian-design-system/vendor/components/dist/guidelines/dropdown-select-default.json
@@ -8,7 +8,7 @@
   "slug": "dropdown-select",
   "component": "Dropdown / Select",
   "meta": {
-    "category": "form-input-selection",
+    "category": "form",
     "a11y_refs": [
       {
         "ref": "forms"
@@ -154,6 +154,6 @@
       "status": "not-started"
     }
   },
-  "updated_at": "2026-07-23T16:24:56+02:00",
+  "updated_at": "2026-08-14T15:49:03+02:00",
   "_alias_of": "dropdown-select"
 }

--- a/plugins/actian-design-system/vendor/components/dist/guidelines/dropdown-select.json
+++ b/plugins/actian-design-system/vendor/components/dist/guidelines/dropdown-select.json
@@ -8,7 +8,7 @@
   "slug": "dropdown-select",
   "component": "Dropdown / Select",
   "meta": {
-    "category": "form-input-selection",
+    "category": "form",
     "a11y_refs": [
       {
         "ref": "forms"
@@ -154,5 +154,5 @@
       "status": "not-started"
     }
   },
-  "updated_at": "2026-07-23T16:24:56+02:00"
+  "updated_at": "2026-08-14T15:49:03+02:00"
 }

--- a/plugins/actian-design-system/vendor/components/dist/guidelines/guidelines.bundle.json
+++ b/plugins/actian-design-system/vendor/components/dist/guidelines/guidelines.bundle.json
@@ -1193,7 +1193,7 @@
       "slug": "calendar",
       "component": "Calendar",
       "meta": {
-        "category": "form-input-selection",
+        "category": "form",
         "a11y_refs": [
           {
             "ref": "forms"
@@ -1349,7 +1349,7 @@
           "status": "not-started"
         }
       },
-      "updated_at": "2026-07-12T11:29:30+02:00"
+      "updated_at": "2026-08-14T15:49:03+02:00"
     },
     "card": {
       "_schema_version": 1,
@@ -2775,7 +2775,7 @@
       "slug": "checkbox",
       "component": "Checkboxes",
       "meta": {
-        "category": "form-input-selection",
+        "category": "form",
         "a11y_refs": [
           {
             "ref": "forms"
@@ -3664,7 +3664,7 @@
           ]
         }
       },
-      "updated_at": "2026-07-23T16:24:56+02:00"
+      "updated_at": "2026-08-14T15:49:03+02:00"
     },
     "collapse-accordion": {
       "_schema_version": 1,
@@ -3839,7 +3839,7 @@
       "slug": "combo-box",
       "component": "Combo box",
       "meta": {
-        "category": "form-input-selection",
+        "category": "form",
         "a11y_refs": [
           {
             "ref": "forms"
@@ -3996,7 +3996,7 @@
           "status": "not-started"
         }
       },
-      "updated_at": "2026-07-12T11:29:30+02:00"
+      "updated_at": "2026-08-14T15:49:03+02:00"
     },
     "confirmation": {
       "_schema_version": 1,
@@ -4449,7 +4449,7 @@
       "slug": "dropdown-select",
       "component": "Dropdown / Select",
       "meta": {
-        "category": "form-input-selection",
+        "category": "form",
         "a11y_refs": [
           {
             "ref": "forms"
@@ -4595,7 +4595,7 @@
           "status": "not-started"
         }
       },
-      "updated_at": "2026-07-23T16:24:56+02:00"
+      "updated_at": "2026-08-14T15:49:03+02:00"
     },
     "dropdown-select-default": {
       "_schema_version": 1,
@@ -4607,7 +4607,7 @@
       "slug": "dropdown-select",
       "component": "Dropdown / Select",
       "meta": {
-        "category": "form-input-selection",
+        "category": "form",
         "a11y_refs": [
           {
             "ref": "forms"
@@ -4753,7 +4753,7 @@
           "status": "not-started"
         }
       },
-      "updated_at": "2026-07-23T16:24:56+02:00",
+      "updated_at": "2026-08-14T15:49:03+02:00",
       "_alias_of": "dropdown-select"
     },
     "empty-state": {
@@ -5687,7 +5687,7 @@
       "slug": "input-date",
       "component": "Date input",
       "meta": {
-        "category": "form-input-selection",
+        "category": "form",
         "related": [
           "calendar",
           "text-input"
@@ -6473,7 +6473,7 @@
           "status": "not-started"
         }
       },
-      "updated_at": "2026-07-12T11:29:30+02:00"
+      "updated_at": "2026-08-14T15:49:03+02:00"
     },
     "link": {
       "_schema_version": 1,
@@ -7578,7 +7578,7 @@
       "slug": "multi-select",
       "component": "Multi-select",
       "meta": {
-        "category": "form-input-selection",
+        "category": "form",
         "a11y_refs": [
           {
             "ref": "forms"
@@ -7741,7 +7741,7 @@
           "status": "not-started"
         }
       },
-      "updated_at": "2026-07-23T16:24:56+02:00"
+      "updated_at": "2026-08-14T15:49:03+02:00"
     },
     "notification": {
       "_schema_version": 1,
@@ -8797,7 +8797,7 @@
       "slug": "radio",
       "component": "Radio",
       "meta": {
-        "category": "form-input-selection",
+        "category": "form",
         "a11y_refs": [
           {
             "ref": "forms"
@@ -9582,7 +9582,7 @@
           "status": "not-started"
         }
       },
-      "updated_at": "2026-07-23T16:24:56+02:00"
+      "updated_at": "2026-08-14T15:49:03+02:00"
     },
     "rich-text": {
       "_schema_version": 1,
@@ -9594,7 +9594,7 @@
       "slug": "rich-text",
       "component": "Rich text",
       "meta": {
-        "category": "form-input-selection",
+        "category": "form",
         "a11y_refs": [
           {
             "ref": "forms"
@@ -9742,7 +9742,7 @@
           "status": "not-started"
         }
       },
-      "updated_at": "2026-07-12T11:29:30+02:00"
+      "updated_at": "2026-08-14T15:49:03+02:00"
     },
     "scroll-bar": {
       "_schema_version": 1,
@@ -9903,7 +9903,7 @@
       "slug": "search",
       "component": "Search",
       "meta": {
-        "category": "form-input-selection",
+        "category": "form",
         "a11y_refs": [
           {
             "ref": "forms"
@@ -10140,7 +10140,7 @@
           ]
         }
       },
-      "updated_at": "2026-07-12T11:29:30+02:00"
+      "updated_at": "2026-08-14T15:49:03+02:00"
     },
     "search-dropdown-menu": {
       "_schema_version": 1,
@@ -10152,7 +10152,7 @@
       "slug": "search-dropdown-menu",
       "component": "Search dropdown menu",
       "meta": {
-        "category": "form-input-selection",
+        "category": "form",
         "a11y_refs": [
           {
             "ref": "dropdowns-menus-popovers"
@@ -10313,7 +10313,7 @@
           "status": "not-started"
         }
       },
-      "updated_at": "2026-07-12T11:29:30+02:00"
+      "updated_at": "2026-08-14T15:49:03+02:00"
     },
     "search-filters": {
       "_schema_version": 1,
@@ -10325,7 +10325,7 @@
       "slug": "search-filters",
       "component": "Filters",
       "meta": {
-        "category": "form-input-selection",
+        "category": "form",
         "a11y_refs": [
           {
             "ref": "forms"
@@ -10471,7 +10471,7 @@
           "status": "not-started"
         }
       },
-      "updated_at": "2026-07-12T11:29:30+02:00"
+      "updated_at": "2026-08-14T15:49:03+02:00"
     },
     "search-result-card": {
       "_schema_version": 1,
@@ -10639,7 +10639,7 @@
       "slug": "segmented-control",
       "component": "Segmented control",
       "meta": {
-        "category": "form-input-selection",
+        "category": "form",
         "a11y_refs": [
           {
             "ref": "tabs"
@@ -11235,7 +11235,7 @@
           "status": "not-started"
         }
       },
-      "updated_at": "2026-07-23T16:24:56+02:00"
+      "updated_at": "2026-08-14T15:49:03+02:00"
     },
     "side-nav": {
       "_schema_version": 1,
@@ -13613,7 +13613,7 @@
       "slug": "text-input",
       "component": "Text input",
       "meta": {
-        "category": "form-input-selection",
+        "category": "form",
         "a11y_refs": [
           {
             "ref": "forms"
@@ -14497,7 +14497,7 @@
           ]
         }
       },
-      "updated_at": "2026-07-12T02:45:52+02:00"
+      "updated_at": "2026-08-14T15:49:03+02:00"
     },
     "toggle": {
       "_schema_version": 1,
@@ -14509,7 +14509,7 @@
       "slug": "toggle",
       "component": "Toggle control",
       "meta": {
-        "category": "form-input-selection",
+        "category": "form",
         "a11y_refs": [
           {
             "ref": "forms"
@@ -15275,7 +15275,7 @@
           "status": "not-started"
         }
       },
-      "updated_at": "2026-07-23T16:24:56+02:00"
+      "updated_at": "2026-08-14T15:49:03+02:00"
     },
     "toolbar": {
       "_schema_version": 1,
@@ -15592,7 +15592,7 @@
       "slug": "upload-file",
       "component": "Upload file",
       "meta": {
-        "category": "form-input-selection",
+        "category": "form",
         "a11y_refs": [
           {
             "ref": "forms"
@@ -15750,7 +15750,7 @@
           "status": "not-started"
         }
       },
-      "updated_at": "2026-07-12T11:29:30+02:00"
+      "updated_at": "2026-08-14T15:49:03+02:00"
     },
     "whats-new-dropdown": {
       "_schema_version": 1,

--- a/plugins/actian-design-system/vendor/components/dist/guidelines/input-date.json
+++ b/plugins/actian-design-system/vendor/components/dist/guidelines/input-date.json
@@ -8,7 +8,7 @@
   "slug": "input-date",
   "component": "Date input",
   "meta": {
-    "category": "form-input-selection",
+    "category": "form",
     "related": [
       "calendar",
       "text-input"
@@ -794,5 +794,5 @@
       "status": "not-started"
     }
   },
-  "updated_at": "2026-07-12T11:29:30+02:00"
+  "updated_at": "2026-08-14T15:49:03+02:00"
 }

--- a/plugins/actian-design-system/vendor/components/dist/guidelines/multi-select.json
+++ b/plugins/actian-design-system/vendor/components/dist/guidelines/multi-select.json
@@ -8,7 +8,7 @@
   "slug": "multi-select",
   "component": "Multi-select",
   "meta": {
-    "category": "form-input-selection",
+    "category": "form",
     "a11y_refs": [
       {
         "ref": "forms"
@@ -171,5 +171,5 @@
       "status": "not-started"
     }
   },
-  "updated_at": "2026-07-23T16:24:56+02:00"
+  "updated_at": "2026-08-14T15:49:03+02:00"
 }

--- a/plugins/actian-design-system/vendor/components/dist/guidelines/radio.json
+++ b/plugins/actian-design-system/vendor/components/dist/guidelines/radio.json
@@ -8,7 +8,7 @@
   "slug": "radio",
   "component": "Radio",
   "meta": {
-    "category": "form-input-selection",
+    "category": "form",
     "a11y_refs": [
       {
         "ref": "forms"
@@ -793,5 +793,5 @@
       "status": "not-started"
     }
   },
-  "updated_at": "2026-07-23T16:24:56+02:00"
+  "updated_at": "2026-08-14T15:49:03+02:00"
 }

--- a/plugins/actian-design-system/vendor/components/dist/guidelines/rich-text.json
+++ b/plugins/actian-design-system/vendor/components/dist/guidelines/rich-text.json
@@ -8,7 +8,7 @@
   "slug": "rich-text",
   "component": "Rich text",
   "meta": {
-    "category": "form-input-selection",
+    "category": "form",
     "a11y_refs": [
       {
         "ref": "forms"
@@ -156,5 +156,5 @@
       "status": "not-started"
     }
   },
-  "updated_at": "2026-07-12T11:29:30+02:00"
+  "updated_at": "2026-08-14T15:49:03+02:00"
 }

--- a/plugins/actian-design-system/vendor/components/dist/guidelines/search-dropdown-menu.json
+++ b/plugins/actian-design-system/vendor/components/dist/guidelines/search-dropdown-menu.json
@@ -8,7 +8,7 @@
   "slug": "search-dropdown-menu",
   "component": "Search dropdown menu",
   "meta": {
-    "category": "form-input-selection",
+    "category": "form",
     "a11y_refs": [
       {
         "ref": "dropdowns-menus-popovers"
@@ -169,5 +169,5 @@
       "status": "not-started"
     }
   },
-  "updated_at": "2026-07-12T11:29:30+02:00"
+  "updated_at": "2026-08-14T15:49:03+02:00"
 }

--- a/plugins/actian-design-system/vendor/components/dist/guidelines/search-filters.json
+++ b/plugins/actian-design-system/vendor/components/dist/guidelines/search-filters.json
@@ -8,7 +8,7 @@
   "slug": "search-filters",
   "component": "Filters",
   "meta": {
-    "category": "form-input-selection",
+    "category": "form",
     "a11y_refs": [
       {
         "ref": "forms"
@@ -154,5 +154,5 @@
       "status": "not-started"
     }
   },
-  "updated_at": "2026-07-12T11:29:30+02:00"
+  "updated_at": "2026-08-14T15:49:03+02:00"
 }

--- a/plugins/actian-design-system/vendor/components/dist/guidelines/search.json
+++ b/plugins/actian-design-system/vendor/components/dist/guidelines/search.json
@@ -8,7 +8,7 @@
   "slug": "search",
   "component": "Search",
   "meta": {
-    "category": "form-input-selection",
+    "category": "form",
     "a11y_refs": [
       {
         "ref": "forms"
@@ -245,5 +245,5 @@
       ]
     }
   },
-  "updated_at": "2026-07-12T11:29:30+02:00"
+  "updated_at": "2026-08-14T15:49:03+02:00"
 }

--- a/plugins/actian-design-system/vendor/components/dist/guidelines/segmented-control.json
+++ b/plugins/actian-design-system/vendor/components/dist/guidelines/segmented-control.json
@@ -8,7 +8,7 @@
   "slug": "segmented-control",
   "component": "Segmented control",
   "meta": {
-    "category": "form-input-selection",
+    "category": "form",
     "a11y_refs": [
       {
         "ref": "tabs"
@@ -604,5 +604,5 @@
       "status": "not-started"
     }
   },
-  "updated_at": "2026-07-23T16:24:56+02:00"
+  "updated_at": "2026-08-14T15:49:03+02:00"
 }

--- a/plugins/actian-design-system/vendor/components/dist/guidelines/text-input.json
+++ b/plugins/actian-design-system/vendor/components/dist/guidelines/text-input.json
@@ -8,7 +8,7 @@
   "slug": "text-input",
   "component": "Text input",
   "meta": {
-    "category": "form-input-selection",
+    "category": "form",
     "a11y_refs": [
       {
         "ref": "forms"
@@ -892,5 +892,5 @@
       ]
     }
   },
-  "updated_at": "2026-07-12T02:45:52+02:00"
+  "updated_at": "2026-08-14T15:49:03+02:00"
 }

--- a/plugins/actian-design-system/vendor/components/dist/guidelines/toggle.json
+++ b/plugins/actian-design-system/vendor/components/dist/guidelines/toggle.json
@@ -8,7 +8,7 @@
   "slug": "toggle",
   "component": "Toggle control",
   "meta": {
-    "category": "form-input-selection",
+    "category": "form",
     "a11y_refs": [
       {
         "ref": "forms"
@@ -774,5 +774,5 @@
       "status": "not-started"
     }
   },
-  "updated_at": "2026-07-23T16:24:56+02:00"
+  "updated_at": "2026-08-14T15:49:03+02:00"
 }

--- a/plugins/actian-design-system/vendor/components/dist/guidelines/upload-file.json
+++ b/plugins/actian-design-system/vendor/components/dist/guidelines/upload-file.json
@@ -8,7 +8,7 @@
   "slug": "upload-file",
   "component": "Upload file",
   "meta": {
-    "category": "form-input-selection",
+    "category": "form",
     "a11y_refs": [
       {
         "ref": "forms"
@@ -166,5 +166,5 @@
       "status": "not-started"
     }
   },
-  "updated_at": "2026-07-12T11:29:30+02:00"
+  "updated_at": "2026-08-14T15:49:03+02:00"
 }

--- a/plugins/actian-design-system/vendor/components/render/dist/usage-notes/calendar.md
+++ b/plugins/actian-design-system/vendor/components/render/dist/usage-notes/calendar.md
@@ -19,4 +19,7 @@ The calendar lets users pick a date or date range from a visual month view. It a
 - Use a single, consistent date format across the product. Spell out or abbreviate the month to avoid ambiguity. For example, "Jun 28, 2026".
 - For a range, label both ends clearly as "Start date" and "End date".
 
+## Category guidance (inherited: design, behavior)
+Inputs and selections converge on Label → Control → Helper → Validation as the dominant anatomy across mature DSes. The `Label position` variant captures the dense-form vs comfortable-form authoring choice. The six accessibility refs map to WCAG criteria that apply to every form control regardless of subtype.
+
 > Note: includes guidance not yet ratified: DRAFT (usage); INHERITED from category (design, behavior).

--- a/plugins/actian-design-system/vendor/components/render/dist/usage-notes/checkbox.md
+++ b/plugins/actian-design-system/vendor/components/render/dist/usage-notes/checkbox.md
@@ -23,4 +23,7 @@ Checkboxes let users select one or more options from a list. They are used for c
 - Keep labels parallel in style and length for readability.
 - Avoid jargon and abbreviations.
 
+## Category guidance (inherited: design, behavior)
+Inputs and selections converge on Label → Control → Helper → Validation as the dominant anatomy across mature DSes. The `Label position` variant captures the dense-form vs comfortable-form authoring choice. The six accessibility refs map to WCAG criteria that apply to every form control regardless of subtype.
+
 > Note: includes guidance not yet ratified: DRAFT (usage); INHERITED from category (design, behavior).

--- a/plugins/actian-design-system/vendor/components/render/dist/usage-notes/combo-box.md
+++ b/plugins/actian-design-system/vendor/components/render/dist/usage-notes/combo-box.md
@@ -22,4 +22,7 @@ A combo box combines a text input with a dropdown list, allowing users to either
 - Keep option labels consistent in format and sentence case.
 - Do not use `Type to filter` as placeholder text - it states the obvious. Instead describe what is being searched.
 
+## Category guidance (inherited: design, behavior)
+Inputs and selections converge on Label → Control → Helper → Validation as the dominant anatomy across mature DSes. The `Label position` variant captures the dense-form vs comfortable-form authoring choice. The six accessibility refs map to WCAG criteria that apply to every form control regardless of subtype.
+
 > Note: includes guidance not yet ratified: DRAFT (usage); INHERITED from category (design, behavior).

--- a/plugins/actian-design-system/vendor/components/render/dist/usage-notes/dropdown-select-default.md
+++ b/plugins/actian-design-system/vendor/components/render/dist/usage-notes/dropdown-select-default.md
@@ -20,4 +20,7 @@ Dropdowns and select menus allow users to choose one option from a list. They ar
 - Use sentence case for all menu items.
 - Multi-selection dropdowns: include checkboxes, and selections should persist until the user closes the menu.
 
+## Category guidance (inherited: design, behavior)
+Inputs and selections converge on Label → Control → Helper → Validation as the dominant anatomy across mature DSes. The `Label position` variant captures the dense-form vs comfortable-form authoring choice. The six accessibility refs map to WCAG criteria that apply to every form control regardless of subtype.
+
 > Note: includes guidance not yet ratified: DRAFT (usage); INHERITED from category (design, behavior).

--- a/plugins/actian-design-system/vendor/components/render/dist/usage-notes/dropdown-select.md
+++ b/plugins/actian-design-system/vendor/components/render/dist/usage-notes/dropdown-select.md
@@ -20,4 +20,7 @@ Dropdowns and select menus allow users to choose one option from a list. They ar
 - Use sentence case for all menu items.
 - Multi-selection dropdowns: include checkboxes, and selections should persist until the user closes the menu.
 
+## Category guidance (inherited: design, behavior)
+Inputs and selections converge on Label → Control → Helper → Validation as the dominant anatomy across mature DSes. The `Label position` variant captures the dense-form vs comfortable-form authoring choice. The six accessibility refs map to WCAG criteria that apply to every form control regardless of subtype.
+
 > Note: includes guidance not yet ratified: DRAFT (usage); INHERITED from category (design, behavior).

--- a/plugins/actian-design-system/vendor/components/render/dist/usage-notes/input-date.md
+++ b/plugins/actian-design-system/vendor/components/render/dist/usage-notes/input-date.md
@@ -19,4 +19,7 @@ A date input lets users enter a single date by typing or by picking from an atta
 - Show the expected format as a placeholder example, not as an instruction. For example, "YYYY-MM-DD".
 - Use a single, consistent date format across the product.
 
+## Category guidance (inherited: design, behavior)
+Inputs and selections converge on Label → Control → Helper → Validation as the dominant anatomy across mature DSes. The `Label position` variant captures the dense-form vs comfortable-form authoring choice. The six accessibility refs map to WCAG criteria that apply to every form control regardless of subtype.
+
 > Note: includes guidance not yet ratified: DRAFT (usage); INHERITED from category (design, behavior).

--- a/plugins/actian-design-system/vendor/components/render/dist/usage-notes/multi-select.md
+++ b/plugins/actian-design-system/vendor/components/render/dist/usage-notes/multi-select.md
@@ -21,4 +21,7 @@ Multi-select allows users to choose more than one option from a list. It is used
 - Keep chip labels concise - use the item name only, not additional metadata.
 - Use **Select all** and **Clear all** as action labels when applicable.
 
+## Category guidance (inherited: design, behavior)
+Inputs and selections converge on Label → Control → Helper → Validation as the dominant anatomy across mature DSes. The `Label position` variant captures the dense-form vs comfortable-form authoring choice. The six accessibility refs map to WCAG criteria that apply to every form control regardless of subtype.
+
 > Note: includes guidance not yet ratified: DRAFT (usage); INHERITED from category (design, behavior).

--- a/plugins/actian-design-system/vendor/components/render/dist/usage-notes/radio.md
+++ b/plugins/actian-design-system/vendor/components/render/dist/usage-notes/radio.md
@@ -23,4 +23,7 @@ Radio buttons let users select exactly one option from a group. Use them when op
 - Always include a group label that describes what is being selected.
 - Avoid labels like "Option 1" or "Other" without further context.
 
+## Category guidance (inherited: design, behavior)
+Inputs and selections converge on Label → Control → Helper → Validation as the dominant anatomy across mature DSes. The `Label position` variant captures the dense-form vs comfortable-form authoring choice. The six accessibility refs map to WCAG criteria that apply to every form control regardless of subtype.
+
 > Note: includes guidance not yet ratified: DRAFT (usage); INHERITED from category (design, behavior).

--- a/plugins/actian-design-system/vendor/components/render/dist/usage-notes/rich-text.md
+++ b/plugins/actian-design-system/vendor/components/render/dist/usage-notes/rich-text.md
@@ -22,4 +22,7 @@ The rich text editor allows users to write and format long-form content such as 
 - Toolbar button labels follow standard conventions: Bold, Italic, Link, Bullet list, Numbered list.
 - Do not use placeholder text to convey formatting instructions. Use helper text below the field instead.
 
+## Category guidance (inherited: design, behavior)
+Inputs and selections converge on Label → Control → Helper → Validation as the dominant anatomy across mature DSes. The `Label position` variant captures the dense-form vs comfortable-form authoring choice. The six accessibility refs map to WCAG criteria that apply to every form control regardless of subtype.
+
 > Note: includes guidance not yet ratified: DRAFT (usage); INHERITED from category (design, behavior).

--- a/plugins/actian-design-system/vendor/components/render/dist/usage-notes/search-dropdown-menu.md
+++ b/plugins/actian-design-system/vendor/components/render/dist/usage-notes/search-dropdown-menu.md
@@ -20,4 +20,7 @@ The search dropdown menu shows suggestions and matching results below a search f
 - Highlight the matched portion of each result so users can confirm relevance.
 - Keep each result to its name plus minimal context, such as type or owner.
 
+## Category guidance (inherited: design, behavior)
+Inputs and selections converge on Label → Control → Helper → Validation as the dominant anatomy across mature DSes. The `Label position` variant captures the dense-form vs comfortable-form authoring choice. The six accessibility refs map to WCAG criteria that apply to every form control regardless of subtype.
+
 > Note: includes guidance not yet ratified: DRAFT (usage); INHERITED from category (design, behavior).

--- a/plugins/actian-design-system/vendor/components/render/dist/usage-notes/search-filters.md
+++ b/plugins/actian-design-system/vendor/components/render/dist/usage-notes/search-filters.md
@@ -23,4 +23,7 @@ Filters allow users to refine visible data by applying structured criteria. They
 - Show the active filter count when filters are collapsed. For example, `Filters (3)`.
 - Use consistent terminology across all filter controls in the same view.
 
+## Category guidance (inherited: design, behavior)
+Inputs and selections converge on Label → Control → Helper → Validation as the dominant anatomy across mature DSes. The `Label position` variant captures the dense-form vs comfortable-form authoring choice. The six accessibility refs map to WCAG criteria that apply to every form control regardless of subtype.
+
 > Note: includes guidance not yet ratified: DRAFT (usage); INHERITED from category (design, behavior).

--- a/plugins/actian-design-system/vendor/components/render/dist/usage-notes/search.md
+++ b/plugins/actian-design-system/vendor/components/render/dist/usage-notes/search.md
@@ -15,4 +15,7 @@ Search allows users to find assets quickly. Placeholder text should provide a hi
 - Don't use it as the only way to narrow a result set by structured attributes (owner, status, type): pair it with filters instead of teaching users keyword tricks.
 - Don't embed a search field for a list short enough to scan; a dozen visible items need no query box.
 
+## Category guidance (inherited: design, behavior)
+Inputs and selections converge on Label → Control → Helper → Validation as the dominant anatomy across mature DSes. The `Label position` variant captures the dense-form vs comfortable-form authoring choice. The six accessibility refs map to WCAG criteria that apply to every form control regardless of subtype.
+
 > Note: includes guidance not yet ratified: DRAFT (usage); INHERITED from category (design, behavior).

--- a/plugins/actian-design-system/vendor/components/render/dist/usage-notes/segmented-control.md
+++ b/plugins/actian-design-system/vendor/components/render/dist/usage-notes/segmented-control.md
@@ -22,4 +22,7 @@ A segmented control lets users switch between mutually exclusive views or modes.
 - Keep all labels similar in length for visual balance.
 - Use sentence case.
 
+## Category guidance (inherited: design, behavior)
+Inputs and selections converge on Label → Control → Helper → Validation as the dominant anatomy across mature DSes. The `Label position` variant captures the dense-form vs comfortable-form authoring choice. The six accessibility refs map to WCAG criteria that apply to every form control regardless of subtype.
+
 > Note: includes guidance not yet ratified: DRAFT (usage); INHERITED from category (design, behavior).

--- a/plugins/actian-design-system/vendor/components/render/dist/usage-notes/text-input.md
+++ b/plugins/actian-design-system/vendor/components/render/dist/usage-notes/text-input.md
@@ -13,4 +13,7 @@ Text inputs allow users to enter freeform text. They are used for naming, descri
 - Don't use it for multi-line or formatted content such as data product descriptions: use rich text.
 - Don't use it for dates: use the date input.
 
+## Category guidance (inherited: behavior)
+Inputs and selections converge on Label → Control → Helper → Validation as the dominant anatomy across mature DSes. The `Label position` variant captures the dense-form vs comfortable-form authoring choice. The six accessibility refs map to WCAG criteria that apply to every form control regardless of subtype.
+
 > Note: includes guidance not yet ratified: DRAFT (usage, design); INHERITED from category (behavior).

--- a/plugins/actian-design-system/vendor/components/render/dist/usage-notes/toggle.md
+++ b/plugins/actian-design-system/vendor/components/render/dist/usage-notes/toggle.md
@@ -20,4 +20,7 @@ Toggle control is a binary control that turns a setting on or off. Use it for se
 - If the on and off states have meaningfully different consequences, add a short description below the toggle label.
 - Use sentence case.
 
+## Category guidance (inherited: design, behavior)
+Inputs and selections converge on Label → Control → Helper → Validation as the dominant anatomy across mature DSes. The `Label position` variant captures the dense-form vs comfortable-form authoring choice. The six accessibility refs map to WCAG criteria that apply to every form control regardless of subtype.
+
 > Note: includes guidance not yet ratified: DRAFT (usage); INHERITED from category (design, behavior).

--- a/plugins/actian-design-system/vendor/components/render/dist/usage-notes/upload-file.md
+++ b/plugins/actian-design-system/vendor/components/render/dist/usage-notes/upload-file.md
@@ -19,4 +19,7 @@ Upload components allow users to add files to the platform. They appear in datas
 - File type restrictions: list accepted formats explicitly. For example, "Accepts `.csv`, `.json`, and `.xlsx` files."
 - File size limit: state the limit in plain language. For example, "Maximum file size: 50 MB."
 
+## Category guidance (inherited: design, behavior)
+Inputs and selections converge on Label → Control → Helper → Validation as the dominant anatomy across mature DSes. The `Label position` variant captures the dense-form vs comfortable-form authoring choice. The six accessibility refs map to WCAG criteria that apply to every form control regardless of subtype.
+
 > Note: includes guidance not yet ratified: DRAFT (usage); INHERITED from category (design, behavior).

--- a/plugins/actian-design-system/vendor/components/src/calendar/_meta.yml
+++ b/plugins/actian-design-system/vendor/components/src/calendar/_meta.yml
@@ -1,6 +1,6 @@
 # yaml-language-server: $schema=../../../schemas/guideline-meta.json
 component: "Calendar"
-category: form-input-selection
+category: form
 a11y_refs:
   - { ref: forms }
 domains:

--- a/plugins/actian-design-system/vendor/components/src/checkbox/_meta.yml
+++ b/plugins/actian-design-system/vendor/components/src/checkbox/_meta.yml
@@ -1,6 +1,6 @@
 # yaml-language-server: $schema=../../../schemas/guideline-meta.json
 component: "Checkboxes"
-category: form-input-selection
+category: form
 a11y_refs:
   - { ref: forms }
 domains:

--- a/plugins/actian-design-system/vendor/components/src/combo-box/_meta.yml
+++ b/plugins/actian-design-system/vendor/components/src/combo-box/_meta.yml
@@ -1,6 +1,6 @@
 # yaml-language-server: $schema=../../../schemas/guideline-meta.json
 component: "Combo box"
-category: form-input-selection
+category: form
 a11y_refs:
   - { ref: forms }
   - { ref: dropdowns-menus-popovers }

--- a/plugins/actian-design-system/vendor/components/src/dropdown-select/_meta.yml
+++ b/plugins/actian-design-system/vendor/components/src/dropdown-select/_meta.yml
@@ -1,6 +1,6 @@
 # yaml-language-server: $schema=../../../schemas/guideline-meta.json
 component: "Dropdown / Select"
-category: form-input-selection
+category: form
 a11y_refs:
   - { ref: forms }
   - { ref: dropdowns-menus-popovers }

--- a/plugins/actian-design-system/vendor/components/src/input-date/_meta.yml
+++ b/plugins/actian-design-system/vendor/components/src/input-date/_meta.yml
@@ -1,6 +1,6 @@
 # yaml-language-server: $schema=../../../schemas/guideline-meta.json
 component: "Date input"
-category: form-input-selection
+category: form
 related: [calendar, text-input]
 a11y_refs:
   - { ref: forms }

--- a/plugins/actian-design-system/vendor/components/src/multi-select/_meta.yml
+++ b/plugins/actian-design-system/vendor/components/src/multi-select/_meta.yml
@@ -1,6 +1,6 @@
 # yaml-language-server: $schema=../../../schemas/guideline-meta.json
 component: "Multi-select"
-category: form-input-selection
+category: form
 a11y_refs:
   - { ref: forms }
   - { ref: dropdowns-menus-popovers }

--- a/plugins/actian-design-system/vendor/components/src/radio/_meta.yml
+++ b/plugins/actian-design-system/vendor/components/src/radio/_meta.yml
@@ -1,6 +1,6 @@
 # yaml-language-server: $schema=../../../schemas/guideline-meta.json
 component: "Radio"
-category: form-input-selection
+category: form
 a11y_refs:
   - { ref: forms }
 domains:

--- a/plugins/actian-design-system/vendor/components/src/rich-text/_meta.yml
+++ b/plugins/actian-design-system/vendor/components/src/rich-text/_meta.yml
@@ -1,6 +1,6 @@
 # yaml-language-server: $schema=../../../schemas/guideline-meta.json
 component: "Rich text"
-category: form-input-selection
+category: form
 a11y_refs:
   - { ref: forms }
 domains:

--- a/plugins/actian-design-system/vendor/components/src/search-dropdown-menu/_meta.yml
+++ b/plugins/actian-design-system/vendor/components/src/search-dropdown-menu/_meta.yml
@@ -1,6 +1,6 @@
 # yaml-language-server: $schema=../../../schemas/guideline-meta.json
 component: "Search dropdown menu"
-category: form-input-selection
+category: form
 a11y_refs:
   - { ref: dropdowns-menus-popovers }
 domains:

--- a/plugins/actian-design-system/vendor/components/src/search-filters/_meta.yml
+++ b/plugins/actian-design-system/vendor/components/src/search-filters/_meta.yml
@@ -1,6 +1,6 @@
 # yaml-language-server: $schema=../../../schemas/guideline-meta.json
 component: "Filters"
-category: form-input-selection
+category: form
 a11y_refs:
   - { ref: forms }
 domains:

--- a/plugins/actian-design-system/vendor/components/src/search/_meta.yml
+++ b/plugins/actian-design-system/vendor/components/src/search/_meta.yml
@@ -1,6 +1,6 @@
 # yaml-language-server: $schema=../../../schemas/guideline-meta.json
 component: "Search"
-category: form-input-selection
+category: form
 a11y_refs:
   - { ref: forms }
 domains:

--- a/plugins/actian-design-system/vendor/components/src/segmented-control/_meta.yml
+++ b/plugins/actian-design-system/vendor/components/src/segmented-control/_meta.yml
@@ -1,6 +1,6 @@
 # yaml-language-server: $schema=../../../schemas/guideline-meta.json
 component: "Segmented control"
-category: form-input-selection
+category: form
 a11y_refs:
   - { ref: tabs }
 domains:

--- a/plugins/actian-design-system/vendor/components/src/text-input/_meta.yml
+++ b/plugins/actian-design-system/vendor/components/src/text-input/_meta.yml
@@ -1,6 +1,6 @@
 # yaml-language-server: $schema=../../../schemas/guideline-meta.json
 component: "Text input"
-category: form-input-selection
+category: form
 a11y_refs:
   - { ref: forms }
 domains:

--- a/plugins/actian-design-system/vendor/components/src/toggle/_meta.yml
+++ b/plugins/actian-design-system/vendor/components/src/toggle/_meta.yml
@@ -1,6 +1,6 @@
 # yaml-language-server: $schema=../../../schemas/guideline-meta.json
 component: "Toggle control"
-category: form-input-selection
+category: form
 a11y_refs:
   - { ref: forms }
 domains:

--- a/plugins/actian-design-system/vendor/components/src/upload-file/_meta.yml
+++ b/plugins/actian-design-system/vendor/components/src/upload-file/_meta.yml
@@ -1,6 +1,6 @@
 # yaml-language-server: $schema=../../../schemas/guideline-meta.json
 component: "Upload file"
-category: form-input-selection
+category: form
 a11y_refs:
   - { ref: forms }
 domains:

--- a/plugins/actian-design-system/vendor/paths-manifest.json
+++ b/plugins/actian-design-system/vendor/paths-manifest.json
@@ -3,7 +3,7 @@
   "_convention": "Fields prefixed with _ are system-managed (auto_generated, source, schema_version, sourceFile, generatedAt, meta). Authored content uses bare keys; system metadata uses _-prefix. Reserved for future extensions.",
   "_naming_convention": "Every key in paths and collections is leaf XOR namespace, never both. A key cannot resolve to a file AND be a prefix of nested children. To add a sibling artifact under an existing leaf, rename the leaf to a sub-key first (e.g., accessibility.guide + accessibility.index, not accessibility + accessibility.index). Enforced by tests/manifest-convention.test.js.",
   "manifest_schema_version": "v1",
-  "knowledge_version": "0.34.131",
+  "knowledge_version": "0.34.132",
   "_zones": {
     "knowledge": [
       "accessibility",

--- a/plugins/actian-design-system/vendored.json
+++ b/plugins/actian-design-system/vendored.json
@@ -1,9 +1,9 @@
 {
   "knowledge_repo": "volivarii/actian-ds-knowledge",
-  "knowledge_repo_version_range": "0.34.131",
-  "knowledge_repo_resolved_version": "v0.34.131",
-  "knowledge_repo_resolved_sha": "600b664b4b6a894033a90404de1f23bcd357af02",
-  "vendored_at": "2026-08-14T13:10:09.659Z",
+  "knowledge_repo_version_range": "0.34.132",
+  "knowledge_repo_resolved_version": "v0.34.132",
+  "knowledge_repo_resolved_sha": "f2a54ba61ecc1b11d32e7fd78099f80ab639d70e",
+  "vendored_at": "2026-08-14T14:37:34.055Z",
   "vendored_entries": [
     "ARCHITECTURE.md",
     "CONSUMING.md",
@@ -40,5 +40,5 @@
     "scripts",
     "tests"
   ],
-  "vendor_url": "https://github.com/volivarii/actian-ds-knowledge/tree/v0.34.131"
+  "vendor_url": "https://github.com/volivarii/actian-ds-knowledge/tree/v0.34.132"
 }


### PR DESCRIPTION
The previous refresh pinned **v0.34.131**, which is the version where 16 components silently lost the
*"Category guidance (inherited: design, behavior)"* section from their usage notes. Knowledge #542
diagnosed and restored it in **v0.34.132**.

The nightly cron would heal this on its own within a day. This carries it now so the plugin is not
serving usage notes with a missing section in the meantime.

**Verified at the artifact**, not at the version number: the section is back in the vendored
`usage-notes/`. Suite 1997 passing. 2026.8.8.

Pure vendor refresh plus the version bump the gate requires; no source changes.