### PR TITLE
fix(flow): the tier badge is author provenance, so it stays off the screen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,19 @@ are summarized at the release level.
 
 ## [Unreleased]
 
+### Changed
+
+- **The tier badge shows on the Overview contact sheet only, not on the screens themselves.**
+  It is author provenance: the tier a screen was classified as, the recipe it matched, the
+  confidence, and whether it carried a justification, all four in its title attribute. It was
+  emitted inside `.screen__content-area` at every one of `screen()`'s three render paths and shown
+  in both views, so a prototype shared with anyone outside the team carried "tier 2" next to the
+  breadcrumb of every screen. The markup is unchanged and the same four fields stay in
+  `flow-data.json`; only the stylesheet changed, revealing the badge under
+  `.proto-stage--overview`. `tests/renderers/tier-badge-author-only.test.js` asserts both
+  directions, because a guard that only checked "hidden by default" would pass on a stylesheet
+  that never shows it at all, which silently deletes a signal the author uses.
+
 ### Fixed
 
 - **The vendor lane had been red for two days, and this is the THIRD refresh in a row to break in

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,8 @@ are summarized at the release level.
 
 ### Changed
 
-- **The tier badge shows on the Overview contact sheet only, not on the screens themselves.**
+- **The tier badge shows on the Overview contact sheet only, not on the screens themselves**
+  ([#341](https://github.com/volivarii/Actian-DS-Claude-plugin/pull/341)).
   It is author provenance: the tier a screen was classified as, the recipe it matched, the
   confidence, and whether it carried a justification, all four in its title attribute. It was
   emitted inside `.screen__content-area` at every one of `screen()`'s three render paths and shown

--- a/plugins/actian-design-system/.claude-plugin/plugin.json
+++ b/plugins/actian-design-system/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "actian-design-system",
   "description": "Actian Design System toolkit — generate wireframe flows with prototype wiring, create component briefs, audit designs, compare flows, and build presentations. 8 skills (with tiered generation: recognized / adapted / improvised), 9 agents, 155 tokens (3 themes, 8 collections), WCAG 2.2 AA. DS knowledge vendored from volivarii/actian-ds-knowledge.",
-  "version": "2026.9.3",
+  "version": "2026.9.4",
   "author": {
     "name": "Actian UX Team"
   },

--- a/plugins/actian-design-system/scripts/renderers/html-renderers/flow-renderer.css
+++ b/plugins/actian-design-system/scripts/renderers/html-renderers/flow-renderer.css
@@ -136,9 +136,22 @@
   color: var(--fm-base-500);
 }
 
-/* ── Tier badge ── */
+/* ── Tier badge ──
+   Author provenance: which tier the screen was classified as, the recipe it
+   matched, the confidence, and whether it carried a justification (all four
+   are in the title attribute). It is not part of the screen being reviewed,
+   and it used to render inside .screen__content-area in BOTH views, so a
+   prototype shared with anyone outside the team carried "tier 2" next to its
+   breadcrumb. It now appears only on the Overview contact sheet, whose reader
+   is the person who generated the flow. The same four fields stay in
+   flow-data.json either way, so nothing is lost by hiding it here.
+   Scope note: the reveal keys on the flow-share wrapper's view class, so on an
+   `assemble-preview --type flow` bundle the badge stays hidden with no way to
+   show it. That path assembles no deliverable anyone reviews (two renderer-
+   wiring tests are its only callers), so it is left alone rather than given a
+   second selector to keep in step. */
 .tier-badge {
-  display: inline-block;
+  display: none;
   padding: 2px 6px;
   border-radius: 4px;
   font-size: 11px;
@@ -157,6 +170,9 @@
   background: var(--fm-base-300);
   border-color: var(--fm-base-500);
   color: var(--fm-text-primary);
+}
+.proto-stage--overview .tier-badge {
+  display: inline-block;
 }
 
 /* ── FM Skeleton (Tier B streaming placeholder) ──────────────────────────

--- a/plugins/actian-design-system/tests/renderers/tier-badge-author-only.test.js
+++ b/plugins/actian-design-system/tests/renderers/tier-badge-author-only.test.js
@@ -1,0 +1,129 @@
+#!/usr/bin/env node
+"use strict";
+
+/**
+ * tier-badge-author-only.test.js
+ *
+ * The tier badge is author provenance: which tier the screen was classified
+ * as, the recipe it matched, the confidence, and whether it carried a
+ * justification. It is emitted INSIDE .screen__content-area, at all three of
+ * screen()'s render paths, so it draws on the screen itself rather than in the
+ * deliverable's chrome. That put "tier 2" next to the breadcrumb of every
+ * screen in a prototype anyone might share outside the team.
+ *
+ * The markup is deliberately unchanged: the badge and its title attribute
+ * still ship, and the same four fields are in flow-data.json regardless. What
+ * changed is that the CSS reveals it only under .proto-stage--overview, the
+ * contact-sheet view, whose reader is the person who generated the flow.
+ *
+ * So the guard is on the STYLESHEET, not the markup, and it has to assert both
+ * directions. Asserting only "hidden by default" would pass on a stylesheet
+ * that never shows it at all, which silently deletes a signal the author uses.
+ */
+
+var { describe, it } = require("node:test");
+var assert = require("node:assert");
+var fs = require("fs");
+var path = require("path");
+
+var CSS_PATH = path.join(
+  __dirname,
+  "..",
+  "..",
+  "scripts",
+  "renderers",
+  "html-renderers",
+  "flow-renderer.css",
+);
+var JS_PATH = path.join(
+  __dirname,
+  "..",
+  "..",
+  "scripts",
+  "renderers",
+  "html-renderers",
+  "flow-renderer.js",
+);
+
+var CSS = fs.readFileSync(CSS_PATH, "utf8");
+var JS = fs.readFileSync(JS_PATH, "utf8");
+
+// Body of the first rule whose selector is exactly `selector`. Brace-counted
+// rather than regex-matched, so a later rule mentioning the same class (the
+// [data-tier] variants, the overview reveal) cannot be picked up instead.
+function ruleBody(css, selector) {
+  var lines = css.split("\n");
+  for (var i = 0; i < lines.length; i++) {
+    if (lines[i].trim() !== selector + " {") continue;
+    var depth = 1;
+    var body = [];
+    for (var j = i + 1; j < lines.length && depth > 0; j++) {
+      depth += (lines[j].match(/{/g) || []).length;
+      depth -= (lines[j].match(/}/g) || []).length;
+      if (depth > 0) body.push(lines[j]);
+    }
+    return body.join("\n");
+  }
+  return null;
+}
+
+// Drop comments so the prose explaining the old value is not read as the value.
+function declarations(body) {
+  return String(body == null ? "" : body).replace(/\/\*[\s\S]*?\*\//g, "");
+}
+
+describe("tier badge is author provenance, not part of the screen", function () {
+  it("still renders into the screen markup", function () {
+    // If the badge stopped being emitted, the CSS below would be guarding
+    // nothing and would keep passing. Assert the subject is present first.
+    assert.ok(
+      /class="tier-badge"/.test(JS),
+      "flow-renderer.js no longer emits a tier badge. If it was removed on " +
+        "purpose, delete this guard rather than relaxing it.",
+    );
+  });
+
+  it("is hidden in the prototype view", function () {
+    var body = declarations(ruleBody(CSS, ".tier-badge"));
+    assert.ok(body !== "", ".tier-badge rule not found in flow-renderer.css");
+    assert.ok(
+      /display:\s*none\s*;/.test(body),
+      "The base .tier-badge rule must hide it. It renders inside " +
+        ".screen__content-area, so any visible default puts internal tier " +
+        "metadata on every screen of a shared prototype.",
+    );
+  });
+
+  it("is revealed on the Overview contact sheet", function () {
+    var body = declarations(ruleBody(CSS, ".proto-stage--overview .tier-badge"));
+    assert.ok(
+      body !== null && body !== "",
+      "No rule reveals the tier badge under .proto-stage--overview. Hiding it " +
+        "everywhere deletes a signal the author uses; it belongs on the " +
+        "contact sheet, not on the screen.",
+    );
+    assert.ok(
+      /display:\s*inline-block\s*;/.test(body),
+      "the Overview rule must restore the badge to inline-block",
+    );
+  });
+
+  it("the Overview view class it keys on is the one the deliverable emits", function () {
+    // The reveal is worthless if the class never appears. This is the join:
+    // the stylesheet's hook and the template's class have to be the same word.
+    var emitters = [
+      path.join(__dirname, "..", "..", "templates", "flow-prototype-wrapper.html"),
+      path.join(__dirname, "..", "..", "scripts", "renderers", "assemble-preview.js"),
+      JS_PATH,
+    ];
+    var found = emitters.some(function (f) {
+      return fs.existsSync(f) && /proto-stage--overview/.test(fs.readFileSync(f, "utf8"));
+    });
+    assert.ok(
+      found,
+      "Nothing in the deliverable emits .proto-stage--overview, so the badge " +
+        "would be hidden in both views. Re-derive which class marks the " +
+        "Overview view before changing the rule.",
+    );
+  });
+});


### PR DESCRIPTION
The tier badge carries the tier a screen was classified as, the recipe it matched, the confidence, and whether it carried a justification. All four are useful, and all four are for the person who generated the flow.

It was emitted inside `.screen__content-area` at each of `screen()`'s three render paths and shown in **both** views, so every screen of a prototype shared with anyone outside the team carried "tier 2" next to its breadcrumb.

Found by rehearsing a six-screen flow end to end and looking at the deliverable, ahead of the 15th.

### The change is in the stylesheet only

The markup is deliberately unchanged: the badge and its title attribute still ship, and the same four fields are in `flow-data.json` regardless. The badge is hidden by default and revealed under `.proto-stage--overview`, the contact-sheet view whose reader is the author.

Verified in the browser on a rendered six-screen flow: **0 of 6 visible in Prototype, 6 of 6 in Overview**, tooltips intact.

Scope note, recorded in the CSS: the reveal keys on the flow-share wrapper's view class, so an `assemble-preview --type flow` bundle keeps the badge hidden with no way to show it. That path assembles no deliverable anyone reviews (two renderer-wiring tests are its only callers), so it is left alone rather than given a second selector to keep in step.

### The guard

`tests/renderers/tier-badge-author-only.test.js` asserts **both directions**. Hidden-by-default alone would pass on a stylesheet that never shows it at all, which silently deletes a signal rather than relocating it. It also asserts the badge is still emitted (so the CSS assertions have a subject) and that the reveal keys on a class the deliverable actually emits.

That last assertion **went red on its first run**: I had pointed it at `assemble-preview.js`, and the class lives in `templates/flow-prototype-wrapper.html:337`. The guard caught my own unverified premise, which is why it is written that way.

Mutation-proved: making the badge visible by default, and dropping the Overview reveal, each turn the matching test red.

### Checks

Full suite 2189 tests / 2184 pass / 5 skipped / 0 fail. No goldens reference the badge, so none changed. Version bumped `2026.9.3` to `2026.9.4` for the bump gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016xG3HeZXekquJKpkv7CVDN