### PR TITLE
fix(tests): a capture is not always named for the pattern it composes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,32 @@ are summarized at the release level.
 
 ## [Unreleased]
 
+### Fixed
+
+- **A test asserted that a captured recipe is always named for the pattern it composes, which was true
+  only by coincidence, and it blocked the substrate's first real use of the declared join.**
+  ([#PR](_PR link added at open_)) knowledge v0.34.145 shipped `studio-quick-edit-drawer`, which
+  declares `patterns: ["right-sliding-drawer"]`: Studio and Explorer draw the same 550px right-hand
+  drawer with different bodies, so one pattern now has two captures told apart by `apps`. The nightly
+  vendor PR went red on `assert.strictEqual(p.pageRecipe, p.slug)` and stopped auto-merging, so the
+  capture reached no consumer.
+
+  **It was the assertion that was wrong, not the capture.** `patterns` is a DECLARED field precisely so
+  a recipe can compose a pattern it is not named for, `resolve-patterns.js` says so in as many words
+  ("the declared link and wins"), and the same suite already contained "serves every pattern a recipe
+  declares, not just the one it is named for" and "joins on the recipe's own slug when it declares no
+  patterns", the second of which proves slug-matching is the FALLBACK rather than the rule. The suite
+  asserted both that a recipe may compose a pattern it is not named for and that it never does; the
+  first capture to exercise the design decided which one it meant.
+
+  The check now asserts the JOIN rather than the NAME: the recipe a pattern points at must DECLARE that
+  pattern (with the same slug fallback the resolver uses) and CLAIM that app. Verified not to be
+  tautological by planting a wrong pairing, which it rejects. A new test pins the capability directly,
+  one pattern with two captures resolving per app, and it is written against a synthetic index rather
+  than the vendored substrate so it holds at every vendored version instead of only after a given sync.
+  Nothing pinned that before, which is why a green suite broke on the first recipe to use the join as
+  designed.
+
 ### Added
 
 - **The generator now composes from a captured page recipe where the substrate has one, instead of

--- a/plugins/actian-design-system/.claude-plugin/plugin.json
+++ b/plugins/actian-design-system/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "actian-design-system",
   "description": "Actian Design System toolkit — generate wireframe flows with prototype wiring, create component briefs, audit designs, compare flows, and build presentations. 8 skills (with tiered generation: recognized / adapted / improvised), 9 agents, 155 tokens (3 themes, 8 collections), WCAG 2.2 AA. DS knowledge vendored from volivarii/actian-ds-knowledge.",
-  "version": "2026.8.17",
+  "version": "2026.8.18",
   "author": {
     "name": "Actian UX Team"
   },

--- a/plugins/actian-design-system/tests/lib/resolve-patterns.test.js
+++ b/plugins/actian-design-system/tests/lib/resolve-patterns.test.js
@@ -658,7 +658,8 @@ describe("resolve-patterns (captured page recipes)", function () {
     // ASSERT THE SUBJECT, both ways. Without the second half this suite passes
     // on an implementation that stamps every pattern with a recipe slug; without
     // the first it passes on a substrate that ships no captures at all.
-    var ps = resolver.resolvePatterns("studio");
+    var APP = "studio";
+    var ps = resolver.resolvePatterns(APP);
     var withCapture = ps.filter(function (p) {
       return p.pageRecipe !== null;
     });
@@ -673,13 +674,77 @@ describe("resolve-patterns (captured page recipes)", function () {
       without.length > 0,
       "and most patterns have none, so a non-null value means something",
     );
+    // 🪤 This asserted `p.pageRecipe === p.slug`, "every shipped capture is named
+    // for the pattern it composes". That was true only by COINCIDENCE, while
+    // every shipped recipe happened to be named for its pattern, and it
+    // contradicted this suite's own "serves every pattern a recipe declares, not
+    // just the one it is named for" plus resolve-patterns.js's comment that
+    // `patterns` "is the declared link and wins". knowledge v0.34.145 shipped
+    // `studio-quick-edit-drawer`, which declares `right-sliding-drawer` because
+    // Studio and Explorer draw the same 550px shell with different bodies, and
+    // this assertion failed on the first recipe to use the join as designed.
+    // What has to hold is the JOIN, not the NAME.
+    var byRecipeSlug = {};
+    resolver.loadPageRecipes().forEach(function (r) {
+      if (r && typeof r.slug === "string") byRecipeSlug[r.slug] = r;
+    });
     withCapture.forEach(function (p) {
-      assert.strictEqual(
-        p.pageRecipe,
-        p.slug,
-        "every shipped capture is named for the pattern it composes",
+      var r = byRecipeSlug[p.pageRecipe];
+      assert.ok(
+        r,
+        p.slug + ": pageRecipe '" + p.pageRecipe + "' names no shipped recipe",
+      );
+      // Mirrors patternSlugsFor EXACTLY: normalize, filter, THEN fall back.
+      // 🪤 Checking `r.patterns.length` BEFORE normalizing diverges: on
+      // `patterns: ["", "  "]` the resolver filters to empty and falls back to
+      // the slug, while a raw length check keeps the blanks and fails a recipe
+      // the resolver resolves correctly. A test that reds on behaviour the code
+      // handles is worse than no test.
+      var norm = function (x) {
+        return typeof x === "string" ? x.trim().toLowerCase() : "";
+      };
+      var declared = (Array.isArray(r.patterns) ? r.patterns : [])
+        .map(norm)
+        .filter(Boolean);
+      if (!declared.length) declared = [norm(r.slug)].filter(Boolean);
+      assert.ok(
+        declared.indexOf(p.slug) !== -1,
+        p.slug + ": recipe '" + r.slug + "' does not declare this pattern",
+      );
+      assert.ok(
+        (Array.isArray(r.apps) ? r.apps : []).some(function (a) {
+          return resolver.normalizeApp(a) === resolver.normalizeApp(APP);
+        }),
+        p.slug + ": recipe '" + r.slug + "' does not claim " + APP,
       );
     });
+  });
+
+  it("serves a capture whose slug differs from the pattern it declares", function () {
+    // The case the `pageRecipe === slug` assertion above used to forbid, and the
+    // reason it was wrong. Two captures of ONE shape, told apart by `apps`: the
+    // product draws the same 550px right-hand drawer in both Studio and Explorer
+    // with different bodies, so knowledge ships `right-sliding-drawer` (explorer)
+    // and `studio-quick-edit-drawer` (studio), both declaring the same pattern.
+    // Kept synthetic rather than read from the vendored substrate, so it pins the
+    // capability at every vendored version rather than only after a given sync.
+    var ctx = {
+      patterns: { "right-sliding-drawer": { apps: ["studio", "explorer"], tags: ["x"] } },
+    };
+    var index = [
+      { slug: "right-sliding-drawer", apps: ["explorer"], patterns: ["right-sliding-drawer"] },
+      { slug: "studio-quick-edit-drawer", apps: ["studio"], patterns: ["right-sliding-drawer"] },
+    ];
+    assert.strictEqual(
+      resolver.resolvePatterns("studio", ctx, [], index)[0].pageRecipe,
+      "studio-quick-edit-drawer",
+      "studio must get the capture named for studio, not the one named for the pattern",
+    );
+    assert.strictEqual(
+      resolver.resolvePatterns("explorer", ctx, [], index)[0].pageRecipe,
+      "right-sliding-drawer",
+      "explorer must keep its own capture",
+    );
   });
 
   it("joins on the recipe's own slug when it declares no patterns", function () {


### PR DESCRIPTION
Unblocks vendor PR #308 (`vendor(knowledge): refresh to v0.34.145`), which is red and not auto-merging,
so no consumer has the Studio drawer capture yet.

## What broke

knowledge v0.34.145 shipped `studio-quick-edit-drawer`, which declares
`patterns: ["right-sliding-drawer"]`. Studio and Explorer draw the same 550px right-hand drawer with
different bodies, so one pattern now has **two captures, told apart by `apps`**. That is the shape
`selectPageRecipe` was built for.

The vendor PR went red on one assertion, 1 of 2039:

```
expected: 'right-sliding-drawer'
actual:   'studio-quick-edit-drawer'
```

```js
assert.strictEqual(p.pageRecipe, p.slug,
  "every shipped capture is named for the pattern it composes")
```

## The assertion was wrong, not the capture

`patterns` is a **declared** field precisely so a recipe can compose a pattern it is not named for.
`resolve-patterns.js` says so directly ("the declared link and wins"), and this same suite already
contained both:

- *"serves every pattern a recipe declares, not just the one it is named for"*
- *"joins on the recipe's own slug when it declares no patterns"*, which proves slug-matching is the
  **fallback**, not the rule

So the suite asserted both that a recipe may compose a pattern it is not named for **and** that it
never does. It held only while every shipped recipe happened to share its pattern's name. The first
capture to use the join as designed decided which one it meant.

## The fix

The check now asserts the **join** rather than the **name**: the recipe a pattern points at must
DECLARE that pattern and CLAIM that app. That keeps what the assertion was for (a non-null `pageRecipe`
means something) without re-encoding the coincidence.

It mirrors `patternSlugsFor` exactly, normalize then filter then fall back. An earlier revision checked
`r.patterns.length` before normalizing, which diverges: on `patterns: ["", "  "]` the resolver filters
to empty and falls back to the slug, while a raw length check keeps the blanks and fails a recipe the
resolver resolves correctly. A test that reds on behaviour the code handles is worse than no test.

Verified non-tautological against the real vendored substrate:

```
wrong pairing (activity-timeline -> faceted-browse): rejected
right pairing (faceted-browse   -> faceted-browse): accepted
```

## And a test that pins the capability

One pattern, two captures, each app getting its own. Written against a **synthetic** index rather than
the vendored substrate, so it holds at every vendored version instead of only after a particular sync.
Nothing pinned that before, which is exactly why a green suite broke on the join's first real use.

## Checks

| state | result |
|---|---|
| v0.34.143 vendored (main today) | 53/53 |
| v0.34.145 recipe present (the CI condition) | 53/53, was 51/1 |

Full suite **2040/2040**. Reproduced the CI failure locally first by copying the v0.34.145 recipe into
the vendor tree, rather than fixing from the log alone.

`plugin.json` bumped to 2026.8.18 via the repo's own `bump-version.js` in calendar mode, since the gate
counts `tests/**` as source for human-authored PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
