### PR TITLE
fix(vendor): the alarm reads why it is running, not only the queue

### DIFF
--- a/.github/scripts/vendor-queue-alarm.sh
+++ b/.github/scripts/vendor-queue-alarm.sh
@@ -9,11 +9,29 @@
 # days. The pile IS the signal, and nobody was looking at it. This runs nightly
 # from vendor-snapshot.yml, so it is the natural place to notice.
 #
-# THREE STATES, and the distinction is the whole design:
+# THREE VERDICTS, and the distinction is the whole design:
 #
-#   stuck    a PR has a failed check or merge conflicts   -> raise/update the alarm
-#   healthy  every open PR positively reported success    -> clear the alarm
+#   stuck    the refresh run did not succeed (REFRESH_OUTCOME, read first,
+#            because the queue cannot show a PR that was never opened;
+#            `cancelled` counts, see below), or an open PR has a failed check,
+#            merge conflicts, or auto-merge not enabled
+#                                                          -> raise/update the alarm
+#   healthy  the refresh completed and every open PR positively reported
+#            a passing conclusion with auto-merge on (the PR this run just
+#            created is not counted: it cannot be stuck yet)
+#                                                          -> clear the alarm
 #   unknown  gh could not say, or checks have not reported -> touch NOTHING
+#
+# A missing job status is not a fourth verdict: the queue is still read and can
+# still find a stuck PR, so an alarm can still be raised. What an absent status
+# blocks is CLEARING, because nothing then says the refresh completed.
+#
+# One non-success run does NOT raise: the run whose own PR merged. Tonight's
+# knowledge landed and a later step failed, so the alarm's title would be false.
+# That night raises nothing and clears nothing, and the run summary carries it.
+#
+# The queue is read on every verdict: the pile is the signal, whatever
+# happened tonight.
 #
 # The two defects this shape exists to prevent, both real:
 #
@@ -34,7 +52,11 @@
 # tested: see tests/vendor/vendor-queue-alarm.test.js, which runs it against a
 # stubbed gh and pins both the verdicts and the queries.
 #
-# Requires: gh on PATH, GH_TOKEN in the environment.
+# Requires: gh on PATH, GH_TOKEN in the environment. The step passes in
+# REFRESH_OUTCOME (the job's status), RUN_URL, OPENED_PR (the PR carrying
+# tonight's refresh, if one exists) and OPENED_OP (created or updated: only a
+# created PR is too new to be stuck). Without a status the script cannot tell
+# whether the refresh completed, treats it as unknown, and never clears.
 # Best-effort by contract: it must never fail the refresh it runs inside, so
 # every path exits 0.
 set +e
@@ -59,36 +81,188 @@ clear_alarm() {
   done
 }
 
-open_prs=$(gh pr list --state open --label vendor --json number,title,createdAt --jq '.[] | [.number, .createdAt[0:10], .title] | @tsv' 2>/dev/null)
+# Raise the alarm, or comment on the open one. The one raise path for every
+# cause: the caller passes the reason, this adds what every alarm says.
+#
+# If gh cannot LIST the open alarms, it is not known whether one exists, and
+# creating one would open a duplicate on exactly the nights (rate limits, a
+# failing API) that coincide with a failed run. Unknown touches nothing, and
+# the run summary carries the reason instead, so the night is not silent.
+CLOSE_NOTE="This issue closes automatically once a refresh completes and every open vendor PR reports healthy."
+raise_alarm() {
+  local reason="$1" listed existing
+  listed=$(own_alarm_issues)
+  if [ $? -ne 0 ]; then
+    could_not_raise "gh could not list the open alarms, so whether one exists is UNKNOWN and creating one could duplicate it" "$reason"
+    return 0
+  fi
+  existing=$(printf '%s\n' "$listed" | head -1)
+  if [ -n "$existing" ]; then
+    gh issue comment "$existing" --body "Still blocked."$'\n\n'"${reason}" 2>/dev/null || could_not_raise "gh could not comment on the open alarm" "$reason"
+  else
+    gh label create vendor-blocked --color B60205 --description "Vendor refresh PRs are stuck; the plugin is not consuming knowledge" 2>/dev/null
+    gh issue create --title "$ALARM_TITLE" --label vendor-blocked --body "${reason}"$'\n\n'"${CLOSE_NOTE}" 2>/dev/null || could_not_raise "gh could not create the alarm" "$reason"
+  fi
+}
+
+# Everything this script tells a human goes through here, so the run summary and
+# the issue body cannot drift into saying different things about one night.
+summary() { [ -n "${GITHUB_STEP_SUMMARY-}" ] && printf '%s\n' "$1" >> "$GITHUB_STEP_SUMMARY"; return 0; }
+
+# A raise that gh refused must not be a silent night: the run summary
+# carries the reason instead.
+could_not_raise() {
+  echo "vendor-queue-alarm: $1."
+  summary "$(printf '%s\n\n%s' "**The vendor alarm could not be raised** ($1), so it is recorded here instead:" "$2")"
+  return 0
+}
+
+# The queue cannot show a PR that was never opened. On 2026-08-27 the refresh
+# died at "Re-record the blank-box baseline", the steps that open the PR were
+# skipped, and this script read the empty queue as drained and reported success
+# on the one night the plugin had stopped consuming knowledge (#317). So it also
+# reads WHY it is running: the step passes the job's own status in.
+run_line="Run: ${RUN_URL:-unknown}"
+refresh_note=""
+may_clear=""
+middle=""
+headline=""
+
+# Read tonight's PR state ONCE, and keep "not merged" apart from "could not
+# tell". Ignoring gh's exit code here let a 502 read as "not merged", which put
+# a false title ("the plugin is not consuming knowledge") on a night the
+# knowledge had in fact landed.
+opened_state=""
+opened_state_known=""
+if [ -n "${OPENED_PR-}" ]; then
+  opened_state=$(gh pr view "$OPENED_PR" --json state --jq .state 2>/dev/null)
+  if [ $? -eq 0 ] && [ -n "$opened_state" ]; then opened_state_known=1; fi
+fi
+
+case "${REFRESH_OUTCOME-}" in
+  success) may_clear=1 ;;
+  "")
+    echo "vendor-queue-alarm: no job status was passed in, so whether the refresh completed is UNKNOWN. The queue is read, but nothing may clear."
+    ;;
+  *)
+    # `cancelled` lands here with every other non-success. It is a human
+    # pressing stop no more often than it is a timeout, a concurrency cancel or
+    # a lost runner, and treating it as its own quiet verdict let a nightly that
+    # hangs every night go silent under a status word.
+    if [ -n "$opened_state_known" ] && [ "$opened_state" = "MERGED" ]; then
+      # The refresh's product landed; a later step failed. Not a night the
+      # plugin consumed nothing, so the alarm's title would be false. No
+      # refresh_note, so nothing is raised: the summary carries it.
+      headline="Vendor refresh FAILED (status: ${REFRESH_OUTCOME}) after PR #${OPENED_PR} merged; tonight's knowledge landed, the run still needs a look."
+    elif [ -n "${OPENED_PR-}" ]; then
+      middle="PR #${OPENED_PR} carries tonight's refresh and a later step failed, so check that PR and the run."
+      headline="Vendor refresh FAILED (status: ${REFRESH_OUTCOME}); PR #${OPENED_PR} carries tonight's refresh, check that PR."
+    else
+      # An empty OPENED_PR is NOT proof that no PR was opened:
+      # create-pull-request sets its outputs last, after labels and assignees,
+      # so a failure anywhere after the PR was created leaves them empty. Say
+      # what is known (the step reported none), never "no PR was opened, so the
+      # plugin consumed nothing", which would be a fabricated certainty.
+      middle="The PR step reported no PR tonight, so no new knowledge is known to have landed."
+      headline="Vendor refresh FAILED (status: ${REFRESH_OUTCOME}) and the PR step reported no PR; the plugin may not be consuming knowledge."
+    fi
+    ;;
+esac
+# One headline and one note per night, assembled once, so the run summary and
+# the issue body cannot state the same facts in two different shapes.
+[ -n "$headline" ] && summary "### ${headline} ${run_line}"
+[ -n "$middle" ] && refresh_note="**The vendor refresh run did not complete (status: ${REFRESH_OUTCOME}). ${middle}** ${run_line}"
+
+# --limit 100, because gh's default is 30, newest first. The pile IS the signal,
+# and a pile is exactly when it exceeds the window: past 30 the OLDEST, most
+# stuck PRs fall outside it, so the count under-reports and, if the newest 30
+# read healthy, the script clears while older ones sit.
+open_prs=$(gh pr list --state open --label vendor --limit 100 --json number,title,createdAt --jq '.[] | [.number, .createdAt[0:10], .title] | @tsv' 2>/dev/null)
 if [ $? -ne 0 ]; then
   # An empty list and a failed list are the same empty string, so this has to be
   # checked before the emptiness is trusted as "drained".
   echo "vendor-queue-alarm: could not read the vendor PR queue, so the queue state is UNKNOWN. Leaving any existing alarm exactly as it is."
+  # A failed refresh is known to have failed whatever the queue says, so it is
+  # raised rather than merely logged. raise_alarm guards its own duplicates and
+  # falls back to the summary when gh cannot list, so this degrades safely.
+  if [ -n "$refresh_note" ]; then
+    raise_alarm "${refresh_note}"$'\n\n'"The vendor PR queue could not be read, so what is waiting in it is unknown."
+  fi
   exit 0
 fi
 
 if [ -z "$open_prs" ]; then
-  clear_alarm "✅ The vendor queue has drained: no open vendor PRs remain."
+  if [ -n "$refresh_note" ]; then
+    raise_alarm "${refresh_note}"$'\n\n'"There is nothing in the queue to review."
+  elif [ -n "$may_clear" ]; then
+    clear_alarm "✅ The vendor queue has drained: no open vendor PRs remain."
+  fi
   exit 0
 fi
 
 blocked=""
 unknown=""
+healthy=0
+tonight_pending=""
 while IFS=$'\t' read -r num created title; do
   [ -z "$num" ] && continue
 
-  # `.conclusion // .state` on purpose: a modern CheckRun carries .conclusion,
-  # a legacy commit status (StatusContext) carries .state, and reading only the
-  # first let a red legacy status pass as healthy. A check with neither has not
-  # reported, which is PENDING, not success.
-  checks=$(gh pr view "$num" --json statusCheckRollup \
-    --jq '[.statusCheckRollup[]? | (.conclusion // .state // "PENDING")] | join(",")' 2>/dev/null)
-  checks_rc=$?
-  dirty=$(gh pr view "$num" --json mergeStateStatus --jq 'select(.mergeStateStatus == "DIRTY") | "conflicts"' 2>/dev/null)
-  dirty_rc=$?
-
-  if [ "$checks_rc" -ne 0 ] || [ "$dirty_rc" -ne 0 ]; then
+  # One read per PR, not three. Three separate `gh pr view` calls tripled the
+  # exposure to a transient 502 on exactly the flaky nights this script exists
+  # for, and any one of them failing discarded the other two.
+  #
+  # First NON-EMPTY of .conclusion, .state, "PENDING". A modern CheckRun carries
+  # .conclusion, a legacy commit status (StatusContext) carries .state, and
+  # reading only the first let a red legacy status pass as healthy.
+  #
+  # Non-empty, not `//`: jq's `//` falls through on null and false but NOT on
+  # "", and gh reports a check that is still running as `"conclusion": ""` with
+  # no .state key at all. So `.conclusion // .state // "PENDING"` yielded ""
+  # for every in-flight check, three running checks joined to ",,", which is not
+  # empty (so the -z guard below misses it) and contains no non-passing token
+  # (so the allow-list misses it too). The PR read HEALTHY and cleared the
+  # alarm while its checks were still running: defect 2 from this file's header.
+  # A vendor PR is built to auto-merge. One with auto-merge off and green
+  # checks will sit unmerged forever, which is stuck, not healthy.
+  pr_state=$(gh pr view "$num" --json state,statusCheckRollup,mergeStateStatus,autoMergeRequest \
+    --jq '[
+      .state,
+      ([.statusCheckRollup[]?
+        | [(.conclusion // ""), (.state // ""), "PENDING"]
+        | map(select(. != "")) | .[0]] | join(",")),
+      (.mergeStateStatus // ""),
+      (if .autoMergeRequest == null then "off" else "" end)
+    ] | join("|")' 2>/dev/null)
+  if [ $? -ne 0 ]; then
     unknown="${unknown}- #${num}: gh could not report its state"$'\n'
+    continue
+  fi
+  # Joined on "|", NOT a tab: a tab is whitespace, and `read` collapses runs of
+  # whitespace delimiters, so a PR with no conflicts silently shifted the
+  # auto-merge field into the conflicts one and a green PR with auto-merge off
+  # read as healthy. Two of these three fields are empty on a healthy PR, so the
+  # delimiter has to be one `read` treats literally.
+  IFS='|' read -r pr_status checks merge_state noauto <<< "$pr_state"
+
+  # The queue was listed a moment ago. A vendor PR carries auto-merge, so one
+  # can merge between the list and this read; it then reports no auto-merge
+  # request (it is spent) and no conflicts, and would be called stuck for having
+  # done exactly what it was supposed to do. A PR that is no longer open is not
+  # in the queue.
+  if [ -n "$pr_status" ] && [ "$pr_status" != "OPEN" ]; then
+    continue
+  fi
+
+  # The PR this very run CREATED moments ago cannot be stuck yet, so it is
+  # exempt from EVERY stuck test, which is what the header has always said. It
+  # used to be exempt only from the pending-checks reading, so the lag between
+  # `gh pr merge --auto` (the step immediately before this one) and
+  # autoMergeRequest appearing reported tonight's own PR as "auto-merge not
+  # enabled" and raised an alarm titled "the plugin is not consuming knowledge"
+  # on a night it did. A PR the run merely UPDATED (a re-used branch
+  # force-pushed) was there before tonight and keeps its history.
+  if [ "${OPENED_OP-}" = "created" ] && [ -n "${OPENED_PR-}" ] && [ "$num" = "$OPENED_PR" ]; then
+    tonight_pending="$num"
     continue
   fi
 
@@ -98,14 +272,31 @@ while IFS=$'\t' read -r num created title; do
       reason="failing check(s)"
       ;;
   esac
-  [ -n "$dirty" ] && reason="${reason:+$reason, }merge conflicts"
+  # A PR GitHub itself will not merge is stuck, whatever its checks say. DIRTY
+  # is a conflict; BLOCKED means a required check that never reported or a
+  # required review, so `gh pr merge --auto` queues silently and never fires;
+  # DRAFT will not merge either. Reducing this field to DIRTY/not-DIRTY let a
+  # BLOCKED PR with every check green CLEAR the alarm, which is the false
+  # all-clear this file calls worse than silence.
+  case "$merge_state" in
+    DIRTY)   reason="${reason:+$reason, }merge conflicts" ;;
+    BLOCKED) reason="${reason:+$reason, }auto-merge cannot fire (mergeStateStatus BLOCKED)" ;;
+    DRAFT)   reason="${reason:+$reason, }the PR is a draft" ;;
+  esac
+  [ -n "$noauto" ] && reason="${reason:+$reason, }auto-merge not enabled"
 
   if [ -n "$reason" ]; then
     blocked="${blocked}- #${num} (opened ${created}): ${title} — ${reason}"$'\n'
     continue
   fi
 
-  # Not stuck. That is only HEALTHY if every check positively reported success.
+  # Not stuck. That is only HEALTHY if every check positively reported SUCCESS.
+  #
+  # Health is stated positively rather than as "none of these bad words".
+  # Listing the pending states let STALE, NEUTRAL and SKIPPED through as
+  # healthy, and auto-merge does not fire on those, so a PR that will sit
+  # forever could clear the alarm. Anything that is not SUCCESS, including a
+  # status GitHub has not invented yet, is unknown.
   #
   # Do NOT read pending as healthy: this step runs in the same workflow that
   # just opened tonight's PR, so pending is the normal state moments after
@@ -117,23 +308,59 @@ while IFS=$'\t' read -r num created title; do
     unknown="${unknown}- #${num}: no checks have reported yet"$'\n'
     continue
   fi
-  case ",$checks," in
-    *,PENDING,* | *,EXPECTED,* | *,IN_PROGRESS,* | *,QUEUED,* | *,WAITING,* | *,REQUESTED,*)
-      unknown="${unknown}- #${num}: checks still running"$'\n'
+  # An explicit allow-list of the conclusions GitHub itself counts as passing
+  # for a required check, so auto-merge WILL fire on them. Anything outside it,
+  # including a conclusion GitHub has not invented yet, is unknown.
+  #
+  # SKIPPED and NEUTRAL are in the list on purpose. Reading health as
+  # "SUCCESS only" is the safe-looking choice and the wrong one: a vendor PR
+  # carrying one skipped required check would then read unknown every night, the
+  # alarm could never clear, and that is defect 1 from this file's own header.
+  # STALE is NOT in the list: it means the answer describes an older commit.
+  # An empty token is named rather than dropped. The jq above should no longer
+  # produce one, and this is the second lock on the same door: an empty line
+  # survives `grep -v` and then vanishes in `paste`, so a list of nothing but
+  # empties collapses to "" and reads as passing.
+  not_passing=$(printf '%s' "$checks" | tr ',' '\n' | sed 's/^$/PENDING/' \
+    | grep -vE '^(SUCCESS|SKIPPED|NEUTRAL)$' | sort -u | paste -sd, -)
+  if [ -n "$not_passing" ]; then
+    unknown="${unknown}- #${num}: not every check reported passing (${not_passing})"$'\n'
+    continue
+  fi
+  # And healthy only if GitHub says it can merge NOW. Stated as an allow-list
+  # for the same reason the check conclusions are: BEHIND (needs an update) and
+  # UNKNOWN (mergeability still being computed) are neither stuck nor healthy,
+  # and a value GitHub adds later must not read as healthy by default.
+  case "$merge_state" in
+    CLEAN | HAS_HOOKS | UNSTABLE) ;;
+    *)
+      unknown="${unknown}- #${num}: not reported mergeable (mergeStateStatus ${merge_state:-empty})"$'\n'
       continue
       ;;
   esac
+  healthy=$((healthy + 1))
 done <<< "$open_prs"
 
 if [ -n "$blocked" ]; then
   count=$(printf '%s' "$blocked" | grep -c '^- ')
-  gh label create vendor-blocked --color B60205 --description "Vendor refresh PRs are stuck; the plugin is not consuming knowledge" 2>/dev/null
-  body="**${count} vendor refresh PR(s) are stuck.** While they are, the plugin is consuming NO new knowledge: every substrate change is piling up on the wrong side of the pipe."$'\n\n'"${blocked}"$'\n'"This issue closes automatically once every open vendor PR reports healthy."
-  existing=$(own_alarm_issues | head -1)
-  if [ -n "$existing" ]; then
-    gh issue comment "$existing" --body "Still blocked (${count} PR(s))."$'\n\n'"${blocked}" 2>/dev/null
+  lead="**${count} vendor refresh PR(s) are stuck.** While they are, the plugin is consuming NO new knowledge: every substrate change is piling up on the wrong side of the pipe."
+  [ -n "$refresh_note" ] && lead="${refresh_note}"$'\n\n'"${lead}"
+  body="${lead}"$'\n\n'"${blocked}"
+  # One stuck PR plus one unreadable PR used to report only the stuck one, so a
+  # reader acting on the alarm would have fixed half the queue and believed it
+  # drained. The refresh-failed body below names them; this one must too.
+  [ -n "$unknown" ] && body="${body}"$'\n'"These could not be read:"$'\n'"${unknown}"
+  raise_alarm "$body"
+  exit 0
+fi
+
+# Nothing in the queue is provably stuck, but the refresh itself did not
+# complete. What could not be read is named rather than called clear.
+if [ -n "$refresh_note" ]; then
+  if [ -n "$unknown" ]; then
+    raise_alarm "${refresh_note}"$'\n\n'"No open vendor PR is provably stuck; these could not be read:"$'\n'"${unknown}"
   else
-    gh issue create --title "$ALARM_TITLE" --label vendor-blocked --body "$body" 2>/dev/null
+    raise_alarm "${refresh_note}"$'\n\n'"No open vendor PR is stuck."
   fi
   exit 0
 fi
@@ -144,6 +371,35 @@ if [ -n "$unknown" ]; then
   exit 0
 fi
 
-# Every open vendor PR positively reported success.
-clear_alarm "✅ Every open vendor PR reports healthy, so the plugin is consuming knowledge again."
+# Every open vendor PR positively reported success, and the refresh completed.
+if [ -z "$may_clear" ]; then
+  # may_clear is empty for two different reasons, and saying "unknown" for both
+  # misreports the one where the status is perfectly well known.
+  if [ -n "${REFRESH_OUTCOME-}" ]; then
+    echo "vendor-queue-alarm: the queue reads healthy, but the refresh did not succeed (status: ${REFRESH_OUTCOME}), so the alarm is left exactly as it is."
+  else
+    echo "vendor-queue-alarm: the queue reads healthy, but no job status was passed in, so whether the refresh completed is unknown and the alarm is left exactly as it is."
+  fi
+  exit 0
+fi
+# "Every open vendor PR reports healthy" is a claim about PRs that were actually
+# measured. Tonight's own PR is exempt (it cannot be stuck yet), so when it is
+# the ONLY open one, nothing was measured and that sentence would be a false
+# all-clear dressed as a reading.
+if [ "$healthy" -gt 0 ] && [ -z "$tonight_pending" ]; then
+  clear_alarm "✅ Every open vendor PR reports healthy, so the plugin is consuming knowledge again."
+elif [ "$healthy" -gt 0 ]; then
+  # Tonight's PR is exempt from the reading, so it is excluded from the claim
+  # rather than folded into it: "every open PR" would be counting one that was
+  # never measured.
+  clear_alarm "✅ ${healthy} open vendor PR(s) report healthy, and tonight's PR #${tonight_pending} is too new to judge. The plugin is consuming knowledge again."
+elif [ -n "$tonight_pending" ]; then
+  # Nothing was measured at all: the only open PR is the one this run created.
+  # Saying its checks "have not reported" would be a claim of its own, and they
+  # may well have reported success; it was skipped for being too new, not for
+  # being silent.
+  clear_alarm "✅ The vendor queue has drained apart from tonight's PR #${tonight_pending}, which is too new to judge."
+else
+  clear_alarm "✅ The vendor queue has drained: no open vendor PRs remain."
+fi
 exit 0

--- a/.github/workflows/vendor-snapshot.yml
+++ b/.github/workflows/vendor-snapshot.yml
@@ -254,7 +254,9 @@ jobs:
           gh pr merge "${{ steps.cpr.outputs.pull-request-number }}" --auto --squash --repo "${{ github.repository }}"
 
       - name: Summarize
-        if: always()
+        # Success lines only. On any other outcome the alarm script writes the
+        # summary, since it holds the status, the run and the PR (#317).
+        if: success()
         run: |
           if [ "${{ steps.diff.outputs.changed }}" = "true" ]; then
             echo "### Vendor refreshed: ${{ steps.target.outputs.label }} (auto-bump applied)" >> "$GITHUB_STEP_SUMMARY"
@@ -270,6 +272,19 @@ jobs:
         if: always()
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # The queue cannot show a PR that was never opened (#317): the script
+          # also reads why it is running. job.status is failure or cancelled
+          # here whenever an earlier step did not succeed.
+          REFRESH_OUTCOME: ${{ job.status }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          # Empty unless "Open pull request" ran and set its outputs, so a
+          # failure after the PR exists is described as that. It is not proof of
+          # the reverse: create-pull-request sets these outputs LAST, so a
+          # failure after the PR was created leaves them empty, which is why the
+          # script says "the PR step reported no PR" and never "no PR exists".
+          OPENED_PR: ${{ steps.cpr.outputs.pull-request-number }}
+          # created or updated: only a PR created tonight is too new to be stuck.
+          OPENED_OP: ${{ steps.cpr.outputs.pull-request-operation }}
         # Best-effort by contract: it must never fail the refresh itself. Kept in
         # a script, not inline, so its branches are testable:
         # plugins/actian-design-system/tests/vendor/vendor-queue-alarm.test.js

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -126,6 +126,71 @@ are summarized at the release level.
 
 ### Fixed
 
+- **The vendor alarm read an empty PR queue as healthy, so a refresh that died before opening a PR
+  reported success on the night the plugin stopped consuming knowledge.** ([#323](https://github.com/volivarii/Actian-DS-Claude-plugin/pull/323), plugin #317) On 2026-08-27 the refresh failed at "Re-record the blank-box baseline" and the
+  four steps after it, including the ones that open and auto-merge the PR, were skipped;
+  `vendor-queue-alarm.sh`, which decides stuck, healthy or unknown by inspecting open vendor PRs,
+  found none and cleared. A queue cannot show a PR that was never opened, so the step now passes the
+  job's own status (`REFRESH_OUTCOME: ${{ job.status }}`), the run URL, and the number and operation
+  (created or updated) of the PR carrying tonight's refresh when one exists. A failed refresh raises
+  or updates the alarm and can never clear it, saying which PR carries tonight's refresh or that the
+  PR step reported none. That wording is deliberate: `create-pull-request` sets its outputs last, so
+  an empty output is not proof no PR exists, and the alarm states what is known rather than that the
+  plugin consumed nothing. If that PR had already merged, nothing is raised and the run summary says
+  so; whether it merged is read with gh's exit code, so a 502 is unknown rather than "not merged",
+  which would put a false title on a night the knowledge landed. The queue is read on every verdict,
+  because the pile is the signal: an older stuck PR is named in the same alarm, what could not be
+  read is named in that same body rather than dropped, and a green vendor PR with auto-merge not
+  enabled is stuck, since it will never merge. A PR is healthy only when every check reported a
+  conclusion on an explicit passing list (`SUCCESS`, `SKIPPED`, `NEUTRAL`, the ones GitHub itself
+  counts as passing for a required check, so auto-merge fires on them); `STALE`, which describes an
+  older commit, and anything GitHub adds later are unknown. The list is positive on purpose, but
+  reading it as `SUCCESS` only would have been the opposite mistake: a vendor PR carrying one skipped
+  required check would read unknown every night and the alarm could never clear. The conclusion is
+  read as the first NON-EMPTY of `.conclusion`, `.state`, `PENDING`, not through `//`: jq's `//`
+  falls through on null and false but not on `""`, and gh reports a check that is still running as
+  `"conclusion": ""` with no `.state` key, so three running checks joined to `,,`, which is not empty
+  and holds no non-passing token. The PR read healthy and cleared the alarm while its checks were
+  still running, which is defect 2 from the script's own header. An empty token is also named rather
+  than dropped on the shell side, since an empty line survives `grep -v` and then vanishes in
+  `paste`. Only the PR this run created is exempt from "pending is
+  unknown", so a transient alarm no longer clears only on a night nothing was published; an updated
+  PR keeps its history. When that exempt PR is the only one open, nothing was measured, so the clear
+  says the queue drained apart from tonight's PR rather than claiming every PR reports healthy. A
+  cancelled run is treated as a failed refresh: a cancel is a timeout, a concurrency cancel or a lost
+  runner as often as it is a human, and its own quiet verdict let a nightly that hangs every night go
+  silent under a status word. An absent status never clears. A failed refresh whose queue cannot be
+  read is raised rather than only logged, since the refresh is known to have failed whatever the
+  queue says. The alarm is raised from one path for every cause, one headline and one note are
+  assembled per night so the run summary and the issue body cannot disagree, and when gh cannot list,
+  create or comment, the reason goes to the run summary instead of nowhere. Each PR's checks, merge
+  state and auto-merge are read in one gh call rather than three, joined on `|` rather than a tab,
+  since two of the four fields are empty on a healthy PR and `read` collapses whitespace delimiters.
+  A PR is healthy only if GitHub reports it mergeable now: `CLEAN`, `HAS_HOOKS` or `UNSTABLE`.
+  `mergeStateStatus` was reduced to conflicts-or-not, so `BLOCKED`, which means a required check that
+  never reported or a required review, cleared the alarm with every check green, though `gh pr merge
+  --auto` queues silently on it and never fires. `BLOCKED` and `DRAFT` are stuck; `BEHIND` and
+  `UNKNOWN` are neither, so they are unknown. The queue is read with `--limit 100`, because gh pages
+  at 30 newest-first and a pile is exactly when it exceeds that window, so the oldest and most stuck
+  fell outside it. Tonight's own PR is exempt from every stuck test rather than only from the
+  pending-checks reading: `gh pr merge --auto` runs in the step before, so the lag before
+  `autoMergeRequest` appears raised an alarm about the one PR that had just succeeded. The test stub
+  now emits the JSON gh really returns and lets the script's own `--jq` run through real jq: it used
+  to answer with the already-joined row, so no test ever executed the filter and every semantic
+  element of it, including the empty-conclusion fallback above, could be deleted with the suite
+  green. A PR that is no longer open is not in the queue: a vendor PR carries auto-merge, so one can merge
+  between the listing and its own read, and it would then report no auto-merge request and be called
+  stuck for doing exactly what it was built to do. The test that pins the questions asked reads the
+  `--json` field list itself rather than the command line, because every field name also appears in
+  the `--jq` filter, so dropping one from `--json` left the suite green while jq read the absent
+  field as null for every PR, which would have fired the alarm every night.
+  The script also writes the failure line of the run
+  summary, which used to say "no changes" for a dead refresh; the Summarize step keeps only the
+  success lines, guarded on success. The contract is asserted against the workflow YAML step by step,
+  including `if: always()` and the four inputs by their expressions, with the step slice bounded by
+  the step's own indent and asserted to hold exactly one step, so an assertion cannot pass against a
+  slice that quietly ran to the end of the file.
+
 - **A component new to the plugin was reported as "demoted to a bare chip", and the false verdict
   halted all knowledge consumption.** ([#321](https://github.com/volivarii/Actian-DS-Claude-plugin/pull/321), plugin #318) `dropdown`
   arrived in knowledge v0.34.155 as a real slot-based menu with no render leaf yet, so it renders as a

--- a/plugins/actian-design-system/.claude-plugin/plugin.json
+++ b/plugins/actian-design-system/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "actian-design-system",
   "description": "Actian Design System toolkit — generate wireframe flows with prototype wiring, create component briefs, audit designs, compare flows, and build presentations. 8 skills (with tiered generation: recognized / adapted / improvised), 9 agents, 155 tokens (3 themes, 8 collections), WCAG 2.2 AA. DS knowledge vendored from volivarii/actian-ds-knowledge.",
-  "version": "2026.8.26",
+  "version": "2026.8.27",
   "author": {
     "name": "Actian UX Team"
   },

--- a/plugins/actian-design-system/tests/vendor/vendor-queue-alarm.test.js
+++ b/plugins/actian-design-system/tests/vendor/vendor-queue-alarm.test.js
@@ -27,7 +27,8 @@ var ALARM = path.join(REPO_ROOT, ".github", "scripts", "vendor-queue-alarm.sh");
 // again. This ecosystem had just lost 11 nights to an expired PAT. So the script
 // is now explicitly three-state:
 //
-//   stuck    -> raise or update the alarm
+//   stuck    -> raise or update the alarm (a refresh that failed before
+//               opening a PR is stuck too, read from the job status first)
 //   healthy  -> clear it
 //   unknown  -> touch nothing, and say why
 //
@@ -42,6 +43,28 @@ var ALARM = path.join(REPO_ROOT, ".github", "scripts", "vendor-queue-alarm.sh");
 // asked. Asserting the questions matters because a stub that answers on the
 // subcommand alone would stay green if the real --json fields or --jq filters
 // were wrong, which would silence the alarm with no red test.
+// The JSON gh really returns for the per-PR read, built from the same fixture
+// keys the tests already use. `checks` is still written as a comma string for
+// brevity; each token becomes one rollup entry, and an EMPTY token becomes an
+// entry shaped like a running CheckRun (`"conclusion": ""`, no .state), which
+// is what gh actually sends and what round 8's defect turned on.
+function prViewFixture(fx) {
+  var raw = fx.checks === undefined ? "SUCCESS" : fx.checks;
+  var rollup = raw === "" ? [] : raw.split(",").map(function (c) {
+    if (c === "") return { __typename: "CheckRun", conclusion: "", status: "IN_PROGRESS" };
+    // A legacy commit status carries .state and no .conclusion.
+    if (fx.legacyStatus) return { __typename: "StatusContext", state: c };
+    return { __typename: "CheckRun", conclusion: c, status: "COMPLETED" };
+  });
+  return {
+    state: fx.queuedPrState || "OPEN",
+    statusCheckRollup: fx.nullRollup ? null : rollup,
+    mergeStateStatus:
+      fx.mergeStateStatus || (fx.dirty ? "DIRTY" : "CLEAN"),
+    autoMergeRequest: fx.noAutoMerge ? null : { enabledAt: "2026-08-28T00:00:00Z" },
+  };
+}
+
 function stubGh(dir, fx) {
   var log = path.join(dir, "gh.log");
   var lines = [
@@ -52,21 +75,47 @@ function stubGh(dir, fx) {
     "    " + (fx.prListFails ? 'echo "HTTP 502" >&2; exit 1' : ""),
     "    printf '%b' " + JSON.stringify(fx.openPrs || ""),
     "    ;;",
+    '  "issue create" | "issue comment")',
+    "    " + (fx.issueWriteFails ? 'echo "HTTP 403" >&2; exit 1' : ""),
+    "    ;;",
     '  "issue list")',
+    "    " + (fx.issueListFails ? 'echo "HTTP 502" >&2; exit 1' : ""),
     "    printf '%b' " + JSON.stringify(fx.blockedIssues || ""),
     "    ;;",
     '  "pr view")',
+    // The stub emits FIXTURE JSON and lets the script's own --jq run it, via
+    // real jq. It used to answer with the already-joined row, which meant no
+    // test ever executed the filter: every semantic element of it could be
+    // broken with the suite green, including the fallback that resolves an
+    // in-flight check's empty conclusion. A gate that cannot fail on its
+    // subject is not a gate, and the filter is exactly where the last defect
+    // lived.
+    '    filter=""; prev=""',
+    '    for a in "$@"; do',
+    '      if [ "$prev" = "--jq" ]; then filter="$a"; fi',
+    '      prev="$a"',
+    '    done',
     '    if [[ "$*" == *statusCheckRollup* ]]; then',
     "      " + (fx.prViewFails ? 'echo "HTTP 502" >&2; exit 1' : ""),
-    "      printf '%b' " +
-      JSON.stringify(fx.checks === undefined ? "SUCCESS" : fx.checks),
-    // Printed a plausible answer, then failed. Only the exit code distinguishes
-    // this from a healthy read.
+    "      " +
+      (fx.prViewFailsFor
+        ? 'if [ "$3" = ' +
+          JSON.stringify(String(fx.prViewFailsFor)) +
+          ' ]; then echo "HTTP 502" >&2; exit 1; fi'
+        : ""),
+    "      printf '%s' " +
+      JSON.stringify(JSON.stringify(prViewFixture(fx))) +
+      ' | jq -r "$filter"',
     "      " + (fx.prViewFailsAfterPrinting ? "exit 1" : ""),
-    "    else",
-    "      " + (fx.prViewFails ? "exit 1" : ""),
-    "      printf '%b' " + JSON.stringify(fx.dirty || ""),
-    "      " + (fx.prViewFailsAfterPrinting ? "exit 1" : ""),
+    '    elif [[ "$*" == *"--json state"* ]]; then',
+    "      printf '%s' " +
+      JSON.stringify(
+        JSON.stringify({
+          state: fx.openedPrState === undefined ? "OPEN" : fx.openedPrState,
+        }),
+      ) +
+      ' | jq -r "$filter"',
+    "      " + (fx.openedPrStateFails ? "exit 1" : ""),
     "    fi",
     "    ;;",
     "esac",
@@ -82,19 +131,76 @@ function stubGh(dir, fx) {
 // not a call.
 var CLOSE_CALL = /issue close [0-9]/;
 
+var DIRS = [];
+test.after(function () {
+  DIRS.forEach(function (d) {
+    fs.rmSync(d, { recursive: true, force: true });
+  });
+});
+
 function runAlarm(fx) {
   var dir = fs.mkdtempSync(path.join(os.tmpdir(), "vqa-"));
+  DIRS.push(dir);
   var log = stubGh(dir, fx || {});
+  var summary = path.join(dir, "summary.md");
   var res = spawnSync("bash", [ALARM], {
     encoding: "utf8",
-    env: Object.assign({}, process.env, { PATH: dir + ":" + process.env.PATH }),
+    // The step always passes the job status; a test that wants the absent
+    // case passes REFRESH_OUTCOME: "" explicitly. OPENED_PR is empty unless
+    // the test says a PR was opened tonight.
+    env: Object.assign(
+      {},
+      process.env,
+      { PATH: dir + ":" + process.env.PATH },
+      {
+        REFRESH_OUTCOME: "success",
+        RUN_URL: "https://example/run/0",
+        OPENED_PR: "",
+        OPENED_OP: "",
+        GITHUB_STEP_SUMMARY: summary,
+      },
+      (fx && fx.env) || {},
+    ),
   });
   return {
     status: res.status,
     calls: fs.existsSync(log) ? fs.readFileSync(log, "utf8") : "",
     stdout: String(res.stdout || ""),
     stderr: String(res.stderr || ""),
+    summary: fs.existsSync(summary) ? fs.readFileSync(summary, "utf8") : "",
   };
+}
+
+var WORKFLOW = fs.readFileSync(
+  path.join(REPO_ROOT, ".github", "workflows", "vendor-snapshot.yml"),
+  "utf8",
+);
+
+// One step of the workflow, from its `- name:` to the next one at the same
+// indent (or the end of the file).
+function sliceStep(name) {
+  var start = WORKFLOW.indexOf("- name: " + name);
+  assert.ok(start !== -1, "the workflow has a step named " + name);
+  // The step's own indent, read from the line it was found on, rather than a
+  // hard-coded six spaces. When that guess did not match the file, the search
+  // for the next step returned -1 and the slice ran to the END OF THE FILE, so
+  // assertions written about one step passed against another step's text. A
+  // slice that quietly widens to everything is a gate that asserts nothing.
+  var lineStart = WORKFLOW.lastIndexOf("\n", start) + 1;
+  var indent = WORKFLOW.slice(lineStart, start);
+  assert.match(indent, /^[ ]*$/, "the step name must start its own line");
+  var next = WORKFLOW.indexOf("\n" + indent + "- name:", start);
+  // From the START OF THE LINE, so the step's own indent is inside the slice
+  // and the count below can anchor on it.
+  var slice = WORKFLOW.slice(lineStart, next === -1 ? WORKFLOW.length : next);
+  assert.equal(
+    (slice.match(new RegExp("^" + indent + "- name:", "gm")) || []).length,
+    1,
+    "sliceStep(" +
+      name +
+      ") must return exactly one step, not run on into the next",
+  );
+  return slice;
 }
 
 var ONE_HEALTHY_PR =
@@ -123,8 +229,7 @@ test("alarm: a queue whose PRs are all healthy ALSO closes the open blocked issu
 
 test("alarm: a genuinely stuck PR still raises a new alarm", function () {
   var r = runAlarm({ openPrs: ONE_PR, blockedIssues: "", checks: "FAILURE" });
-  assert.match(r.calls, /issue create/);
-  assert.match(r.calls, /vendor-blocked/);
+  assert.match(r.calls, /issue create .*--label vendor-blocked/);
   assert.doesNotMatch(r.calls, CLOSE_CALL);
 });
 
@@ -214,9 +319,30 @@ test("alarm: a PR with no checks at all is unknown, not healthy", function () {
 
 test("alarm: a failing legacy commit status counts as stuck", function () {
   // A StatusContext carries `.state`, not `.conclusion`. Reading conclusion
-  // alone let a red legacy status read as healthy.
-  var r = runAlarm({ openPrs: ONE_PR, blockedIssues: "", checks: "FAILURE" });
+  // alone let a red legacy status read as healthy. `legacyStatus` makes the
+  // fixture that shape: without it the entry is a CheckRun and the .state
+  // fallback in the filter could be deleted with every test still green.
+  var r = runAlarm({
+    openPrs: ONE_PR,
+    blockedIssues: "",
+    checks: "FAILURE",
+    legacyStatus: true,
+  });
   assert.match(r.calls, /issue create/);
+  assert.match(r.calls, /failing check/);
+});
+
+test("alarm: a PASSING legacy commit status is read as passing, not as unreported", function () {
+  // The other side of the same fallback: dropping it makes every legacy status
+  // read PENDING, so a green legacy PR reads unknown and the alarm never
+  // clears. One test on the red side alone cannot see that.
+  var r = runAlarm({
+    openPrs: ONE_HEALTHY_PR,
+    blockedIssues: "272\n",
+    checks: "SUCCESS",
+    legacyStatus: true,
+  });
+  assert.match(r.calls, /issue close 272/);
 });
 
 test("alarm: merge conflicts are stuck even when every check passed", function () {
@@ -243,20 +369,58 @@ test("alarm: it asks the right questions, not just reaches the right verdict", f
     /pr list .*--state open .*--label vendor/,
     "the queue query must be open vendor-labelled PRs",
   );
+  // Pinned against the --json FIELD LIST, not against the command line as a
+  // whole. Every one of these names also appears in the --jq filter, so a bare
+  // /autoMergeRequest/ match stays green when the field is dropped from --json
+  // while jq still mentions it. jq then reads the absent field as null for
+  // every PR, so every healthy vendor PR reports "auto-merge not enabled" and
+  // the alarm fires every single night. The stub answers on the subcommand and
+  // never runs jq, so this assertion is the only thing standing between that
+  // and a green suite.
+  var jsonList = (r.calls.match(/pr view [0-9]+ --json (\S+)/) || [])[1];
+  assert.ok(jsonList, "the per-PR read must pass a --json field list");
+  [
+    "state",
+    "statusCheckRollup",
+    "mergeStateStatus",
+    "autoMergeRequest",
+  ].forEach(function (field) {
+    assert.ok(
+      jsonList.split(",").indexOf(field) !== -1,
+      field + " must be in the --json field list, got: " + jsonList,
+    );
+  });
   assert.match(
     r.calls,
-    /statusCheckRollup/,
-    "check state must come from the rollup",
+    /\.conclusion/,
+    "check state must come from .conclusion first",
   );
   assert.match(
     r.calls,
     /\.state/,
-    "the rollup filter must fall back to .state so a legacy commit status counts",
+    "and fall back to .state so a legacy commit status counts",
   );
+  // The load-bearing part: the fallback picks the first NON-EMPTY value. jq's
+  // `//` does not fall through on "", and gh reports a running check as
+  // `"conclusion": ""`, so a `//` chain yielded "" for every in-flight check.
   assert.match(
     r.calls,
-    /mergeStateStatus/,
-    "conflicts must still be consulted",
+    /select\(\. != ""\)/,
+    "the fallback must skip empty values, or a running check reads as passing",
+  );
+  // The three answers come back as one row, and the delimiter is load-bearing:
+  // a tab is whitespace, which `read` collapses, so the fields would shift.
+  assert.match(
+    r.calls,
+    /join\("\|"\)/,
+    "the three fields must be joined on a non-whitespace delimiter",
+  );
+  // One call, not three: three tripled the exposure to a transient 502 on
+  // exactly the flaky nights this script exists for.
+  assert.equal(
+    (r.calls.match(/pr view /g) || []).length,
+    1,
+    "each PR's state must be read in a single gh call",
   );
 });
 
@@ -277,5 +441,633 @@ test("alarm: it only closes its own tracking issue, not every issue wearing the 
       "An identity filter is deliberately avoided: if --author @me failed to " +
       "resolve under a CI token, the alarm would silently stop clearing again, " +
       "which is the bug this file exists for.",
+  );
+});
+
+// --- plugin #317, 2026-08-27 --------------------------------------------------
+//
+// The refresh died at "Re-record the blank-box baseline", so the steps that
+// open the PR were skipped and the queue this script inspects was empty. It
+// read empty as drained and reported success, on the one night the plugin had
+// stopped consuming knowledge. A queue cannot show a PR that was never opened,
+// so the script must also read WHY it is running: the job's own status.
+
+var DIED = {
+  REFRESH_OUTCOME: "failure",
+  RUN_URL:
+    "https://github.com/volivarii/Actian-DS-Claude-plugin/actions/runs/33064557503",
+};
+
+test("alarm: a refresh that died before opening a PR raises the alarm, whatever the queue says", function () {
+  var r = runAlarm({ openPrs: "", blockedIssues: "", env: DIED });
+  assert.match(r.calls, /issue create .*--label vendor-blocked/);
+  assert.match(r.calls, /33064557503/, "the alarm names the run that died");
+  assert.doesNotMatch(r.calls, CLOSE_CALL);
+});
+
+test("alarm: a dead refresh with the alarm already open comments on it, and does not clear it on the empty queue it left behind", function () {
+  var r = runAlarm({ openPrs: "", blockedIssues: "272\n", env: DIED });
+  assert.match(r.calls, /issue comment 272/);
+  assert.doesNotMatch(r.calls, /issue create/);
+  assert.doesNotMatch(r.calls, CLOSE_CALL);
+});
+
+test("alarm: the workflow hands the script the job status and the run URL", function () {
+  // The script can only read why it is running if the step passes it in. A
+  // stub that answers on env alone would stay green if the workflow stopped
+  // setting it, so the contract is asserted against the YAML itself.
+  var step = sliceStep("Raise the alarm if the vendor queue is blocked");
+  assert.match(
+    step,
+    /if: always\(\)/,
+    "without always() the step never runs on the failed night it exists for",
+  );
+  assert.match(step, /REFRESH_OUTCOME:\s*\$\{\{\s*job\.status\s*\}\}/);
+  assert.match(
+    step,
+    /RUN_URL:\s*\$\{\{\s*github\.server_url\s*\}\}\/\$\{\{\s*github\.repository\s*\}\}\/actions\/runs\/\$\{\{\s*github\.run_id\s*\}\}/,
+  );
+  assert.match(
+    step,
+    /OPENED_PR:\s*\$\{\{\s*steps\.cpr\.outputs\.pull-request-number\s*\}\}/,
+  );
+  assert.match(
+    step,
+    /OPENED_OP:\s*\$\{\{\s*steps\.cpr\.outputs\.pull-request-operation\s*\}\}/,
+  );
+});
+
+test("alarm: the script writes the failure line of the run summary, and the Summarize step no longer guesses at one", function () {
+  // One writer of "what happened tonight" on a failed night: the script, which
+  // holds the status, the run and the PR. The step keeps the two success
+  // lines, guarded on success, so a dead run cannot summarise as "no changes".
+  var r = runAlarm({ openPrs: "", blockedIssues: "", env: DIED });
+  assert.match(r.summary, /### Vendor refresh FAILED/);
+  assert.match(r.summary, /33064557503/);
+  var step = sliceStep("Summarize");
+  assert.match(
+    step,
+    /if: (success\(\)|\$\{\{\s*job\.status == 'success'\s*\}\})/,
+  );
+  assert.doesNotMatch(step, /FAILED/);
+});
+
+// --- round 1 of the #317 review -----------------------------------------------
+
+test("alarm: a cancelled refresh with no PR is a failed refresh, not a quiet night", function () {
+  // `cancelled` was its own verdict that raised nothing, on the reading that it
+  // means a human pressed stop. It equally means a timeout, a concurrency
+  // cancel or a lost runner, so a nightly that hangs every single night went
+  // silent under a status word while the plugin consumed nothing. It is
+  // non-success like any other, and it still never clears.
+  var r = runAlarm({
+    openPrs: "",
+    blockedIssues: "272\n",
+    env: { REFRESH_OUTCOME: "cancelled", RUN_URL: "https://example/run/2" },
+  });
+  // An alarm is already open, so the raise is a comment on it rather than a
+  // duplicate.
+  assert.match(r.calls, /issue comment 272/);
+  assert.match(r.calls, /status: cancelled/);
+  assert.doesNotMatch(r.calls, CLOSE_CALL);
+  assert.match(r.summary, /cancelled/i);
+});
+
+test("alarm: a cancelled refresh with no alarm open raises a new one", function () {
+  var r = runAlarm({
+    openPrs: "",
+    blockedIssues: "",
+    env: { REFRESH_OUTCOME: "cancelled", RUN_URL: "https://example/run/2" },
+  });
+  assert.match(r.calls, /issue create .*--label vendor-blocked/);
+  assert.doesNotMatch(r.calls, CLOSE_CALL);
+});
+
+test("alarm: a cancelled run still reads the queue, so a stuck pile is raised whatever happened tonight", function () {
+  var r = runAlarm({
+    openPrs: ONE_PR,
+    blockedIssues: "",
+    checks: "FAILURE",
+    env: { REFRESH_OUTCOME: "cancelled", RUN_URL: "https://example/run/2" },
+  });
+  assert.match(r.calls, /issue create/);
+  assert.match(r.calls, /#271/);
+});
+
+test("alarm: with no job status at all the queue is read but nothing may clear", function () {
+  // The env contract fails closed: a caller that forgot to pass the status
+  // cannot produce the false all-clear this script exists to prevent.
+  var r = runAlarm({
+    openPrs: "",
+    blockedIssues: "272\n",
+    env: { REFRESH_OUTCOME: "" },
+  });
+  assert.doesNotMatch(r.calls, CLOSE_CALL);
+  assert.match(r.stdout, /UNKNOWN/);
+});
+
+test("alarm: a failed refresh still inspects the queue, so a stuck older PR is named alongside the failure", function () {
+  // job.status is failure for a failure at ANY step, including one after the
+  // PR exists, so the alarm must not claim the queue is empty.
+  var r = runAlarm({
+    openPrs: ONE_PR,
+    blockedIssues: "",
+    checks: "FAILURE",
+    env: DIED,
+  });
+  assert.match(r.calls, /issue create/);
+  assert.match(r.calls, /pr view 271/);
+  assert.match(r.calls, /33064557503/);
+  assert.match(r.calls, /#271/);
+  assert.equal(
+    (r.calls.match(/issue create/g) || []).length,
+    1,
+    "one alarm, not one per cause",
+  );
+  // Worded as what is KNOWN. create-pull-request sets its outputs last, so an
+  // empty OPENED_PR is not proof no PR exists, and "no PR was opened, so the
+  // plugin consumed nothing" would be a fabricated certainty on a night a PR
+  // may well have been created before a later step failed.
+  assert.match(r.calls, /The PR step reported no PR tonight/i);
+  assert.doesNotMatch(r.calls, /no PR was opened/i);
+});
+
+test("alarm: when gh cannot list the open alarms, a failed refresh raises nothing rather than a duplicate", function () {
+  var r = runAlarm({
+    openPrs: "",
+    blockedIssues: "",
+    issueListFails: true,
+    env: DIED,
+  });
+  assert.doesNotMatch(r.calls, /issue create/);
+  assert.doesNotMatch(r.calls, CLOSE_CALL);
+  assert.match(r.stdout, /UNKNOWN/);
+  // and the night is not silent: the run summary carries the reason
+  assert.match(r.summary, /could not/i);
+  assert.match(r.summary, /33064557503/);
+});
+
+// --- round 2 of the #317 review -----------------------------------------------
+
+test("alarm: a failure after the PR was opened names that PR and does not claim nothing was consumed", function () {
+  // job.status is failure for a failure at ANY step. When "Enable auto-merge"
+  // fails, tonight's PR exists with real content; the alarm must say so.
+  var r = runAlarm({
+    openPrs: ONE_HEALTHY_PR,
+    blockedIssues: "",
+    checks: "PENDING",
+    env: Object.assign({}, DIED, { OPENED_PR: "274", OPENED_OP: "created" }),
+  });
+  assert.match(r.calls, /issue create/);
+  assert.match(r.calls, /PR #274 carries tonight's refresh/);
+  // The no-PR branch's real sentence. Naming a string the script cannot emit
+  // made this inert; this one it emits whenever OPENED_PR is empty, so wiring
+  // the branches the wrong way round turns it red.
+  assert.doesNotMatch(r.calls, /The PR step reported no PR tonight/);
+  assert.doesNotMatch(r.calls, CLOSE_CALL);
+});
+
+test("alarm: a comment on the open alarm does not recreate the label", function () {
+  var r = runAlarm({ openPrs: "", blockedIssues: "272\n", env: DIED });
+  assert.match(r.calls, /issue comment 272/);
+  assert.doesNotMatch(r.calls, /label create/);
+});
+
+test("alarm: the failure line of the run summary names the PR carrying tonight's refresh", function () {
+  var r = runAlarm({
+    openPrs: ONE_HEALTHY_PR,
+    blockedIssues: "",
+    checks: "PENDING",
+    env: Object.assign({}, DIED, { OPENED_PR: "274", OPENED_OP: "created" }),
+  });
+  assert.match(r.summary, /### Vendor refresh FAILED.*PR #274/);
+});
+
+// --- round 3 of the #317 review -----------------------------------------------
+
+test("alarm: a failed refresh names the PRs it could not read instead of calling the queue clear", function () {
+  var r = runAlarm({
+    openPrs: ONE_PR,
+    blockedIssues: "",
+    prViewFails: true,
+    env: DIED,
+  });
+  assert.match(r.calls, /issue create/);
+  assert.match(r.calls, /#271: gh could not report its state/);
+  assert.doesNotMatch(r.calls, /No open vendor PR is stuck\./);
+});
+
+test("alarm: when gh cannot create or comment, the run summary carries the reason", function () {
+  var r = runAlarm({
+    openPrs: "",
+    blockedIssues: "",
+    issueWriteFails: true,
+    env: DIED,
+  });
+  assert.equal(r.status, 0);
+  assert.match(r.summary, /could not/i);
+  assert.match(r.summary, /33064557503/);
+});
+
+test("alarm: with no job status, a healthy-looking non-empty queue still clears nothing", function () {
+  var r = runAlarm({
+    openPrs: ONE_HEALTHY_PR,
+    blockedIssues: "272\n",
+    checks: "SUCCESS",
+    env: { REFRESH_OUTCOME: "" },
+  });
+  assert.doesNotMatch(r.calls, CLOSE_CALL);
+});
+
+test("alarm: the PR this run just opened cannot be stuck yet, so its pending checks do not hold the alarm open", function () {
+  // Every successful night opens a PR seconds before this step runs, so
+  // "pending" is the normal state here; without this a transient alarm only
+  // clears on a night the knowledge repo published nothing.
+  var r = runAlarm({
+    openPrs: ONE_HEALTHY_PR,
+    blockedIssues: "272\n",
+    checks: "PENDING",
+    env: { OPENED_PR: "274", OPENED_OP: "created" },
+  });
+  assert.match(r.calls, /issue close 272/);
+});
+
+test("alarm: a re-pushed existing PR is not tonight's newcomer, so its pending checks still hold the alarm", function () {
+  // create-pull-request reports the existing PR's number with operation
+  // "updated" when it force-pushes a re-used branch; that PR was stuck before
+  // tonight, and a reset to PENDING must not read as fresh.
+  var r = runAlarm({
+    openPrs: ONE_HEALTHY_PR,
+    blockedIssues: "272\n",
+    checks: "PENDING",
+    env: { OPENED_PR: "274", OPENED_OP: "updated" },
+  });
+  assert.doesNotMatch(r.calls, CLOSE_CALL);
+});
+
+test("alarm: a green vendor PR with auto-merge not enabled will never merge, so it is stuck", function () {
+  var r = runAlarm({
+    openPrs: ONE_PR,
+    blockedIssues: "",
+    checks: "SUCCESS",
+    noAutoMerge: true,
+  });
+  assert.match(r.calls, /issue create/);
+  assert.match(r.calls, /auto-merge not enabled/);
+  assert.doesNotMatch(r.calls, CLOSE_CALL);
+});
+
+test("alarm: a failed run whose PR already merged raises nothing and says so in the run summary", function () {
+  // A failure in a step after the merge (Summarize, say) is not a night the
+  // plugin consumed nothing; the alarm's title would be false.
+  var r = runAlarm({
+    openPrs: "",
+    blockedIssues: "",
+    openedPrState: "MERGED",
+    env: Object.assign({}, DIED, { OPENED_PR: "274", OPENED_OP: "created" }),
+  });
+  assert.doesNotMatch(r.calls, /issue create|issue comment/);
+  assert.match(r.summary, /merged/i);
+});
+
+test("alarm: a failed refresh whose queue cannot be read is still RAISED, not just logged", function () {
+  // The refresh is known to have failed whatever the queue says, so this night
+  // is not a summary line: it is the alarm. Recording it only in the run
+  // summary put the one signal that the plugin had stopped consuming knowledge
+  // on a page nobody opens, on exactly the nights the API was also flaky.
+  var r = runAlarm({ openPrs: "", prListFails: true, env: DIED });
+  assert.match(r.calls, /issue create .*--label vendor-blocked/);
+  assert.match(r.calls, /33064557503/);
+  assert.doesNotMatch(r.calls, CLOSE_CALL);
+});
+
+test("alarm: a failed refresh whose queue AND issue list both fail still reaches the run summary", function () {
+  // raise_alarm cannot list, so it cannot know whether an alarm is already
+  // open; creating one could duplicate. The night must not go silent, so the
+  // reason lands in the run summary instead.
+  var r = runAlarm({
+    openPrs: "",
+    prListFails: true,
+    issueListFails: true,
+    env: DIED,
+  });
+  assert.doesNotMatch(r.calls, /issue create/);
+  assert.match(r.summary, /could not/i);
+  assert.match(r.summary, /33064557503/);
+});
+
+test("alarm: a PR opened on an earlier night with pending checks still holds the alarm open", function () {
+  var r = runAlarm({
+    openPrs: ONE_PR,
+    blockedIssues: "272\n",
+    checks: "PENDING",
+    env: { OPENED_PR: "274" },
+  });
+  assert.doesNotMatch(r.calls, CLOSE_CALL);
+});
+
+// --- round 6 of the #317 review -----------------------------------------------
+
+test("alarm: a failed refresh whose PR state cannot be read does not claim the PR merged", function () {
+  // The MERGED probe used to ignore gh's exit code, so a 502 read as "not
+  // merged". That is the safe direction for the title, but the guard was
+  // unverified: removing the exit-code check left every test green. A failed
+  // read is unknown, so the run is described as a failure carrying that PR.
+  var r = runAlarm({
+    openPrs: "",
+    blockedIssues: "",
+    openedPrState: "MERGED",
+    openedPrStateFails: true,
+    env: {
+      REFRESH_OUTCOME: "failure",
+      OPENED_PR: "281",
+      RUN_URL: "https://example/run/9",
+    },
+  });
+  assert.match(r.calls, /issue create .*--label vendor-blocked/);
+  assert.doesNotMatch(
+    r.summary,
+    /merged/i,
+    "an unreadable state must not be reported as merged",
+  );
+});
+
+test("alarm: a PR that merged between the queue listing and its own read is not stuck", function () {
+  // A vendor PR carries auto-merge, so it can merge in the seconds between
+  // `gh pr list` and this PR's own read. It then reports no auto-merge request
+  // (it is spent) and no conflicts, and was called "auto-merge not enabled":
+  // a false alarm for doing exactly what it was built to do.
+  var r = runAlarm({
+    openPrs: ONE_PR,
+    blockedIssues: "272\n",
+    queuedPrState: "MERGED",
+    noAutoMerge: true,
+  });
+  assert.doesNotMatch(r.calls, /issue create|issue comment/);
+  assert.match(
+    r.calls,
+    /issue close 272/,
+    "the queue is drained, so the alarm clears",
+  );
+});
+
+test("alarm: the clear does not claim a reading of tonight's unmeasured PR", function () {
+  // Tonight's own PR is exempt from "pending is unknown", so when it is the
+  // only open one NOTHING was measured. Claiming "every open vendor PR reports
+  // healthy" would be a false all-clear dressed as a reading, and claiming its
+  // checks "have not reported" is equally a claim: it was skipped for being too
+  // new, and they may have reported success.
+  var r = runAlarm({
+    openPrs: ONE_PR,
+    blockedIssues: "272\n",
+    env: { OPENED_PR: "271", OPENED_OP: "created" },
+  });
+  assert.match(r.calls, /issue close 272/);
+  assert.match(r.calls, /drained apart from tonight's PR #271/);
+  assert.doesNotMatch(r.calls, /Every open vendor PR reports healthy/);
+  // The whole clear comment, so a reworded claim about the unmeasured PR fails
+  // here rather than sliding through a doesNotMatch on a string that is gone.
+  assert.match(
+    r.calls,
+    /issue close 272 --comment .*drained apart from tonight's PR #271, which is too new to judge/,
+  );
+});
+
+test("sliceStep: a slice is bounded by the next step, not by the end of the file", function () {
+  // The "exactly one step" count inside sliceStep is 1 by construction once the
+  // indent is derived, so it guards the derivation but cannot itself prove the
+  // slice stops where it should. This asserts the boundary directly, against
+  // two steps that really do follow one another in the workflow.
+  var summarize = sliceStep("Summarize");
+  assert.doesNotMatch(
+    summarize,
+    /Raise the alarm if the vendor queue is blocked/,
+    "the Summarize slice must not run on into the alarm step",
+  );
+  assert.ok(
+    summarize.length < WORKFLOW.length,
+    "a slice that is the whole file asserts nothing",
+  );
+});
+
+// --- round 7 of the #317 review -----------------------------------------------
+
+test("alarm: SKIPPED and NEUTRAL are passing, so a PR carrying one can still clear the alarm", function () {
+  // Health as "SUCCESS only" looks like the safe reading and is the wrong one.
+  // GitHub counts SKIPPED and NEUTRAL as passing for a required check, so
+  // auto-merge fires on them; calling them unknown would leave a vendor PR
+  // reading unknown every night and the alarm unable to clear, which is defect
+  // 1 from the script's own header.
+  var r = runAlarm({
+    openPrs: ONE_HEALTHY_PR,
+    blockedIssues: "272\n",
+    checks: "SUCCESS,SKIPPED,NEUTRAL",
+  });
+  assert.match(r.calls, /issue close 272/);
+});
+
+test("alarm: STALE is not passing, so it is unknown and cannot clear the alarm", function () {
+  // STALE means the answer describes an older commit, so it says nothing about
+  // the head this PR would merge.
+  var r = runAlarm({
+    openPrs: ONE_HEALTHY_PR,
+    blockedIssues: "272\n",
+    checks: "SUCCESS,STALE",
+  });
+  assert.doesNotMatch(r.calls, CLOSE_CALL);
+  assert.doesNotMatch(r.calls, /issue create|issue comment/);
+  assert.match(r.stdout, /UNKNOWN/i);
+});
+
+test("alarm: a conclusion GitHub has not invented yet is unknown, not healthy", function () {
+  // The allow-list is stated positively so a new conclusion is unknown by
+  // default. A deny-list of pending states let anything unlisted read as
+  // healthy and clear a real alarm.
+  var r = runAlarm({
+    openPrs: ONE_HEALTHY_PR,
+    blockedIssues: "272\n",
+    checks: "SUCCESS,SOME_NEW_CONCLUSION",
+  });
+  assert.doesNotMatch(r.calls, CLOSE_CALL);
+});
+
+test("alarm: a failed refresh whose PR merged does not call its own status unknown", function () {
+  // may_clear is empty for two different reasons. Tonight's PR merged, so
+  // nothing is raised, but the status is `failure` and perfectly well known;
+  // reporting it as unknown misdescribes the one night a reader is looking at.
+  var r = runAlarm({
+    openPrs: ONE_HEALTHY_PR,
+    blockedIssues: "",
+    openedPrState: "MERGED",
+    checks: "SUCCESS",
+    env: {
+      REFRESH_OUTCOME: "failure",
+      OPENED_PR: "281",
+      RUN_URL: "https://example/run/7",
+    },
+  });
+  assert.match(r.stdout, /did not succeed \(status: failure\)/);
+  // Targets the string the script really emits on the unknown-status path, so
+  // this can fail. The old wording it named no longer exists anywhere, which
+  // made it an assertion nothing could break.
+  assert.doesNotMatch(r.stdout, /no job status was passed in/);
+});
+
+test("alarm: with no job status, the queue's own verdict still raises", function () {
+  // An absent status is not a fourth verdict that silences everything: it
+  // blocks CLEARING, because nothing says the refresh completed, while a stuck
+  // PR found in the queue is still stuck.
+  var r = runAlarm({
+    openPrs: ONE_PR,
+    blockedIssues: "",
+    checks: "FAILURE",
+    env: { REFRESH_OUTCOME: "" },
+  });
+  assert.match(r.calls, /issue create .*--label vendor-blocked/);
+});
+
+// --- round 8 of the #317 review -----------------------------------------------
+
+test("alarm: a check still running reports an EMPTY conclusion, which is not passing", function () {
+  // gh reports an in-flight CheckRun as `"conclusion": ""` with no .state key
+  // at all, and jq's `//` falls through on null and false but NOT on "". So the
+  // fallback chain yielded "" per check, three running checks joined to ",,",
+  // which is not empty (the -z guard misses it) and contains no non-passing
+  // token (the allow-list misses it too). The PR read healthy and CLEARED the
+  // alarm while its checks were still running: defect 2 from the script header.
+  var r = runAlarm({
+    openPrs: ONE_HEALTHY_PR,
+    blockedIssues: "272\n",
+    checks: ",,",
+  });
+  assert.doesNotMatch(
+    r.calls,
+    CLOSE_CALL,
+    "checks that have not concluded must never clear the alarm",
+  );
+  assert.match(r.stdout, /UNKNOWN/i);
+});
+
+test("alarm: one empty conclusion among successes is still not passing", function () {
+  var r = runAlarm({
+    openPrs: ONE_HEALTHY_PR,
+    blockedIssues: "272\n",
+    checks: "SUCCESS,,SUCCESS",
+  });
+  assert.doesNotMatch(r.calls, CLOSE_CALL);
+});
+
+test("alarm: a measured healthy PR alongside tonight's exempt one is counted, and the clear says so", function () {
+  // The branch where healthy > 0 AND tonight's PR is pending had no test at
+  // all: the counter could be frozen at zero and every test stayed green.
+  var r = runAlarm({
+    openPrs:
+      ONE_PR + "299\t2026-08-28\tvendor(knowledge): refresh to v0.34.156\n",
+    blockedIssues: "272\n",
+    checks: "SUCCESS",
+    env: { OPENED_PR: "299", OPENED_OP: "created" },
+  });
+  assert.match(r.calls, /issue close 272/);
+  assert.match(
+    r.calls,
+    /1 open vendor PR\(s\) report healthy, and tonight's PR #299 is too new to judge/,
+  );
+});
+
+test("alarm: the stuck alarm body names the PRs it could not read, not only the stuck ones", function () {
+  // One stuck PR plus one unreadable PR reported only the stuck one, so a
+  // reader acting on the alarm would fix half the queue and believe it drained.
+  // The line that fixes it had no gate: replacing it with `:` stayed green.
+  var r = runAlarm({
+    openPrs:
+      ONE_PR + "288\t2026-08-20\tvendor(knowledge): refresh to v0.34.150\n",
+    blockedIssues: "",
+    checks: "FAILURE",
+    prViewFailsFor: "288",
+  });
+  assert.match(r.calls, /issue create/);
+  assert.match(r.calls, /#271.*failing check/, "the stuck PR is named");
+  assert.match(r.calls, /These could not be read/);
+  assert.match(r.calls, /#288: gh could not report its state/);
+});
+
+// --- round 9 of the #317 review -----------------------------------------------
+
+test("alarm: a PR GitHub will not merge is stuck, however green its checks are", function () {
+  // mergeStateStatus was reduced to DIRTY / not-DIRTY, so BLOCKED (a required
+  // check that never reported, or a required review) cleared the alarm with
+  // every check green. `gh pr merge --auto` queues silently on BLOCKED and
+  // never fires, so that PR sits forever: the false all-clear this file calls
+  // worse than the silence it replaced, on the frequently-taken path.
+  ["BLOCKED", "DRAFT"].forEach(function (state) {
+    var r = runAlarm({
+      openPrs: ONE_PR,
+      blockedIssues: "",
+      checks: "SUCCESS",
+      mergeStateStatus: state,
+    });
+    assert.match(r.calls, /issue create/, state + " must raise");
+    assert.doesNotMatch(r.calls, CLOSE_CALL, state + " must not clear");
+  });
+});
+
+test("alarm: a merge state that is neither mergeable nor stuck is unknown", function () {
+  // BEHIND needs an update and UNKNOWN is still being computed. Neither says
+  // the plugin is consuming knowledge, and neither says it has stopped.
+  ["BEHIND", "UNKNOWN"].forEach(function (state) {
+    var r = runAlarm({
+      openPrs: ONE_HEALTHY_PR,
+      blockedIssues: "272\n",
+      checks: "SUCCESS",
+      mergeStateStatus: state,
+    });
+    assert.doesNotMatch(r.calls, CLOSE_CALL, state + " must not clear");
+    assert.doesNotMatch(r.calls, /issue create/, state + " must not raise");
+  });
+});
+
+test("alarm: a mergeable state GitHub already uses does clear", function () {
+  // The allow-list has to admit the states a healthy vendor PR really sits in,
+  // or the alarm can never clear and that is defect 1 again.
+  ["CLEAN", "HAS_HOOKS", "UNSTABLE"].forEach(function (state) {
+    var r = runAlarm({
+      openPrs: ONE_HEALTHY_PR,
+      blockedIssues: "272\n",
+      checks: "SUCCESS",
+      mergeStateStatus: state,
+    });
+    assert.match(r.calls, /issue close 272/, state + " must clear");
+  });
+});
+
+test("alarm: tonight's own PR is exempt from EVERY stuck test, not only pending checks", function () {
+  // `gh pr merge --auto` runs in the step immediately before this one, so
+  // autoMergeRequest can lag. Exempting tonight's PR from the pending-checks
+  // reading only meant that lag raised an alarm titled "the plugin is not
+  // consuming knowledge" on the very night it did, which is what the header
+  // has always said must not happen.
+  var r = runAlarm({
+    openPrs: "299\t2026-08-28\tvendor(knowledge): refresh to v0.34.156\n",
+    blockedIssues: "",
+    checks: "SUCCESS",
+    noAutoMerge: true,
+    env: { OPENED_PR: "299", OPENED_OP: "created" },
+  });
+  assert.doesNotMatch(r.calls, /issue create|issue comment/);
+});
+
+test("alarm: the queue is read past gh's default page of 30", function () {
+  // The pile IS the signal, and a pile is exactly when it exceeds the default
+  // window. Newest-first, so past 30 the OLDEST and most stuck fall outside it.
+  var r = runAlarm({ openPrs: "", blockedIssues: "" });
+  assert.match(r.calls, /pr list .*--limit 100/);
+});
+
+test("alarm: a successful quiet night writes no bare heading to the run summary", function () {
+  var r = runAlarm({ openPrs: "", blockedIssues: "272\n" });
+  assert.doesNotMatch(
+    r.summary,
+    /^###\s*Run:/m,
+    "a headline-less night must not emit an empty heading",
   );
 });


### PR DESCRIPTION
Closes #317.

## What was wrong

On 2026-08-27 the vendor refresh died at "Re-record the blank-box baseline". The steps that open and auto-merge the PR were skipped, so no PR was opened. `vendor-queue-alarm.sh` decides stuck / healthy / unknown by inspecting open vendor PRs, found none, and **cleared the alarm on the night the plugin stopped consuming knowledge**.

A queue cannot show a PR that was never opened. So the step now passes the job's own status in, and the script reads why it is running before it reads the queue.

## What changes

- **The step passes `REFRESH_OUTCOME: ${{ job.status }}`**, the run URL, and the number and operation (created or updated) of the PR carrying tonight's refresh. A failed refresh raises or updates the alarm and can never clear it.
- **The alarm claims only what it measured.** An empty `OPENED_PR` is not proof no PR exists, because `create-pull-request` sets its outputs last, so the wording is "the PR step reported no PR" and never "the plugin consumed nothing". Whether tonight's PR merged is read with gh's exit code, so a 502 is unknown rather than "not merged", which would put a false title on a night the knowledge landed.
- **A cancelled run is a failed refresh** like any other non-success. A cancel is a timeout, a concurrency cancel or a lost runner as often as it is a human, and giving it its own quiet verdict let a nightly that hangs every night go silent under a status word.
- **Health is positive, and about mergeability as well as checks.** A PR is healthy only when every check reported a conclusion on an explicit passing list (`SUCCESS`, `SKIPPED`, `NEUTRAL`, the ones GitHub counts as passing for a required check, so auto-merge fires on them) **and** GitHub reports it mergeable now (`CLEAN`, `HAS_HOOKS`, `UNSTABLE`). `STALE` describes an older commit; `BLOCKED` and `DRAFT` are stuck; `BEHIND` and `UNKNOWN` are neither.
- **A check that is still running reports an EMPTY conclusion**, and jq's `//` falls through on null and false but not on `""`. So the old fallback chain yielded `""` per in-flight check, three running checks joined to `,,` (not empty, and holding no non-passing token), and the PR read healthy and cleared the alarm while its checks were still running. The conclusion is now the first non-empty of `.conclusion`, `.state`, `PENDING`.
- **The queue is read with `--limit 100`.** gh pages at 30, newest first, and a pile is exactly when it exceeds that window, so the oldest and most stuck PRs fell outside it.
- **Tonight's own PR is exempt from every stuck test**, not only from the pending-checks reading. `gh pr merge --auto` runs in the step immediately before, so the lag before `autoMergeRequest` appears raised an alarm about the one PR that had just succeeded.
- One headline and one note are assembled per night, so the run summary and the issue body cannot state the same facts in two shapes. When gh cannot list, create or comment, the reason reaches the run summary instead of nowhere.

## The tests now exercise the thing they were guarding

The stub answered `pr view` with the already-joined row, so **no test ever executed the `--jq` filter**. Every semantic element of it could be deleted with the suite green, including the empty-conclusion fix above. The stub now emits the JSON gh really returns and lets the script's own filter run through real `jq`. The five mutations that used to pass now fail:

```
autoMergeRequest branch -> ""            # fail 1
mergeStateStatus -> always CLEAN         # fail 1
drop the StatusContext .state fallback   # fail 2
revert the // chain                      # fail 1
PR .state -> constant OPEN               # fail 1
```

## Review history

Five rounds (5 to 9), each of which found real defects, most in the previous round's fix. Two were **false all-clears on the frequently-taken path**: the empty-conclusion case above, and a `BLOCKED` PR clearing the alarm though `gh pr merge --auto` will never fire on it. Several were gates that could not fail: the `healthy` counter (`healthy=$((healthy + 0))` left the whole suite green), the line naming unreadable PRs inside a stuck alarm's body, and three `doesNotMatch` assertions naming strings the script no longer emits.

A defect I introduced and the tests caught: collapsing three `gh pr view` calls into one meant parsing a joined row, and a tab is whitespace, so `read` collapsed the empty middle field and a green PR with auto-merge off read as healthy. Joined on `|` instead.

Round 9 also walked the three verdicts as a state machine over `REFRESH_OUTCOME` x opened-PR state x queue contents and found no other path that clears or stays silent wrongly, and confirmed the exit-code captures, the here-string loop scoping and the `IFS` splitting are sound.

## Proof

- Full plugin suite **2163 tests, 0 failures, 1 skipped** on the rebased branch.
- Every guard on a verdict path is mutation-tested: each mutant turns exactly its own test red.
- Rebased onto `main` after #321 merged; both entries kept in `CHANGELOG.md`, `plugin.json` at 2026.8.27 since main is at .26.

## Context

#321 (the newcomer-chip fix) merged first and restarted the nightly, which then opened #322 refreshing to v0.34.156. This PR is what makes a refused bank visible at all, since a refusal exits before any PR exists.
