### PR TITLE
fix(preview): the browser bundle inlines the retired-slug map it reads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,22 @@ are summarized at the release level.
   slug, plus a guard that the cache cannot come back.
 
 
+- **The flow preview did not resolve a renamed component, and could not say so.**
+  ([#PR](_PR link added at open_)) knowledge #601 made the renderer resolve a retired slug
+  through the identity ledger, but the map it reads is a separate vendored module,
+  `ds-retired-slugs.js`, and there is no fs in the browser: `ds-html-map.js` takes it from
+  `require` in Node and from `window.dsRetiredSlugs` in the browser. `assemble-preview.js`
+  inlines its renderer modules from a hand-kept list, and the new module was never added to it,
+  so the browser fell back to the empty map. An empty map is a legitimate state, no renames
+  recorded yet, which is exactly why this was silent: the whole Node-side suite passed while a
+  flow preview rendered `tag-default` as a grey chip. The module is now inlined before its
+  reader, and `preview-retired-slug-wiring.test.js` pulls the assembled bundle's own scripts
+  back out, runs them with a browser's globals and no `require`, and requires the retired slug
+  to render byte-identically to its current name. Moving the module after its reader turns the
+  behavioural assertions red, not only the ordering one, so the order is proved load-bearing
+  rather than asserted as style. Its specimen is read from the ledger, so it follows the next
+  rename by itself.
+
 - **A component archived in Figma while it is rebuilt no longer costs its tests.**
   ([#327](https://github.com/volivarii/Actian-DS-Claude-plugin/pull/327)) The knowledge v0.34.157 refresh unpublished
   `chat-with-ai-steward`: an old version being rebuilt, archived in the file rather than deleted,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,7 +34,7 @@ are summarized at the release level.
 
 
 - **The flow preview did not resolve a renamed component, and could not say so.**
-  ([#PR](_PR link added at open_)) knowledge #601 made the renderer resolve a retired slug
+  ([#328](https://github.com/volivarii/Actian-DS-Claude-plugin/pull/328)) knowledge #601 made the renderer resolve a retired slug
   through the identity ledger, but the map it reads is a separate vendored module,
   `ds-retired-slugs.js`, and there is no fs in the browser: `ds-html-map.js` takes it from
   `require` in Node and from `window.dsRetiredSlugs` in the browser. `assemble-preview.js`

--- a/plugins/actian-design-system/.claude-plugin/plugin.json
+++ b/plugins/actian-design-system/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "actian-design-system",
   "description": "Actian Design System toolkit — generate wireframe flows with prototype wiring, create component briefs, audit designs, compare flows, and build presentations. 8 skills (with tiered generation: recognized / adapted / improvised), 9 agents, 155 tokens (3 themes, 8 collections), WCAG 2.2 AA. DS knowledge vendored from volivarii/actian-ds-knowledge.",
-  "version": "2026.8.29",
+  "version": "2026.8.30",
   "author": {
     "name": "Actian UX Team"
   },

--- a/plugins/actian-design-system/scripts/renderers/assemble-preview.js
+++ b/plugins/actian-design-system/scripts/renderers/assemble-preview.js
@@ -64,6 +64,15 @@ var TYPE_CONFIGS = {
       // window.dsHtmlMap to route library:"ds" INSTANCE nodes). Order is
       // load-bearing: fm-html-map → appearance-style → appearance-render →
       // ds-html-map → render-node → flow-renderer.
+      // ds-retired-slugs.js must load BEFORE ds-html-map.js: the map is a
+      // separate vendored module and there is no fs in the browser, so
+      // ds-html-map.js reads it from window.dsRetiredSlugs when its IIFE
+      // evaluates. Absent, it falls back to an empty map, which is a
+      // legitimate state (no renames recorded yet) and therefore SILENT:
+      // every slug the design system has renamed would render as a graceful
+      // chip in the preview while the Node path stayed correct. Order is
+      // load-bearing here for the same reason it is for appearance-render.
+      rendererModule.modulePath("html-renderers/ds-retired-slugs.js"),
       rendererModule.modulePath("html-renderers/ds-html-map.js"),
       // render-node.js UMD must load BEFORE flow-renderer.js so the IIFE can
       // pick it up via window.renderNode (shared structural-node renderer).

--- a/plugins/actian-design-system/tests/integration/preview-retired-slug-wiring.test.js
+++ b/plugins/actian-design-system/tests/integration/preview-retired-slug-wiring.test.js
@@ -1,0 +1,227 @@
+"use strict";
+
+// preview-retired-slug-wiring.test.js — DELIVERABLE-level proof that the
+// BROWSER flow bundle (assemble-preview.js --type flow) resolves a slug the
+// design system has renamed, the way the Node path already does.
+//
+// knowledge #601 made the renderer resolve a retired slug through the identity
+// ledger, so content authored against an old name still renders. The map it
+// reads is a SEPARATE vendored module, ds-retired-slugs.js, and there is no fs
+// in the browser: ds-html-map.js takes it from `require` in Node and from
+// window.dsRetiredSlugs in the browser, falling back to an empty map when
+// neither supplies one. An empty map is a legitimate state (no renames
+// recorded yet) and resolves nothing, so a bundle that forgets to inline the
+// module degrades in complete silence: every test on the Node path still
+// passes, while a flow preview renders a renamed component as a grey chip.
+//
+// This is the same failure shape preview-appearance-wiring.test.js guards for
+// appearance-style.js and appearance-render.js, one module later. Both halves
+// are asserted deliberately: that the module is inlined in the right ORDER,
+// and, because a marker can be present while the wiring is broken, that the
+// assembled bundle's own scripts actually RESOLVE a retired slug when run with
+// a browser's globals and no require.
+
+var { describe, it, before } = require("node:test");
+var assert = require("node:assert");
+var spawnSync = require("child_process").spawnSync;
+var path = require("path");
+var os = require("os");
+var fs = require("fs");
+var vm = require("vm");
+
+var SCRIPT = path.join(
+  __dirname,
+  "..",
+  "..",
+  "scripts",
+  "renderers",
+  "assemble-preview.js",
+);
+
+var renderer = require("../../scripts/lib/renderer.js");
+var RETIRED = require(
+  renderer.modulePath("html-renderers/ds-retired-slugs.js"),
+).RETIRED_SLUGS;
+
+// Derive the specimen instead of naming one: every entry here is a rename the
+// ledger recorded, and which names are current changes with every Figma sync.
+// Prefer a pair whose CURRENT slug has a bespoke leaf, so "did it resolve" is
+// answerable from the markup alone without an anatomy doc map.
+var BUILT = {};
+(renderer.dsHtmlMap.BUILT_SLUGS || []).forEach(function (s) {
+  BUILT[s] = true;
+});
+var SPECIMEN = Object.keys(RETIRED)
+  .sort() // deterministic across runs and machines
+  .map(function (retired) {
+    return { retired: retired, current: RETIRED[retired] };
+  })
+  .filter(function (p) {
+    return BUILT[p.current];
+  })[0];
+
+function fixture(slug) {
+  return {
+    meta: { feature: "Retired slug", app: "Preview" },
+    screens: [
+      {
+        id: "s1",
+        name: "S1",
+        content: [
+          {
+            type: "INSTANCE",
+            library: "ds",
+            dsSlug: slug,
+            props: { Label: "Probe" },
+          },
+        ],
+      },
+    ],
+  };
+}
+
+function assemble(slug) {
+  var tmpJson = path.join(
+    os.tmpdir(),
+    "preview-retired-slug-" +
+      Date.now() +
+      "-" +
+      Math.random().toString(36).slice(2, 8) +
+      ".json",
+  );
+  var outputFile = tmpJson.replace(/\.json$/, ".html");
+  fs.writeFileSync(tmpJson, JSON.stringify(fixture(slug)), "utf8");
+  var result = spawnSync(
+    "node",
+    [SCRIPT, tmpJson, "--type", "flow", "-o", outputFile],
+    { encoding: "utf8" },
+  );
+  var html = fs.existsSync(outputFile)
+    ? fs.readFileSync(outputFile, "utf8")
+    : "";
+  fs.unlinkSync(tmpJson);
+  if (fs.existsSync(outputFile)) fs.unlinkSync(outputFile);
+  return { status: result.status, stderr: result.stderr, html: html };
+}
+
+// Pull the inlined renderer modules back out of the deliverable and run them
+// the way a browser would: a window, no require, no fs. Anything the bundle
+// failed to inline is simply absent, which is the whole point.
+function renderInBrowserBundle(html, node) {
+  var sandbox = { console: console };
+  sandbox.window = sandbox;
+  var ctx = vm.createContext(sandbox);
+
+  var re = /<script>\n\s*\/\* ([^*]+?) \*\/\n([\s\S]*?)<\/script>/g;
+  var m;
+  var loaded = [];
+  while ((m = re.exec(html))) {
+    loaded.push(m[1].trim());
+    vm.runInContext(m[2], ctx, { filename: m[1].trim() });
+  }
+  assert.ok(
+    loaded.indexOf("ds-html-map.js") !== -1,
+    "the bundle did not inline ds-html-map.js at all, so this test cannot " +
+      "say anything about resolution. Inlined: " + loaded.join(", "),
+  );
+  return {
+    loaded: loaded,
+    html: sandbox.dsHtmlMap.renderDSComponent(node),
+  };
+}
+
+function isGracefulChip(markup) {
+  return /<span class="ds-component"/.test(String(markup));
+}
+
+describe("assemble-preview --type flow: retired-slug wiring", function () {
+  var r;
+
+  before(function () {
+    assert.ok(
+      SPECIMEN,
+      "the vendored identity ledger records no rename whose current slug is " +
+        "BUILT, so there is no specimen for this gate. Repoint it at an " +
+        "anatomy-tier pair or retire it rather than letting it pass vacuously.",
+    );
+    r = assemble(SPECIMEN.retired);
+  });
+
+  it("assembles cleanly", function () {
+    assert.strictEqual(r.status, 0, "exits cleanly: " + r.stderr);
+  });
+
+  it("inlines ds-retired-slugs.js BEFORE ds-html-map.js", function () {
+    // ds-html-map.js captures window.dsRetiredSlugs when its IIFE evaluates,
+    // so a module inlined after it is a module that arrived too late.
+    var retiredIdx = r.html.indexOf("/* ds-retired-slugs.js */");
+    var dsMapIdx = r.html.indexOf("/* ds-html-map.js */");
+    assert.ok(
+      retiredIdx !== -1,
+      "ds-retired-slugs.js is not inlined, so window.dsRetiredSlugs is " +
+        "undefined in the browser and every renamed component chips",
+    );
+    assert.ok(dsMapIdx !== -1, "ds-html-map.js marker present");
+    assert.ok(
+      retiredIdx < dsMapIdx,
+      "ds-retired-slugs.js must be inlined before ds-html-map.js",
+    );
+  });
+
+  it("carries the ledger's own mapping, not an empty map", function () {
+    // Non-vacuity: an inlined module that generated to {} would satisfy the
+    // marker check above while resolving nothing.
+    var idx = r.html.indexOf("/* ds-retired-slugs.js */");
+    // Anchor first. A -1 index would make substring() read from the top of
+    // the document, where spec-data mentions the slug anyway, and this
+    // assertion would pass on a bundle that inlined nothing.
+    assert.ok(idx !== -1, "ds-retired-slugs.js is not inlined");
+    var block = r.html.substring(idx, r.html.indexOf("</script>", idx));
+    assert.ok(
+      block.indexOf(SPECIMEN.retired) !== -1 &&
+        block.indexOf(SPECIMEN.current) !== -1,
+      "the inlined map must carry " +
+        SPECIMEN.retired +
+        " -> " +
+        SPECIMEN.current,
+    );
+  });
+
+  it("resolves the retired slug when run with a browser's globals", function () {
+    var out = renderInBrowserBundle(r.html, {
+      type: "INSTANCE",
+      library: "ds",
+      dsSlug: SPECIMEN.retired,
+      props: { Label: "Probe" },
+    });
+    assert.ok(
+      !isGracefulChip(out.html),
+      SPECIMEN.retired +
+        " rendered as a graceful chip in the browser bundle: " +
+        String(out.html).slice(0, 160),
+    );
+  });
+
+  it("renders the retired slug EXACTLY as its current name", function () {
+    // The contract knowledge #601 rests on: a retired slug renders what the
+    // component answers to now. Asserting "not a chip" alone would pass on a
+    // half-resolved render that picked up the leaf but not its variant data.
+    var current = renderInBrowserBundle(r.html, {
+      type: "INSTANCE",
+      library: "ds",
+      dsSlug: SPECIMEN.current,
+      props: { Label: "Probe" },
+    });
+    var retired = renderInBrowserBundle(r.html, {
+      type: "INSTANCE",
+      library: "ds",
+      dsSlug: SPECIMEN.retired,
+      props: { Label: "Probe" },
+    });
+    assert.strictEqual(
+      retired.html,
+      current.html,
+      SPECIMEN.retired + " must render identically to " + SPECIMEN.current,
+    );
+  });
+});


### PR DESCRIPTION
Stacked on #327, which is where `ds-retired-slugs.js` first arrives in the vendored tree. Retarget to `main` once that merges.

## What was wrong

knowledge #601 made the renderer resolve a retired slug through the identity ledger, so a flow authored against an old component name still renders. The map it reads is a **separate vendored module** and there is no fs in the browser: `ds-html-map.js` takes it from `require` in Node and from `window.dsRetiredSlugs` in the browser.

`assemble-preview.js` inlines its renderer modules from a hand-kept list and the new module was never added to it, so the browser got neither source and fell back to an empty map. That fallback is correct on its own terms, an empty map means no renames recorded yet, which is exactly why nothing went red: **the entire Node-side suite passed while a flow preview rendered `tag-default` as a grey chip.** Measured at the surface, the fix had not shipped.

```
before:  <span class="ds-component" data-slug="tag-default">tag-default</span>
after:   <span class="ds-tag ds-tag--shared"><span class="ds-tag__icon">...
```

`preview-appearance-wiring.test.js` already guards this exact failure shape for `appearance-style.js` and `appearance-render.js`. The new module was added to neither the list nor a guard.

## The gate

It does not stop at the marker. `preview-retired-slug-wiring.test.js` pulls the assembled bundle's own `<script>` blocks back out of the deliverable, runs them with a browser's globals and no `require`, and requires the retired slug to render **byte-identically** to what its current name renders.

Moving the module after its reader turns the two behavioural assertions red as well as the ordering one, so the order is proved load-bearing rather than asserted as style.

Nothing in it is hand-listed. The specimen is read from the vendored ledger and filtered to a pair whose current slug is BUILT, so it follows the next rename by itself, and the run refuses to pass when the ledger records no usable pair rather than passing vacuously.

## Scope

`--type flow` was the only gap: `brief` and `presentation` never inline `ds-html-map.js`, and `flow-share` renders server-side in Node.

## Proof

**2186 tests, 2181 pass, 0 fail, 5 skipped.** Written test-first; the first RED had an assertion that passed vacuously (a `-1` index made `substring` read from the top of the document) and that was fixed before going green.