### PR TITLE
fix(tests): two false reds that only appeared once the vendor refresh landed

### DIFF
--- a/plugins/actian-design-system/.claude-plugin/plugin.json
+++ b/plugins/actian-design-system/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "actian-design-system",
   "description": "Actian Design System toolkit — generate wireframe flows with prototype wiring, create component briefs, audit designs, compare flows, and build presentations. 8 skills (with tiered generation: recognized / adapted / improvised), 9 agents, 155 tokens (3 themes, 8 collections), WCAG 2.2 AA. DS knowledge vendored from volivarii/actian-ds-knowledge.",
-  "version": "2026.9.8",
+  "version": "2026.9.9",
   "author": {
     "name": "Actian UX Team"
   },

--- a/plugins/actian-design-system/tests/integration/css-staleness.test.js
+++ b/plugins/actian-design-system/tests/integration/css-staleness.test.js
@@ -44,7 +44,33 @@ function extractClassesFromJS(jsPath) {
   var re = /class="([^"]*)"/g;
   var match;
   while ((match = re.exec(src)) !== null) {
-    var parts = match[1].split(/\s+/);
+    // Only the STATIC prefix of the attribute is a class list. The capture is
+    // line-agnostic, so `class="' + cls + '"` captures the concatenation itself,
+    // and the old code tried to salvage class names token by token out of it.
+    // That is not analysable: everything after the first quote or `+` is a JS
+    // expression, and its identifiers are variables, not classes. Two rounds of
+    // filters were added to guess which tokens to drop (a bare `?` from a
+    // multi-line ternary, then camelCase names like `alertType`), and both were
+    // patching symptoms. A lowercase, hyphen-free variable such as `cls` slipped
+    // through every one of them and the gate reported a missing rule for it.
+    //
+    // Cutting at the first marker is exact rather than heuristic. It keeps the
+    // real half: `class="ds-x ' + extra + '"` still yields `ds-x` and is still
+    // checked. It only drops what static analysis genuinely cannot see.
+    var staticPrefix = match[1].split(/['"`+(]/)[0];
+    var parts = staticPrefix.split(/\s+/);
+    // If the static half does not end at a space, the expression CONTINUES its
+    // last token, so that token is a truncated stem and not a class. This is the
+    // `class="fm-button fm-button--' + variant + '"` case: `fm-button` is a real
+    // class and `fm-button--` is half of one. The old code got this right only by
+    // accident, because it split before stripping the quote and the surviving
+    // `fm-button--'` was then dropped for containing a quote.
+    // Only when something was actually cut off. A fully static attribute was not
+    // truncated, so its last token is a real class: popping unconditionally made
+    // `class="ds-foo"` extract nothing, which a positive control caught.
+    if (staticPrefix !== match[1] && parts.length && !/\s$/.test(staticPrefix)) {
+      parts.pop();
+    }
     for (var i = 0; i < parts.length; i++) {
       var cls = parts[i].trim();
       // Skip dynamic parts (contain JS variable concatenation)

--- a/plugins/actian-design-system/tests/lib/resolve-patterns.test.js
+++ b/plugins/actian-design-system/tests/lib/resolve-patterns.test.js
@@ -1338,7 +1338,12 @@ describe("resolve-patterns (entity join)", function () {
   it("is defensive about the shapes a caller and a snapshot can actually produce", function () {
     assert.deepStrictEqual(resolver.resolveEntityPatterns("", CTX), []);
     assert.deepStrictEqual(resolver.resolveEntityPatterns(null, CTX), []);
-    assert.deepStrictEqual(resolver.resolveEntityPatterns("dataset", null), []);
+    // NOT `resolveEntityPatterns("dataset", null)`. A null ctx does not mean
+    // "empty context", it means "read the VENDORED file", so asserting [] there
+    // was asserting that the vendor pin predates the join. It passed only
+    // because that happened to be true when it was written, and went red the
+    // moment the refresh it was waiting for arrived. The vendored state has its
+    // own test below, which asserts whichever state it finds and names it.
     assert.deepStrictEqual(resolver.resolveEntityPatterns("dataset", {}), []);
     assert.deepStrictEqual(resolver.resolveEntityPatterns("nope", CTX), []);
     // Slugs are normalized the same way every other slug in this file is.


### PR DESCRIPTION
Unblocks the v0.34.191 vendor refresh (#354), which went red at two gates. Neither was a real defect in the substrate, and neither was the re-bank this refresh was expected to need (the vendor job did that itself: blank-box total 65 to 50, with the four form controls moving into `builtSlugs`).

## The CSS staleness gate reported a missing rule for `cls`

`cls` is a variable, not a class. The scraper matches `class="..."` and then salvages class names token by token out of whatever it captured, but `class="' + cls + '"` captures the JS concatenation itself and the identifiers in it are variables. Two rounds of filters had already been added to guess which tokens to drop, a bare `?` from a multi-line ternary and camelCase names like `alertType`. Both patched symptoms. `inputGroup` in the knowledge renderer names its variable `cls`, lowercase and hyphen-free, and it slipped through every one.

Cutting at the first quote or `+` is exact rather than heuristic: everything after it is an expression static analysis cannot read. The real half survives, so `class="ds-x ' + extra + '"` still yields `ds-x` and is still checked.

Where something **was** cut off and the static half does not end at a space, its last token is a truncated stem rather than a class (`fm-button fm-button--`), so it is dropped. The old code got that right only by accident: it split before stripping the quote, and the surviving `fm-button--'` was then dropped for containing one.

**That drop was wrong on its first cut.** Applied unconditionally it made a fully static `class="ds-foo"` extract nothing, which would have gutted the gate while leaving it green. A positive control caught it. Both directions are now proven by injection into the real renderer: a missing static class is reported, a concatenated BEM modifier is not, and the file is restored byte-identical after each.

## My own entity-join test asserted the stale vendor state

`resolveEntityPatterns("dataset", null)` sat in a defensiveness test asserting `[]`. A null ctx does not mean "empty context", it means "read the vendored file", so that assertion was really saying the vendor pin predates the join. It passed only because that happened to be true when it was written, and it went red the moment the refresh it was waiting for arrived.

Removed rather than updated. The vendored state already has its own test, which asserts whichever state it finds and names which one that was; that is the shape this assertion should have had.

## Verification

2210 pass / 0 fail / 5 skipped on **both** pins, v0.34.187 and v0.34.191. On the refreshed pin the join resolves for real: `--entity dataset` reports 25 of 30 entities joined, `dataset` naming 5 patterns and reaching 25 components.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016xG3HeZXekquJKpkv7CVDN
