### PR TITLE
fix(render): generated screens read each app's real navigation, not a leaf default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,8 @@ are summarized at the release level.
 
 ### Fixed
 
-- **Every generated screen showed the same four navigation items, in every app.** The side rail read
+- **Every generated screen showed the same four navigation items, in every app**
+  ([#351](https://github.com/volivarii/Actian-DS-Claude-plugin/pull/351)). The side rail read
   `Catalog, Pipelines, Connections, Settings` on every screen of every flow. Those four are the
   side-nav leaf's own specimen default and they belong to no Actian product: Studio's navigation is
   seven items and does not include Pipelines, Administration's is eight, and Explorer is on record

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,40 @@ are summarized at the release level.
 
 ## [Unreleased]
 
+### Fixed
+
+- **Every generated screen showed the same four navigation items, in every app.** The side rail read
+  `Catalog, Pipelines, Connections, Settings` on every screen of every flow. Those four are the
+  side-nav leaf's own specimen default and they belong to no Actian product: Studio's navigation is
+  seven items and does not include Pipelines, Administration's is eight, and Explorer is on record
+  as having none. app-context has held each app's real navigation the whole time and the render path
+  never read it.
+
+  The chain, none of which errored: `ds-screen-tree.js` kept its own hardcoded `TEMPLATE_CHROME` and
+  its own `resolveChrome`, while the app-context-reading `resolveChrome` in `scripts/lib/app-context/`
+  was never called from a render; `screenTree` defaulted the sidebar config to the **number** 6;
+  `chromeNodes` tested `Array.isArray` on it, set nothing, and shipped empty props; and the leaf
+  substituted its default for the empty props.
+
+  Chrome is now resolved from app-context, injected process-wide in `scripts/lib/renderer.js`
+  alongside the existing icon injection. Studio and Administration render their own navigation.
+  `administration` resolves as a template name, which it never did before (only `admin` was in the
+  table, so a screen authored with the app's full name got no chrome at all). Explorer renders no
+  standing rail, because app-context records none; if that turns out to be wrong, the fix is to
+  author Explorer's sidebar in app-context, where the other two apps already declare theirs, and the
+  plugin follows.
+
+  **An authored screen still wins.** A screen carrying `sidebar: { items: [...] }` renders those
+  items on any app, including Explorer. app-context is the default for a screen that says nothing
+  about its rail, never an override of one that does. That precedence was missing from the first cut
+  of this change and the explorer HTML golden caught it, because that fixture authors two items of
+  its own and had its rail suppressed.
+
+  `tests/renderers/screen-chrome-is-grounded.test.js` asserts the join in both directions: the rail
+  carries the app's own labels, read from app-context rather than typed into the test, and it does
+  not carry the leaf's default. Both halves are needed, because "Catalog" appears in Studio's real
+  list *and* in the default, which is how this went unnoticed.
+
 ### Changed
 
 - **Tier provenance no longer reaches the deliverable at all**

--- a/plugins/actian-design-system/.claude-plugin/plugin.json
+++ b/plugins/actian-design-system/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "actian-design-system",
   "description": "Actian Design System toolkit — generate wireframe flows with prototype wiring, create component briefs, audit designs, compare flows, and build presentations. 8 skills (with tiered generation: recognized / adapted / improvised), 9 agents, 155 tokens (3 themes, 8 collections), WCAG 2.2 AA. DS knowledge vendored from volivarii/actian-ds-knowledge.",
-  "version": "2026.9.6",
+  "version": "2026.9.7",
   "author": {
     "name": "Actian UX Team"
   },

--- a/plugins/actian-design-system/scripts/lib/renderer.js
+++ b/plugins/actian-design-system/scripts/lib/renderer.js
@@ -88,6 +88,33 @@ var defaultProps = JSON.parse(
 // glyph would silently blank. That is the failure this whole task exists to
 // prevent, so a wrong shape must be loud. Mirrors knowledge's canonical caller,
 // scripts/render/derive-from-renderer.js.
+// --- App context injection ------------------------------------------------
+// ds-screen-tree builds the chrome nodes for every generated screen and runs in
+// the browser as well as in Node, so it cannot read app-context itself. This is
+// the process-wide load point (same reasoning as the icon injection above), and
+// every render path reaches it: flow-renderer.js pulls dsHtmlMap from here, so
+// requiring this module is what arms the chrome.
+//
+// Without it, ds-screen-tree has no app record, chromeNodes sends the side-nav
+// leaf empty props, and the leaf falls back to its own specimen default of
+// "Catalog, Pipelines, Connections, Settings". That default belongs to no app:
+// Studio's real navigation is seven items and does not include Pipelines,
+// Administration's is eight, and Explorer is on record as having none. Every
+// generated screen of every app shipped those four items.
+//
+// Loaded, not asserted-non-empty: an app-context that fails to parse leaves the
+// chrome ungrounded rather than blank, which is the pre-existing behaviour, and
+// tests/renderers/screen-chrome-is-grounded.test.js is what makes a broken
+// injection fail loudly rather than silently reinstating the four items.
+var dsScreenTree = require("../renderers/html-renderers/ds-screen-tree.js");
+var appContext = null;
+try {
+  appContext = JSON.parse(fs.readFileSync(PATHS.appContext, "utf8"));
+} catch (e) {
+  appContext = null;
+}
+dsScreenTree.setAppContext(appContext);
+
 var iconsFile = JSON.parse(fs.readFileSync(PATHS.components.icons.svg, "utf8"));
 var icons = iconsFile.icons;
 if (!icons || typeof icons !== "object" || Object.keys(icons).length === 0) {

--- a/plugins/actian-design-system/scripts/renderers/html-renderers/ds-screen-tree.js
+++ b/plugins/actian-design-system/scripts/renderers/html-renderers/ds-screen-tree.js
@@ -39,6 +39,61 @@ function appProfile(appHeaderType) {
 }
 
 // ---------------------------------------------------------------------------
+// App context injection
+// ---------------------------------------------------------------------------
+//
+// This module runs in the browser as well as in Node (see the UMD dance in
+// flow-renderer.js), so it cannot read app-context off disk itself. The caller
+// injects it, the same way ds-html-map takes its icons and anatomy doc map.
+//
+// What it is for: each app's REAL navigation. app-context is the substrate's
+// record of how Actian's products are actually laid out, and until this existed
+// the render path had no way to reach it, so every screen of every app rendered
+// the side-nav leaf's own four-item default ("Catalog, Pipelines, Connections,
+// Settings"). Studio has seven items and none of them is Pipelines;
+// Administration has eight; Explorer declares none at all.
+var APP_CONTEXT = null;
+
+function setAppContext(ctx) {
+  APP_CONTEXT = ctx || null;
+}
+
+// The app a template speaks for, or null when the template describes a shape
+// rather than a product. `administration` is here because TEMPLATE_CHROME only
+// ever had `admin`, so a screen authored with the full app name fell through to
+// no chrome at all.
+var TEMPLATE_APP = {
+  studio: "studio",
+  explorer: "explorer",
+  admin: "administration",
+  administration: "administration",
+};
+
+// The app's sidebar labels, or null when we cannot ground them.
+//
+// null and [] mean different things and the caller must keep them apart:
+//   []   the app is on record as having no side rail (Explorer)
+//   null no app context was injected, so we do not know
+// Neither is an invitation to fall back to the leaf's default. A rail we cannot
+// ground is a rail we should not draw: four invented items read as product
+// truth to anyone looking at the screen.
+function appSidebarLabels(templateName) {
+  var appKey = TEMPLATE_APP[templateName];
+  if (!appKey) return null;
+  if (!APP_CONTEXT || !APP_CONTEXT.apps || !APP_CONTEXT.apps[appKey]) {
+    return null;
+  }
+  var entries = APP_CONTEXT.apps[appKey].sidebar;
+  if (!Array.isArray(entries)) return null;
+  var labels = [];
+  for (var i = 0; i < entries.length; i++) {
+    var label = entries[i] && entries[i].label;
+    if (label) labels.push(label);
+  }
+  return labels;
+}
+
+// ---------------------------------------------------------------------------
 // TEMPLATE_CHROME + resolveChrome
 // ---------------------------------------------------------------------------
 
@@ -55,9 +110,45 @@ var TEMPLATE_CHROME = {
 };
 
 function resolveChrome(s) {
-  if (s.template && TEMPLATE_CHROME[s.template]) {
-    return TEMPLATE_CHROME[s.template];
+  var tpl = s.template;
+
+  // `administration` was never in TEMPLATE_CHROME, only `admin`, so a screen
+  // authored with the app's full name got no chrome at all. Resolve the alias
+  // before the lookup rather than adding a second entry that could drift.
+  var tplKey =
+    tpl === "administration" && !TEMPLATE_CHROME[tpl] ? "admin" : tpl;
+
+  if (tplKey && TEMPLATE_CHROME[tplKey]) {
+    var base = TEMPLATE_CHROME[tplKey];
+    var labels = appSidebarLabels(tpl);
+
+    // A template that names a real app defers to app-context on whether that
+    // app has a rail, because app-context is the record of how the product is
+    // laid out and this table is a hand-kept restatement of it. `labels` is
+    // null when the template names no app or nothing was injected; then the
+    // table stands, which keeps every existing non-app template unchanged.
+    // Precedence: an authored screen wins. app-context is the DEFAULT for a
+    // screen that says nothing about its rail, never an override of one that
+    // does. A screen carrying `sidebar: { items: [...] }` has stated its own
+    // navigation and must render it, including on an app the substrate records
+    // as having no rail. Missing this is what suppressed the rail on the
+    // explorer golden, which authors two items of its own.
+    var authored =
+      s.sidebar &&
+      typeof s.sidebar === "object" &&
+      ((Array.isArray(s.sidebar.items) && s.sidebar.items.length > 0) ||
+        (Array.isArray(s.sidebar.groups) && s.sidebar.groups.length > 0));
+
+    if (labels !== null && !authored) {
+      return {
+        appHeaderType: base.appHeaderType,
+        hasSidebar: labels.length > 0,
+        sidebarLabels: labels,
+      };
+    }
+    return base;
   }
+
   // Backward compat: derive from legacy s.appHeader / s.sidebar
   return {
     appHeaderType: s.appHeader || null,
@@ -136,7 +227,20 @@ function chromeNodes(chrome, sidebarConfig, pageHeaderConfig, headerConfig) {
         sidebarProps.Groups = JSON.stringify([{ items: items }]);
       } else if (labels.length) {
         sidebarProps.Items = labels.join(", ");
+      } else if (chrome.sidebarLabels && chrome.sidebarLabels.length) {
+        // Nothing authored on the screen, but the app is on record. Use the
+        // product's own navigation rather than letting the leaf fall back to
+        // its four-item default, which belongs to no app.
+        sidebarProps.Items = chrome.sidebarLabels.join(", ");
       }
+      // No else. When nothing is grounded the props stay empty and the leaf
+      // uses its own default, which is what happened before this change and is
+      // wrong. It is left alone deliberately: sending `Items: ""` does not stop
+      // it (parseItems treats empty as absent, verified), and suppressing the
+      // rail here would change the Figma emit path too, which does not inject.
+      // The place this is made safe is the guard: a test asserts the real
+      // assembler path renders the app's OWN labels, so a broken injection
+      // fails CI rather than quietly reinstating the four invented items.
       if (active) sidebarProps.Active = active;
     }
 
@@ -284,6 +388,8 @@ function screenTree(s) {
 
 module.exports = {
   appProfile: appProfile,
+  setAppContext: setAppContext,
+  TEMPLATE_APP: TEMPLATE_APP,
   TEMPLATE_CHROME: TEMPLATE_CHROME,
   resolveChrome: resolveChrome,
   chromeNodes: chromeNodes,

--- a/plugins/actian-design-system/tests/renderers/flow-renderer.test.js
+++ b/plugins/actian-design-system/tests/renderers/flow-renderer.test.js
@@ -466,7 +466,30 @@ assert(
   explorerChrome.appHeaderType === "Explorer",
   "explorer → Explorer header",
 );
-assert(explorerChrome.hasSidebar === true, "explorer → sidebar present");
+// Explorer's rail now follows app-context, which records `sidebar: []` for it.
+// This assertion used to read `=== true`, taken from the hardcoded
+// TEMPLATE_CHROME table. That table was the only thing saying Explorer has a
+// rail, and because nothing filled it, every Explorer screen rendered the
+// side-nav leaf's specimen default: "Catalog, Pipelines, Connections,
+// Settings", which is Studio's shape and belongs to no app.
+//
+// This is not a claim that Explorer can never have a rail. A screen that
+// authors `sidebar: { items: [...] }` still gets one (asserted below and in the
+// explorer HTML golden, which authors two items), and if Explorer turns out to
+// have standing navigation the fix is to author it in app-context, where the
+// other two apps already declare theirs. The plugin follows the substrate
+// rather than carrying its own answer.
+assert(
+  explorerChrome.hasSidebar === false,
+  "explorer → no standing rail, because app-context records none",
+);
+assert(
+  resolveChrome({
+    template: "explorer",
+    sidebar: { items: [{ label: "Marketplace" }] },
+  }).hasSidebar === true,
+  "explorer + an authored sidebar → rail present (authored wins over app-context)",
+);
 
 const noSidebarChrome = resolveChrome({ template: "no-sidebar" });
 assert(noSidebarChrome.appHeaderType !== null, "no-sidebar → has app header");

--- a/plugins/actian-design-system/tests/renderers/screen-chrome-is-grounded.test.js
+++ b/plugins/actian-design-system/tests/renderers/screen-chrome-is-grounded.test.js
@@ -1,0 +1,213 @@
+#!/usr/bin/env node
+"use strict";
+
+/**
+ * screen-chrome-is-grounded.test.js
+ *
+ * Every generated screen used to render the same four navigation items, in
+ * every app: "Catalog, Pipelines, Connections, Settings". They are the side-nav
+ * leaf's own specimen default and they belong to no Actian product. Studio's
+ * real navigation is seven items and does not include Pipelines,
+ * Administration's is eight, and Explorer is on record as having no rail.
+ *
+ * The chain that produced it: ds-screen-tree kept its own hardcoded
+ * TEMPLATE_CHROME and never read app-context, screenTree defaulted the sidebar
+ * config to the NUMBER 6, chromeNodes tested Array.isArray on it and set
+ * nothing, and the leaf substituted its default for the empty props. Nothing
+ * errored at any step.
+ *
+ * This guard asserts the JOIN, on the real render path, in both directions:
+ *
+ *   1. the rendered rail carries the app's OWN labels, read from app-context
+ *      rather than typed here, so this file cannot drift from the substrate;
+ *   2. it does NOT carry the leaf's default.
+ *
+ * Both halves are needed. (1) alone passes if the leaf's default happened to
+ * contain the label being looked for ("Catalog" is in both Studio's list and
+ * the default, which is exactly how this went unnoticed). (2) alone passes if
+ * the rail stopped rendering altogether.
+ *
+ * 🔑 The injection is what makes this work, and it is easy to lose: it lives in
+ * scripts/lib/renderer.js and is armed by requiring that module. If someone
+ * removes it, chromeNodes silently falls back to the leaf default again. That
+ * is why this test drives the real modules rather than calling setAppContext
+ * itself: a test that injects its own context would pass while production
+ * shipped the four invented items.
+ */
+
+var { describe, it } = require("node:test");
+var assert = require("node:assert");
+var fs = require("fs");
+var path = require("path");
+
+var ROOT = path.join(__dirname, "..", "..");
+var PATHS = require(path.join(ROOT, "scripts", "lib", "paths.js"));
+
+// Requiring lib/renderer.js is what arms the injection. Ordering matters and is
+// the point: this is the production entry point, not a test fixture.
+require(path.join(ROOT, "scripts", "lib", "renderer.js"));
+
+var screenTree = require(
+  path.join(ROOT, "scripts", "renderers", "html-renderers", "ds-screen-tree.js"),
+);
+var dsHtmlMap = require(
+  path.join(
+    ROOT, "vendor", "components", "render", "renderer",
+    "html-renderers", "ds-html-map.js",
+  ),
+);
+
+// The leaf's specimen default, quoted from the renderer it lives in
+// (ds-html-map.js, the Items-mode branch). Named here so the assertion says
+// what it is rather than testing an anonymous string.
+var LEAF_DEFAULT = ["Catalog", "Pipelines", "Connections", "Settings"];
+
+var appContext = JSON.parse(fs.readFileSync(PATHS.appContext, "utf8"));
+
+function labelsFor(appKey) {
+  var app = appContext.apps[appKey];
+  return (app.sidebar || []).map(function (e) {
+    return e.label;
+  });
+}
+
+// Render a screen's rail through the real chrome builder + the real leaf.
+function renderRail(template) {
+  var chrome = screenTree.resolveChrome({ template: template });
+  if (!chrome.hasSidebar) return null;
+  var nodes = screenTree.chromeNodes(
+    chrome,
+    { items: 6, activeItem: null }, // the default screenTree() itself passes
+    null,
+    null,
+  );
+  var html = dsHtmlMap.renderDSComponent({
+    dsSlug: "side-nav",
+    name: "Side nav",
+    props: nodes.sidebar.props,
+  });
+  return (html.match(/ds-sidenav__label">[^<]*/g) || []).map(function (s) {
+    return s.split(">")[1];
+  });
+}
+
+describe("generated screen chrome is grounded in app-context", function () {
+  it("fixture sanity: app-context declares distinct navigation per app", function () {
+    var studio = labelsFor("studio");
+    var admin = labelsFor("administration");
+    assert.ok(
+      studio.length > 0 && admin.length > 0,
+      "app-context has no sidebar entries for studio/administration, so every " +
+        "assertion below would be vacuous. Check the vendored app-context " +
+        "rather than deleting this test.",
+    );
+    assert.notDeepEqual(
+      studio,
+      LEAF_DEFAULT,
+      "fixture sanity: Studio's real navigation must differ from the leaf's " +
+        "default, or this file cannot tell a grounded rail from an ungrounded " +
+        "one.",
+    );
+  });
+
+  it("Studio renders Studio's own navigation, not the leaf default", function () {
+    var rendered = renderRail("studio");
+    assert.deepEqual(
+      rendered,
+      labelsFor("studio"),
+      "The Studio rail must carry app-context's labels. Expected the " +
+        "substrate's list; got " + JSON.stringify(rendered) + ". If this is " +
+        "the leaf's four-item default, the app-context injection in " +
+        "scripts/lib/renderer.js is not reaching ds-screen-tree.",
+    );
+  });
+
+  it("Administration renders its own navigation, under either template name", function () {
+    var expected = labelsFor("administration");
+    assert.deepEqual(renderRail("admin"), expected);
+    assert.deepEqual(
+      renderRail("administration"),
+      expected,
+      "`administration` was never in TEMPLATE_CHROME, only `admin`, so a " +
+        "screen authored with the app's full name fell through to no chrome " +
+        "at all. It must resolve to the same rail as `admin`.",
+    );
+  });
+
+  it("no app renders the leaf's specimen default", function () {
+    var offenders = [];
+    ["studio", "explorer", "admin", "administration"].forEach(function (tpl) {
+      var rendered = renderRail(tpl);
+      if (rendered && JSON.stringify(rendered) === JSON.stringify(LEAF_DEFAULT)) {
+        offenders.push(tpl);
+      }
+    });
+    assert.deepEqual(
+      offenders,
+      [],
+      "These templates render " + JSON.stringify(LEAF_DEFAULT) + ", which is " +
+        "the side-nav leaf's own specimen content and is not any Actian " +
+        "product's navigation.",
+    );
+  });
+
+  it("an authored sidebar wins over app-context, on every app", function () {
+    // Found by this change breaking the explorer HTML golden, which authors two
+    // items of its own and had its rail suppressed. app-context is the DEFAULT
+    // for a screen that says nothing about its navigation, never an override of
+    // one that does. Asserted on Explorer specifically because that is the app
+    // whose app-context record is empty, so it is the only place the two can
+    // disagree today.
+    var authored = screenTree.resolveChrome({
+      template: "explorer",
+      sidebar: { items: [{ label: "Marketplace" }, { label: "My requests" }] },
+    });
+    assert.equal(
+      authored.hasSidebar,
+      true,
+      "A screen that authors sidebar items must render them even where " +
+        "app-context records no standing rail.",
+    );
+
+    var nodes = screenTree.chromeNodes(
+      authored,
+      { items: [{ label: "Marketplace" }, { label: "My requests" }] },
+      null,
+      null,
+    );
+    var html = dsHtmlMap.renderDSComponent({
+      dsSlug: "side-nav",
+      name: "Side nav",
+      props: nodes.sidebar.props,
+    });
+    var labels = (html.match(/ds-sidenav__label">[^<]*/g) || []).map(
+      function (x) {
+        return x.split(">")[1];
+      },
+    );
+    assert.deepEqual(
+      labels,
+      ["Marketplace", "My requests"],
+      "The authored labels must reach the markup, not just flip hasSidebar.",
+    );
+  });
+
+  it("Explorer renders no rail, because app-context records none", function () {
+    // Deliberately asserted rather than left implicit: `sidebar: []` for
+    // Explorer is an explicit empty array in app-context/src/apps/explorer.md,
+    // next to two apps whose lists are fully populated, so it reads as a
+    // statement rather than an unfilled field. If Explorer turns out to have a
+    // rail, the fix is to author it in app-context and this test follows.
+    assert.deepEqual(
+      appContext.apps.explorer.sidebar,
+      [],
+      "fixture sanity: this test encodes Explorer having no sidebar entries.",
+    );
+    assert.equal(
+      screenTree.resolveChrome({ template: "explorer" }).hasSidebar,
+      false,
+      "Explorer must not render a rail while app-context records none. It " +
+        "previously rendered one, filled with Studio's items.",
+    );
+  });
+});


### PR DESCRIPTION
Closes #348. First item of the plugin output-quality plan.

## What was wrong

Every generated screen in every app rendered the same four side-nav items:

```
Catalog, Pipelines, Connections, Settings
```

They are the side-nav leaf's own specimen default and belong to no Actian product.

| app | rendered before | app-context has |
|---|---|---|
| Studio | the four | Dashboard, Catalog, Topics, Import, Access requests, Catalog design, Analytics |
| Administration | the four | Users and contacts, Catalogs, Groups, Connections, Scanners, API keys, Policies, Maintenance mode |
| Explorer | the four | `[]` |
| `template: "administration"` | no chrome at all | as above |

## The chain

Nothing errored at any step.

1. `ds-screen-tree.js` kept its own hardcoded `TEMPLATE_CHROME` and its own `resolveChrome`. The
   app-context-reading `resolveChrome` in `scripts/lib/app-context/` was never called from a render
   path, and `ds-screen-tree.js` has no `require` of it.
2. `screenTree` defaulted the sidebar config to `{ items: s.navItems || 6 }` — the **number** 6.
3. `chromeNodes` tested `Array.isArray(sc.items)`, which is false, set nothing, shipped `props: {}`.
4. The leaf, given empty props, substituted its own default.

## What this does

Resolves chrome from app-context, injected process-wide in `scripts/lib/renderer.js` next to the
existing icon injection and for the same reason: `ds-screen-tree` runs in the browser as well as in
Node and cannot read it itself, and every render path reaches that module.

`administration` now resolves as a template name. Explorer renders no standing rail because
app-context records `sidebar: []` for it, explicitly, beside two apps whose lists are populated.

**An authored screen still wins.** `sidebar: { items: [...] }` renders on any app, Explorer
included. app-context is the default for a screen that says nothing about its rail, never an
override of one that does.

## The defect my own change introduced

The first cut had no precedence rule, so it suppressed the rail on the explorer HTML golden, which
authors two items of its own. The golden caught it. Adding the rule fixed it **without regenerating
the golden**, which is the outcome that says the golden was right and the change was wrong.

## Guard

`tests/renderers/screen-chrome-is-grounded.test.js`, 6 tests, asserts the join both ways: the rail
carries the app's own labels **read from app-context rather than typed into the test**, and does not
carry the leaf default. Both halves are needed, because `Catalog` appears in Studio's real list *and*
in the default, which is exactly how this went unnoticed.

It deliberately drives the real modules rather than calling `setAppContext` itself: a test that
injects its own context would pass while production shipped the four invented items.

| mutation | result |
|---|---|
| drop the `setAppContext` call | 4 of 6 red |
| make `resolveChrome` ignore app-context | 4 red |
| drop the `sidebarLabels` branch in `chromeNodes` | 3 red |
| drop the `administration` alias | 2 red |
| drop the authored-wins precedence | 1 red here, plus the explorer golden |

Each restored byte-exact by sha256.

## Checks

`npm test` 2194 tests, 2189 pass, 0 fail, 5 skipped. Version 2026.9.6 to 2026.9.7.

Verified end to end in a rendered `flow-share` deliverable and looked at in the browser: Studio draws
its seven items, Explorer draws none and reads as intentional rather than broken.

## One thing this does not settle

Whether `sidebar: []` for Explorer means "has no rail" or "nobody filled it in". The evidence that it
is deliberate: it is an explicit empty array, the other two apps are fully populated, and Explorer's
documented jobs are all browse/search shaped. The one captured Explorer recipe is a drawer, so it
shows no page chrome and settles nothing. If Explorer does have standing navigation, author it in
app-context and this code renders it with no further change.

## Noticed while looking, not fixed here

The Studio rail highlights `Dashboard` as active while the page is `Catalog`: the active item
defaults to the first entry rather than matching the page. Out of scope for this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016xG3HeZXekquJKpkv7CVDN
