### PR TITLE
fix(flow): the lo-fi deliverable is visible and the validator is quiet on a clean flow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,7 +78,8 @@ are summarized at the release level.
   written back to the file, so a refine command had no id to scope to. `validate-flow-data.js
   --write-ids` now writes the stamped ids back, both the incremental and plain `merge-partials.js`
   paths stamp them, and the generate-flow skill's Step 6 commands and its sequential stub carry the
-  flag through.
+  flag through. A screen without an id derives one that skips any id another screen in the same
+  flow already carries, so inserting a screen ahead of an existing one never stamps a duplicate.
 
 - **Terminology and avoid-word findings name the word and the fix.** The CLI printed only the
   sentence a finding pointed at, leaving a designer to find which word triggered it. A line ending

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,49 @@ are summarized at the release level.
 
 ### Fixed
 
+- **Lo-fi text is visible again.** FM TEXT nodes authored without an explicit color inherited the
+  share wrapper's near-white body color and rendered invisible on the white screen canvas.
+  `.fm-text` now reads `--fm-text-primary` and the wrapper's `body` rule carries no color of its
+  own.
+
+- **The validator resolves FM tokens.** `validate-flow-data.js` read token names from `tokens.css`
+  alone, so every `--fm-*` reference in a lo-fi flow read as an unresolved-token P1, 113 of them on
+  the audit flow. It now reads the FM sheet through the renderer accessor too and unions both
+  sources before flagging a token as unknown.
+
+- **Enum slots are not placeholder text.** The placeholder-text check flagged `state`, `template`
+  and `status` values such as `"default"` as leaked specimen copy, matching the same patterns real
+  placeholder text does. Those three keys are now skipped by name; `navItems[].label` still trips
+  the check, since it carries real user-visible copy.
+
+- **A required override accepts its plain prop name.** The missing-required-override check compared
+  an authored prop only against its exact hashed registry name, `Label#1411:32`, while the
+  generate-flow skill's own examples and the renderer both accept the plain name, `Label`. A prop
+  authored either way now satisfies the requirement; an override missing under both spellings is
+  still a P0.
+
+- **The share view stops baking specimen data.** The generated flow's header avatar defaulted to a
+  real person's initials, and the generated-on stamp printed a full ISO timestamp down to the
+  millisecond. The avatar now defaults to `JD` and the stamp prints the calendar date alone.
+
+- **Screen ids reach flow-data.json.** Stable screen ids were computed during validation but never
+  written back to the file, so a refine command had no id to scope to. `validate-flow-data.js
+  --write-ids` now writes the stamped ids back, both the incremental and plain `merge-partials.js`
+  paths stamp them, and the generate-flow skill's Step 6 commands and its sequential stub carry the
+  flag through.
+
+- **Terminology and avoid-word findings name the word and the fix.** The CLI printed only the
+  sentence a finding pointed at, leaving a designer to find which word triggered it. A line ending
+  in a matched word now reads `(found "dataset", use "Data product")`; a finding with no matched
+  word prints exactly as before.
+
+- **Flow recipes carry tokens, not hex.** 57 fills and strokes across the 8 flow recipes were
+  authored as hardcoded hex values instead of `--fm-*` tokens, and two `fmTextInput` nodes in
+  `form-create.json` carried a `State` axis the registry does not define, instead of its real
+  `Type` axis. Recipes now read tokens throughout and the real axis, and
+  `tests/integration/recipes.test.js` gained two repo-wide assertions that fail the suite on a new
+  hex fill or an unknown variant axis or value.
+
 - **Every generated screen showed the same four navigation items, in every app**
   ([#351](https://github.com/volivarii/Actian-DS-Claude-plugin/pull/351)). The side rail read
   `Catalog, Pipelines, Connections, Settings` on every screen of every flow. Those four are the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,44 +49,44 @@ are summarized at the release level.
 
 ### Fixed
 
-- **Lo-fi text is visible again.** FM TEXT nodes authored without an explicit color inherited the
+- **Lo-fi text is visible again** ([#359](https://github.com/volivarii/Actian-DS-Claude-plugin/pull/359)). FM TEXT nodes authored without an explicit color inherited the
   share wrapper's near-white body color and rendered invisible on the white screen canvas.
   `.fm-text` now reads `--fm-text-primary` and the wrapper's `body` rule carries no color of its
   own.
 
-- **The validator resolves FM tokens.** `validate-flow-data.js` read token names from `tokens.css`
+- **The validator resolves FM tokens** ([#359](https://github.com/volivarii/Actian-DS-Claude-plugin/pull/359)). `validate-flow-data.js` read token names from `tokens.css`
   alone, so every `--fm-*` reference in a lo-fi flow read as an unresolved-token P1, 113 of them on
   the audit flow. It now reads the FM sheet through the renderer accessor too and unions both
   sources before flagging a token as unknown.
 
-- **Enum slots are not placeholder text.** The placeholder-text check flagged `state`, `template`
+- **Enum slots are not placeholder text** ([#359](https://github.com/volivarii/Actian-DS-Claude-plugin/pull/359)). The placeholder-text check flagged `state`, `template`
   and `status` values such as `"default"` as leaked specimen copy, matching the same patterns real
   placeholder text does. Those three keys are now skipped by name; `navItems[].label` still trips
   the check, since it carries real user-visible copy.
 
-- **A required override accepts its plain prop name.** The missing-required-override check compared
+- **A required override accepts its plain prop name** ([#359](https://github.com/volivarii/Actian-DS-Claude-plugin/pull/359)). The missing-required-override check compared
   an authored prop only against its exact hashed registry name, `Label#1411:32`, while the
   generate-flow skill's own examples and the renderer both accept the plain name, `Label`. A prop
   authored either way now satisfies the requirement; an override missing under both spellings is
   still a P0.
 
-- **The share view stops baking specimen data.** The generated flow's header avatar defaulted to a
+- **The share view stops baking specimen data** ([#359](https://github.com/volivarii/Actian-DS-Claude-plugin/pull/359)). The generated flow's header avatar defaulted to a
   real person's initials, and the generated-on stamp printed a full ISO timestamp down to the
   millisecond. The avatar now defaults to `JD` and the stamp prints the calendar date alone.
 
-- **Screen ids reach flow-data.json.** Stable screen ids were computed during validation but never
+- **Screen ids reach flow-data.json** ([#359](https://github.com/volivarii/Actian-DS-Claude-plugin/pull/359)). Stable screen ids were computed during validation but never
   written back to the file, so a refine command had no id to scope to. `validate-flow-data.js
   --write-ids` now writes the stamped ids back, both the incremental and plain `merge-partials.js`
   paths stamp them, and the generate-flow skill's Step 6 commands and its sequential stub carry the
   flag through. A screen without an id derives one that skips any id another screen in the same
   flow already carries, so inserting a screen ahead of an existing one never stamps a duplicate.
 
-- **Terminology and avoid-word findings name the word and the fix.** The CLI printed only the
+- **Terminology and avoid-word findings name the word and the fix** ([#359](https://github.com/volivarii/Actian-DS-Claude-plugin/pull/359)). The CLI printed only the
   sentence a finding pointed at, leaving a designer to find which word triggered it. A line ending
   in a matched word now reads `(found "dataset", use "Data product")`; a finding with no matched
   word prints exactly as before.
 
-- **Flow recipes carry tokens, not hex.** 57 fills and strokes across the 8 flow recipes were
+- **Flow recipes carry tokens, not hex** ([#359](https://github.com/volivarii/Actian-DS-Claude-plugin/pull/359)). 57 fills and strokes across the 8 flow recipes were
   authored as hardcoded hex values instead of `--fm-*` tokens, and two `fmTextInput` nodes in
   `form-create.json` carried a `State` axis the registry does not define, instead of its real
   `Type` axis. Recipes now read tokens throughout and the real axis, and

--- a/plugins/actian-design-system/.claude-plugin/plugin.json
+++ b/plugins/actian-design-system/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "actian-design-system",
   "description": "Actian Design System toolkit — generate wireframe flows with prototype wiring, create component briefs, audit designs, compare flows, and build presentations. 8 skills (with tiered generation: recognized / adapted / improvised), 9 agents, 155 tokens (3 themes, 8 collections), WCAG 2.2 AA. DS knowledge vendored from volivarii/actian-ds-knowledge.",
-  "version": "2026.9.11",
+  "version": "2026.9.12",
   "author": {
     "name": "Actian UX Team"
   },

--- a/plugins/actian-design-system/recipes/flow/browse-search.json
+++ b/plugins/actian-design-system/recipes/flow/browse-search.json
@@ -46,7 +46,7 @@
                 "sizing": { "horizontal": "FILL", "vertical": 40 },
                 "children": [
                   { "type": "INSTANCE", "ref": "fmCheckbox", "variant": "State=Off", "props": {} },
-                  { "type": "TEXT", "content": "Sort by", "font": "Inter:Regular", "size": 13, "color": "#595968" },
+                  { "type": "TEXT", "content": "Sort by", "font": "Inter:Regular", "size": 13, "color": "var(--fm-text-tertiary)" },
                   {
                     "type": "INSTANCE", "ref": "fmDropdown", "variant": "Type=Filled",
                     "sizing": { "horizontal": 120 },
@@ -62,8 +62,8 @@
                 "type": "FRAME",
                 "name": "Result card: {{result1_title}}",
                 "layout": { "mode": "VERTICAL", "spacing": 8, "padding": [16, 16, 16, 16] },
-                "fills": ["#FFFFFF"],
-                "stroke": { "color": "#E0E0E0", "weight": 1, "align": "INSIDE" },
+                "fills": ["var(--fm-base-white)"],
+                "stroke": { "color": "var(--fm-border)", "weight": 1, "align": "INSIDE" },
                 "sizing": { "horizontal": "FILL", "vertical": "HUG" },
                 "children": [
                   {
@@ -73,18 +73,18 @@
                     "sizing": { "horizontal": "FILL", "vertical": "HUG" },
                     "children": [
                       { "type": "INSTANCE", "ref": "fmBadge", "variant": "Size=Small", "props": { "Label": "{{result1_type}}" } },
-                      { "type": "TEXT", "content": "{{result1_title}}", "font": "Inter:Semi Bold", "size": 14, "color": "#1A1A2E" }
+                      { "type": "TEXT", "content": "{{result1_title}}", "font": "Inter:Semi Bold", "size": 14, "color": "var(--fm-text-secondary)" }
                     ]
                   },
-                  { "type": "TEXT", "content": "{{result1_description}}", "font": "Inter:Regular", "size": 13, "color": "#595968" }
+                  { "type": "TEXT", "content": "{{result1_description}}", "font": "Inter:Regular", "size": 13, "color": "var(--fm-text-tertiary)" }
                 ]
               },
               {
                 "type": "FRAME",
                 "name": "Result card: {{result2_title}}",
                 "layout": { "mode": "VERTICAL", "spacing": 8, "padding": [16, 16, 16, 16] },
-                "fills": ["#FFFFFF"],
-                "stroke": { "color": "#E0E0E0", "weight": 1, "align": "INSIDE" },
+                "fills": ["var(--fm-base-white)"],
+                "stroke": { "color": "var(--fm-border)", "weight": 1, "align": "INSIDE" },
                 "sizing": { "horizontal": "FILL", "vertical": "HUG" },
                 "children": [
                   {
@@ -94,10 +94,10 @@
                     "sizing": { "horizontal": "FILL", "vertical": "HUG" },
                     "children": [
                       { "type": "INSTANCE", "ref": "fmBadge", "variant": "Size=Small", "props": { "Label": "{{result2_type}}" } },
-                      { "type": "TEXT", "content": "{{result2_title}}", "font": "Inter:Semi Bold", "size": 14, "color": "#1A1A2E" }
+                      { "type": "TEXT", "content": "{{result2_title}}", "font": "Inter:Semi Bold", "size": 14, "color": "var(--fm-text-secondary)" }
                     ]
                   },
-                  { "type": "TEXT", "content": "{{result2_description}}", "font": "Inter:Regular", "size": 13, "color": "#595968" }
+                  { "type": "TEXT", "content": "{{result2_description}}", "font": "Inter:Regular", "size": 13, "color": "var(--fm-text-tertiary)" }
                 ]
               }
             ]

--- a/plugins/actian-design-system/recipes/flow/browse-search.json
+++ b/plugins/actian-design-system/recipes/flow/browse-search.json
@@ -73,7 +73,7 @@
                     "sizing": { "horizontal": "FILL", "vertical": "HUG" },
                     "children": [
                       { "type": "INSTANCE", "ref": "fmBadge", "variant": "Size=Small", "props": { "Label": "{{result1_type}}" } },
-                      { "type": "TEXT", "content": "{{result1_title}}", "font": "Inter:Semi Bold", "size": 14, "color": "var(--fm-text-secondary)" }
+                      { "type": "TEXT", "content": "{{result1_title}}", "font": "Inter:Semi Bold", "size": 14, "color": "var(--fm-text-primary)" }
                     ]
                   },
                   { "type": "TEXT", "content": "{{result1_description}}", "font": "Inter:Regular", "size": 13, "color": "var(--fm-text-tertiary)" }
@@ -94,7 +94,7 @@
                     "sizing": { "horizontal": "FILL", "vertical": "HUG" },
                     "children": [
                       { "type": "INSTANCE", "ref": "fmBadge", "variant": "Size=Small", "props": { "Label": "{{result2_type}}" } },
-                      { "type": "TEXT", "content": "{{result2_title}}", "font": "Inter:Semi Bold", "size": 14, "color": "var(--fm-text-secondary)" }
+                      { "type": "TEXT", "content": "{{result2_title}}", "font": "Inter:Semi Bold", "size": 14, "color": "var(--fm-text-primary)" }
                     ]
                   },
                   { "type": "TEXT", "content": "{{result2_description}}", "font": "Inter:Regular", "size": 13, "color": "var(--fm-text-tertiary)" }

--- a/plugins/actian-design-system/recipes/flow/dashboard.json
+++ b/plugins/actian-design-system/recipes/flow/dashboard.json
@@ -25,39 +25,39 @@
             "type": "FRAME",
             "name": "Metric: {{metric1_label}}",
             "layout": { "mode": "VERTICAL", "spacing": 4, "padding": [16, 16, 16, 16] },
-            "fills": ["#FFFFFF"],
+            "fills": ["var(--fm-base-white)"],
             "cornerRadius": 8,
-            "stroke": { "color": "#E0E0E0", "weight": 1, "align": "INSIDE" },
+            "stroke": { "color": "var(--fm-border)", "weight": 1, "align": "INSIDE" },
             "sizing": { "horizontal": "FILL", "vertical": "HUG" },
             "children": [
-              { "type": "TEXT", "content": "{{metric1_label}}", "font": "Inter:Regular", "size": 13, "color": "#595968" },
-              { "type": "TEXT", "content": "{{metric1_value}}", "font": "Inter:Semi Bold", "size": 24, "color": "#1A1A2E" }
+              { "type": "TEXT", "content": "{{metric1_label}}", "font": "Inter:Regular", "size": 13, "color": "var(--fm-text-tertiary)" },
+              { "type": "TEXT", "content": "{{metric1_value}}", "font": "Inter:Semi Bold", "size": 24, "color": "var(--fm-text-secondary)" }
             ]
           },
           {
             "type": "FRAME",
             "name": "Metric: {{metric2_label}}",
             "layout": { "mode": "VERTICAL", "spacing": 4, "padding": [16, 16, 16, 16] },
-            "fills": ["#FFFFFF"],
+            "fills": ["var(--fm-base-white)"],
             "cornerRadius": 8,
-            "stroke": { "color": "#E0E0E0", "weight": 1, "align": "INSIDE" },
+            "stroke": { "color": "var(--fm-border)", "weight": 1, "align": "INSIDE" },
             "sizing": { "horizontal": "FILL", "vertical": "HUG" },
             "children": [
-              { "type": "TEXT", "content": "{{metric2_label}}", "font": "Inter:Regular", "size": 13, "color": "#595968" },
-              { "type": "TEXT", "content": "{{metric2_value}}", "font": "Inter:Semi Bold", "size": 24, "color": "#1A1A2E" }
+              { "type": "TEXT", "content": "{{metric2_label}}", "font": "Inter:Regular", "size": 13, "color": "var(--fm-text-tertiary)" },
+              { "type": "TEXT", "content": "{{metric2_value}}", "font": "Inter:Semi Bold", "size": 24, "color": "var(--fm-text-secondary)" }
             ]
           },
           {
             "type": "FRAME",
             "name": "Metric: {{metric3_label}}",
             "layout": { "mode": "VERTICAL", "spacing": 4, "padding": [16, 16, 16, 16] },
-            "fills": ["#FFFFFF"],
+            "fills": ["var(--fm-base-white)"],
             "cornerRadius": 8,
-            "stroke": { "color": "#E0E0E0", "weight": 1, "align": "INSIDE" },
+            "stroke": { "color": "var(--fm-border)", "weight": 1, "align": "INSIDE" },
             "sizing": { "horizontal": "FILL", "vertical": "HUG" },
             "children": [
-              { "type": "TEXT", "content": "{{metric3_label}}", "font": "Inter:Regular", "size": 13, "color": "#595968" },
-              { "type": "TEXT", "content": "{{metric3_value}}", "font": "Inter:Semi Bold", "size": 24, "color": "#1A1A2E" }
+              { "type": "TEXT", "content": "{{metric3_label}}", "font": "Inter:Regular", "size": 13, "color": "var(--fm-text-tertiary)" },
+              { "type": "TEXT", "content": "{{metric3_value}}", "font": "Inter:Semi Bold", "size": 24, "color": "var(--fm-text-secondary)" }
             ]
           }
         ]
@@ -72,9 +72,9 @@
             "type": "FRAME",
             "name": "Card: {{card1_title}}",
             "layout": { "mode": "VERTICAL", "spacing": 0 },
-            "fills": ["#FFFFFF"],
+            "fills": ["var(--fm-base-white)"],
             "cornerRadius": 8,
-            "stroke": { "color": "#E0E0E0", "weight": 1, "align": "INSIDE" },
+            "stroke": { "color": "var(--fm-border)", "weight": 1, "align": "INSIDE" },
             "sizing": { "horizontal": "FILL", "vertical": "HUG" },
             "children": [
               {
@@ -83,7 +83,7 @@
                 "layout": { "mode": "HORIZONTAL", "spacing": 8, "padding": [12, 16, 12, 16], "primaryAxisAlignItems": "SPACE_BETWEEN" },
                 "sizing": { "horizontal": "FILL", "vertical": 48 },
                 "children": [
-                  { "type": "TEXT", "content": "{{card1_title}}", "font": "Inter:Semi Bold", "size": 14, "color": "#1A1A2E" },
+                  { "type": "TEXT", "content": "{{card1_title}}", "font": "Inter:Semi Bold", "size": 14, "color": "var(--fm-text-secondary)" },
                   { "type": "INSTANCE", "ref": "fmButton", "variant": "Type=Outline, Size=sm, Shape=Regular, State=Default", "props": { "Label": "View all", "👁 Leading Icon": false, "👁 Trailing Icon": false } }
                 ]
               },
@@ -103,9 +103,9 @@
             "type": "FRAME",
             "name": "Card: {{card2_title}}",
             "layout": { "mode": "VERTICAL", "spacing": 0 },
-            "fills": ["#FFFFFF"],
+            "fills": ["var(--fm-base-white)"],
             "cornerRadius": 8,
-            "stroke": { "color": "#E0E0E0", "weight": 1, "align": "INSIDE" },
+            "stroke": { "color": "var(--fm-border)", "weight": 1, "align": "INSIDE" },
             "sizing": { "horizontal": "FILL", "vertical": "HUG" },
             "children": [
               {
@@ -114,7 +114,7 @@
                 "layout": { "mode": "HORIZONTAL", "spacing": 8, "padding": [12, 16, 12, 16], "primaryAxisAlignItems": "SPACE_BETWEEN" },
                 "sizing": { "horizontal": "FILL", "vertical": 48 },
                 "children": [
-                  { "type": "TEXT", "content": "{{card2_title}}", "font": "Inter:Semi Bold", "size": 14, "color": "#1A1A2E" }
+                  { "type": "TEXT", "content": "{{card2_title}}", "font": "Inter:Semi Bold", "size": 14, "color": "var(--fm-text-secondary)" }
                 ]
               },
               { "type": "DIVIDER" },

--- a/plugins/actian-design-system/recipes/flow/dashboard.json
+++ b/plugins/actian-design-system/recipes/flow/dashboard.json
@@ -31,7 +31,7 @@
             "sizing": { "horizontal": "FILL", "vertical": "HUG" },
             "children": [
               { "type": "TEXT", "content": "{{metric1_label}}", "font": "Inter:Regular", "size": 13, "color": "var(--fm-text-tertiary)" },
-              { "type": "TEXT", "content": "{{metric1_value}}", "font": "Inter:Semi Bold", "size": 24, "color": "var(--fm-text-secondary)" }
+              { "type": "TEXT", "content": "{{metric1_value}}", "font": "Inter:Semi Bold", "size": 24, "color": "var(--fm-text-primary)" }
             ]
           },
           {
@@ -44,7 +44,7 @@
             "sizing": { "horizontal": "FILL", "vertical": "HUG" },
             "children": [
               { "type": "TEXT", "content": "{{metric2_label}}", "font": "Inter:Regular", "size": 13, "color": "var(--fm-text-tertiary)" },
-              { "type": "TEXT", "content": "{{metric2_value}}", "font": "Inter:Semi Bold", "size": 24, "color": "var(--fm-text-secondary)" }
+              { "type": "TEXT", "content": "{{metric2_value}}", "font": "Inter:Semi Bold", "size": 24, "color": "var(--fm-text-primary)" }
             ]
           },
           {
@@ -57,7 +57,7 @@
             "sizing": { "horizontal": "FILL", "vertical": "HUG" },
             "children": [
               { "type": "TEXT", "content": "{{metric3_label}}", "font": "Inter:Regular", "size": 13, "color": "var(--fm-text-tertiary)" },
-              { "type": "TEXT", "content": "{{metric3_value}}", "font": "Inter:Semi Bold", "size": 24, "color": "var(--fm-text-secondary)" }
+              { "type": "TEXT", "content": "{{metric3_value}}", "font": "Inter:Semi Bold", "size": 24, "color": "var(--fm-text-primary)" }
             ]
           }
         ]
@@ -83,7 +83,7 @@
                 "layout": { "mode": "HORIZONTAL", "spacing": 8, "padding": [12, 16, 12, 16], "primaryAxisAlignItems": "SPACE_BETWEEN" },
                 "sizing": { "horizontal": "FILL", "vertical": 48 },
                 "children": [
-                  { "type": "TEXT", "content": "{{card1_title}}", "font": "Inter:Semi Bold", "size": 14, "color": "var(--fm-text-secondary)" },
+                  { "type": "TEXT", "content": "{{card1_title}}", "font": "Inter:Semi Bold", "size": 14, "color": "var(--fm-text-primary)" },
                   { "type": "INSTANCE", "ref": "fmButton", "variant": "Type=Outline, Size=sm, Shape=Regular, State=Default", "props": { "Label": "View all", "👁 Leading Icon": false, "👁 Trailing Icon": false } }
                 ]
               },
@@ -114,7 +114,7 @@
                 "layout": { "mode": "HORIZONTAL", "spacing": 8, "padding": [12, 16, 12, 16], "primaryAxisAlignItems": "SPACE_BETWEEN" },
                 "sizing": { "horizontal": "FILL", "vertical": 48 },
                 "children": [
-                  { "type": "TEXT", "content": "{{card2_title}}", "font": "Inter:Semi Bold", "size": 14, "color": "var(--fm-text-secondary)" }
+                  { "type": "TEXT", "content": "{{card2_title}}", "font": "Inter:Semi Bold", "size": 14, "color": "var(--fm-text-primary)" }
                 ]
               },
               { "type": "DIVIDER" },

--- a/plugins/actian-design-system/recipes/flow/data-visualization.json
+++ b/plugins/actian-design-system/recipes/flow/data-visualization.json
@@ -56,10 +56,10 @@
         "type": "FRAME",
         "name": "Graph canvas",
         "layout": { "mode": "VERTICAL", "spacing": 0 },
-        "fills": ["#F8F8FC"],
+        "fills": ["var(--fm-bg-grey)"],
         "sizing": { "horizontal": "FILL", "vertical": "FILL" },
         "children": [
-          { "type": "TEXT", "content": "{{visualization_description}}", "font": "Inter:Regular", "size": 13, "color": "#9999A6" }
+          { "type": "TEXT", "content": "{{visualization_description}}", "font": "Inter:Regular", "size": 13, "color": "var(--fm-text-light)" }
         ]
       }
     ]

--- a/plugins/actian-design-system/recipes/flow/detail-view.json
+++ b/plugins/actian-design-system/recipes/flow/detail-view.json
@@ -92,7 +92,7 @@
                     "content": "{{section1_title}}",
                     "font": "Inter:Semi Bold",
                     "size": 16,
-                    "color": "var(--fm-text-secondary)"
+                    "color": "var(--fm-text-primary)"
                   },
                   {
                     "type": "TEXT",
@@ -134,7 +134,7 @@
                     "content": "{{meta_section_title}}",
                     "font": "Inter:Semi Bold",
                     "size": 16,
-                    "color": "var(--fm-text-secondary)"
+                    "color": "var(--fm-text-primary)"
                   },
                   {
                     "type": "INSTANCE",

--- a/plugins/actian-design-system/recipes/flow/detail-view.json
+++ b/plugins/actian-design-system/recipes/flow/detail-view.json
@@ -78,10 +78,10 @@
                   "spacing": 8,
                   "padding": [16, 16, 16, 16]
                 },
-                "fills": ["#FFFFFF"],
+                "fills": ["var(--fm-base-white)"],
                 "cornerRadius": 8,
                 "stroke": {
-                  "color": "#E0E0E0",
+                  "color": "var(--fm-border)",
                   "weight": 1,
                   "align": "INSIDE"
                 },
@@ -92,14 +92,14 @@
                     "content": "{{section1_title}}",
                     "font": "Inter:Semi Bold",
                     "size": 16,
-                    "color": "#1A1A2E"
+                    "color": "var(--fm-text-secondary)"
                   },
                   {
                     "type": "TEXT",
                     "content": "{{section1_body}}",
                     "font": "Inter:Regular",
                     "size": 14,
-                    "color": "#595968",
+                    "color": "var(--fm-text-tertiary)",
                     "width": 520
                   }
                 ]
@@ -120,10 +120,10 @@
                   "spacing": 8,
                   "padding": [16, 16, 16, 16]
                 },
-                "fills": ["#FFFFFF"],
+                "fills": ["var(--fm-base-white)"],
                 "cornerRadius": 8,
                 "stroke": {
-                  "color": "#E0E0E0",
+                  "color": "var(--fm-border)",
                   "weight": 1,
                   "align": "INSIDE"
                 },
@@ -134,7 +134,7 @@
                     "content": "{{meta_section_title}}",
                     "font": "Inter:Semi Bold",
                     "size": 16,
-                    "color": "#1A1A2E"
+                    "color": "var(--fm-text-secondary)"
                   },
                   {
                     "type": "INSTANCE",

--- a/plugins/actian-design-system/recipes/flow/explorer-homepage.json
+++ b/plugins/actian-design-system/recipes/flow/explorer-homepage.json
@@ -19,7 +19,7 @@
         "fills": ["var(--fm-brand-light)"],
         "sizing": { "horizontal": "FILL", "vertical": "HUG" },
         "children": [
-          { "type": "TEXT", "content": "{{hero_title}}", "font": "Inter:Bold", "size": 28, "color": "var(--fm-text-secondary)" },
+          { "type": "TEXT", "content": "{{hero_title}}", "font": "Inter:Bold", "size": 28, "color": "var(--fm-text-primary)" },
           { "type": "INSTANCE", "ref": "fmSearchInput", "variant": "Type=Empty", "props": { "Placeholder": "Search items..." } }
         ]
       },
@@ -35,7 +35,7 @@
             "layout": { "mode": "HORIZONTAL", "spacing": 8, "primaryAxisAlignItems": "SPACE_BETWEEN" },
             "sizing": { "horizontal": "FILL", "vertical": 32 },
             "children": [
-              { "type": "TEXT", "content": "{{section1_title}}", "font": "Inter:Semi Bold", "size": 16, "color": "var(--fm-text-secondary)" },
+              { "type": "TEXT", "content": "{{section1_title}}", "font": "Inter:Semi Bold", "size": 16, "color": "var(--fm-text-primary)" },
               { "type": "INSTANCE", "ref": "fmButton", "variant": "Type=Outline, Size=sm, Shape=Regular, State=Default", "props": { "Label": "Browse all", "👁 Leading Icon": false, "👁 Trailing Icon": false } }
             ]
           },
@@ -55,7 +55,7 @@
                 "sizing": { "horizontal": 240, "vertical": "HUG" },
                 "children": [
                   { "type": "INSTANCE", "ref": "fmBadge", "variant": "Size=Small", "props": { "Label": "{{tile1_type}}" } },
-                  { "type": "TEXT", "content": "{{tile1_title}}", "font": "Inter:Semi Bold", "size": 14, "color": "var(--fm-text-secondary)" },
+                  { "type": "TEXT", "content": "{{tile1_title}}", "font": "Inter:Semi Bold", "size": 14, "color": "var(--fm-text-primary)" },
                   { "type": "TEXT", "content": "{{tile1_description}}", "font": "Inter:Regular", "size": 13, "color": "var(--fm-text-tertiary)" }
                 ]
               },
@@ -69,7 +69,7 @@
                 "sizing": { "horizontal": 240, "vertical": "HUG" },
                 "children": [
                   { "type": "INSTANCE", "ref": "fmBadge", "variant": "Size=Small", "props": { "Label": "{{tile2_type}}" } },
-                  { "type": "TEXT", "content": "{{tile2_title}}", "font": "Inter:Semi Bold", "size": 14, "color": "var(--fm-text-secondary)" },
+                  { "type": "TEXT", "content": "{{tile2_title}}", "font": "Inter:Semi Bold", "size": 14, "color": "var(--fm-text-primary)" },
                   { "type": "TEXT", "content": "{{tile2_description}}", "font": "Inter:Regular", "size": 13, "color": "var(--fm-text-tertiary)" }
                 ]
               }

--- a/plugins/actian-design-system/recipes/flow/explorer-homepage.json
+++ b/plugins/actian-design-system/recipes/flow/explorer-homepage.json
@@ -16,10 +16,10 @@
         "type": "FRAME",
         "name": "Hero area",
         "layout": { "mode": "VERTICAL", "spacing": 16, "padding": [32, 32, 32, 32] },
-        "fills": ["#F0F8F8"],
+        "fills": ["var(--fm-brand-light)"],
         "sizing": { "horizontal": "FILL", "vertical": "HUG" },
         "children": [
-          { "type": "TEXT", "content": "{{hero_title}}", "font": "Inter:Bold", "size": 28, "color": "#1A1A2E" },
+          { "type": "TEXT", "content": "{{hero_title}}", "font": "Inter:Bold", "size": 28, "color": "var(--fm-text-secondary)" },
           { "type": "INSTANCE", "ref": "fmSearchInput", "variant": "Type=Empty", "props": { "Placeholder": "Search items..." } }
         ]
       },
@@ -35,7 +35,7 @@
             "layout": { "mode": "HORIZONTAL", "spacing": 8, "primaryAxisAlignItems": "SPACE_BETWEEN" },
             "sizing": { "horizontal": "FILL", "vertical": 32 },
             "children": [
-              { "type": "TEXT", "content": "{{section1_title}}", "font": "Inter:Semi Bold", "size": 16, "color": "#1A1A2E" },
+              { "type": "TEXT", "content": "{{section1_title}}", "font": "Inter:Semi Bold", "size": 16, "color": "var(--fm-text-secondary)" },
               { "type": "INSTANCE", "ref": "fmButton", "variant": "Type=Outline, Size=sm, Shape=Regular, State=Default", "props": { "Label": "Browse all", "👁 Leading Icon": false, "👁 Trailing Icon": false } }
             ]
           },
@@ -49,28 +49,28 @@
                 "type": "FRAME",
                 "name": "Tile: {{tile1_title}}",
                 "layout": { "mode": "VERTICAL", "spacing": 8, "padding": [16, 16, 16, 16] },
-                "fills": ["#FFFFFF"],
+                "fills": ["var(--fm-base-white)"],
                 "cornerRadius": 8,
-                "stroke": { "color": "#E0E0E0", "weight": 1, "align": "INSIDE" },
+                "stroke": { "color": "var(--fm-border)", "weight": 1, "align": "INSIDE" },
                 "sizing": { "horizontal": 240, "vertical": "HUG" },
                 "children": [
                   { "type": "INSTANCE", "ref": "fmBadge", "variant": "Size=Small", "props": { "Label": "{{tile1_type}}" } },
-                  { "type": "TEXT", "content": "{{tile1_title}}", "font": "Inter:Semi Bold", "size": 14, "color": "#1A1A2E" },
-                  { "type": "TEXT", "content": "{{tile1_description}}", "font": "Inter:Regular", "size": 13, "color": "#595968" }
+                  { "type": "TEXT", "content": "{{tile1_title}}", "font": "Inter:Semi Bold", "size": 14, "color": "var(--fm-text-secondary)" },
+                  { "type": "TEXT", "content": "{{tile1_description}}", "font": "Inter:Regular", "size": 13, "color": "var(--fm-text-tertiary)" }
                 ]
               },
               {
                 "type": "FRAME",
                 "name": "Tile: {{tile2_title}}",
                 "layout": { "mode": "VERTICAL", "spacing": 8, "padding": [16, 16, 16, 16] },
-                "fills": ["#FFFFFF"],
+                "fills": ["var(--fm-base-white)"],
                 "cornerRadius": 8,
-                "stroke": { "color": "#E0E0E0", "weight": 1, "align": "INSIDE" },
+                "stroke": { "color": "var(--fm-border)", "weight": 1, "align": "INSIDE" },
                 "sizing": { "horizontal": 240, "vertical": "HUG" },
                 "children": [
                   { "type": "INSTANCE", "ref": "fmBadge", "variant": "Size=Small", "props": { "Label": "{{tile2_type}}" } },
-                  { "type": "TEXT", "content": "{{tile2_title}}", "font": "Inter:Semi Bold", "size": 14, "color": "#1A1A2E" },
-                  { "type": "TEXT", "content": "{{tile2_description}}", "font": "Inter:Regular", "size": 13, "color": "#595968" }
+                  { "type": "TEXT", "content": "{{tile2_title}}", "font": "Inter:Semi Bold", "size": 14, "color": "var(--fm-text-secondary)" },
+                  { "type": "TEXT", "content": "{{tile2_description}}", "font": "Inter:Regular", "size": 13, "color": "var(--fm-text-tertiary)" }
                 ]
               }
             ]

--- a/plugins/actian-design-system/recipes/flow/form-create.json
+++ b/plugins/actian-design-system/recipes/flow/form-create.json
@@ -29,7 +29,7 @@
           {
             "type": "INSTANCE",
             "ref": "fmTextInput",
-            "variant": "State=Default",
+            "variant": "Type=Default",
             "name": "Input: {{field1_label}}",
             "props": {
               "Label Text": "{{field1_label}}",
@@ -42,7 +42,7 @@
           {
             "type": "INSTANCE",
             "ref": "fmTextInput",
-            "variant": "State=Default",
+            "variant": "Type=Default",
             "name": "Input: {{field2_label}}",
             "props": {
               "Label Text": "{{field2_label}}",

--- a/plugins/actian-design-system/recipes/flow/form-create.json
+++ b/plugins/actian-design-system/recipes/flow/form-create.json
@@ -81,8 +81,8 @@
           "padding": [16, 32, 16, 32],
           "primaryAxisAlignItems": "MAX"
         },
-        "fills": ["#FFFFFF"],
-        "stroke": { "color": "#E0E0E0", "weight": 1, "align": "INSIDE" },
+        "fills": ["var(--fm-base-white)"],
+        "stroke": { "color": "var(--fm-border)", "weight": 1, "align": "INSIDE" },
         "sizing": { "horizontal": "FILL", "vertical": 64 },
         "children": [
           {

--- a/plugins/actian-design-system/recipes/flow/overlay.json
+++ b/plugins/actian-design-system/recipes/flow/overlay.json
@@ -35,7 +35,7 @@
                 "content": "{{panel_title}}",
                 "font": "Inter:Semi Bold",
                 "size": 18,
-                "color": "var(--fm-text-secondary)"
+                "color": "var(--fm-text-primary)"
               },
               {
                 "type": "INSTANCE",
@@ -132,7 +132,7 @@
                 "content": "{{confirm_title}}",
                 "font": "Inter:Semi Bold",
                 "size": 18,
-                "color": "var(--fm-text-secondary)"
+                "color": "var(--fm-text-primary)"
               },
               {
                 "type": "INSTANCE",

--- a/plugins/actian-design-system/recipes/flow/overlay.json
+++ b/plugins/actian-design-system/recipes/flow/overlay.json
@@ -16,7 +16,7 @@
         "type": "FRAME",
         "name": "Side panel (550px)",
         "layout": { "mode": "VERTICAL", "spacing": 0 },
-        "fills": ["#FFFFFF"],
+        "fills": ["var(--fm-base-white)"],
         "sizing": { "horizontal": 550, "vertical": 896 },
         "children": [
           {
@@ -35,7 +35,7 @@
                 "content": "{{panel_title}}",
                 "font": "Inter:Semi Bold",
                 "size": 18,
-                "color": "#1A1A2E"
+                "color": "var(--fm-text-secondary)"
               },
               {
                 "type": "INSTANCE",
@@ -113,7 +113,7 @@
         "name": "Confirmation modal (450px)",
         "intent": "destructive-action",
         "layout": { "mode": "VERTICAL", "spacing": 0 },
-        "fills": ["#FFFFFF"],
+        "fills": ["var(--fm-base-white)"],
         "sizing": { "horizontal": 450, "vertical": "HUG" },
         "children": [
           {
@@ -132,7 +132,7 @@
                 "content": "{{confirm_title}}",
                 "font": "Inter:Semi Bold",
                 "size": 18,
-                "color": "#1A1A2E"
+                "color": "var(--fm-text-secondary)"
               },
               {
                 "type": "INSTANCE",

--- a/plugins/actian-design-system/recipes/flow/sticky-footer.json
+++ b/plugins/actian-design-system/recipes/flow/sticky-footer.json
@@ -37,8 +37,8 @@
           "padding": [16, 32, 16, 32],
           "primaryAxisAlignItems": "MAX"
         },
-        "fills": ["#FFFFFF"],
-        "stroke": { "color": "#E0E0E0", "weight": 1, "align": "INSIDE" },
+        "fills": ["var(--fm-base-white)"],
+        "stroke": { "color": "var(--fm-border)", "weight": 1, "align": "INSIDE" },
         "sizing": { "horizontal": "FILL", "vertical": 64 },
         "children": [
           {
@@ -94,8 +94,8 @@
           "padding": [16, 32, 16, 32],
           "primaryAxisAlignItems": "MAX"
         },
-        "fills": ["#FFFFFF"],
-        "stroke": { "color": "#E0E0E0", "weight": 1, "align": "INSIDE" },
+        "fills": ["var(--fm-base-white)"],
+        "stroke": { "color": "var(--fm-border)", "weight": 1, "align": "INSIDE" },
         "sizing": { "horizontal": "FILL", "vertical": 64 },
         "children": [
           {

--- a/plugins/actian-design-system/scripts/lib/paths.js
+++ b/plugins/actian-design-system/scripts/lib/paths.js
@@ -156,21 +156,6 @@ if (typeof PATHS.content.section === "function") {
   PATHS.content.bySlug = PATHS.content.section;
 }
 
-// Plugin-derived overlay: the leaf path to the lo-fi Fat Marker renderer
-// stylesheet, which declares the --fm-* token names. Already reachable via
-// the manifest-driven components.render.renderer collection above (called
-// with the member name fm-base.css), but validate-flow-data.js needs a
-// plain leaf path rather than a collection call, so it is overlaid here
-// beside the other renderer-related entries.
-PATHS.render = PATHS.render || {};
-PATHS.render.fmBaseCss = path.join(
-  VENDOR,
-  "components",
-  "render",
-  "renderer",
-  "fm-base.css",
-);
-
 // Top-level convenience constants (not in manifest — direct access for plugin internals).
 PATHS.pluginRoot = PLUGIN_ROOT;
 PATHS.vendor = VENDOR;

--- a/plugins/actian-design-system/scripts/lib/paths.js
+++ b/plugins/actian-design-system/scripts/lib/paths.js
@@ -156,6 +156,21 @@ if (typeof PATHS.content.section === "function") {
   PATHS.content.bySlug = PATHS.content.section;
 }
 
+// Plugin-derived overlay: the leaf path to the lo-fi Fat Marker renderer
+// stylesheet, which declares the --fm-* token names. Already reachable via
+// the manifest-driven components.render.renderer collection above (called
+// with the member name fm-base.css), but validate-flow-data.js needs a
+// plain leaf path rather than a collection call, so it is overlaid here
+// beside the other renderer-related entries.
+PATHS.render = PATHS.render || {};
+PATHS.render.fmBaseCss = path.join(
+  VENDOR,
+  "components",
+  "render",
+  "renderer",
+  "fm-base.css",
+);
+
 // Top-level convenience constants (not in manifest — direct access for plugin internals).
 PATHS.pluginRoot = PLUGIN_ROOT;
 PATHS.vendor = VENDOR;

--- a/plugins/actian-design-system/scripts/lib/screen-id.js
+++ b/plugins/actian-design-system/scripts/lib/screen-id.js
@@ -12,11 +12,23 @@ function deriveScreenId(feature, index) {
 function stampScreenIds(data) {
   if (!data || !Array.isArray(data.screens)) return;
   var feature = (data.meta && data.meta.feature) || "";
+  var usedIds = {};
+  for (var j = 0; j < data.screens.length; j++) {
+    var existing = data.screens[j];
+    if (existing && existing.id) usedIds[existing.id] = true;
+  }
   for (var i = 0; i < data.screens.length; i++) {
     var s = data.screens[i];
     if (!s) continue;
     if (s.id) continue;
-    s.id = deriveScreenId(feature, i);
+    var k = i;
+    var candidate = deriveScreenId(feature, k);
+    while (usedIds[candidate]) {
+      k++;
+      candidate = deriveScreenId(feature, k);
+    }
+    s.id = candidate;
+    usedIds[candidate] = true;
   }
 }
 

--- a/plugins/actian-design-system/scripts/renderers/assemble-flow-share.js
+++ b/plugins/actian-design-system/scripts/renderers/assemble-flow-share.js
@@ -154,7 +154,7 @@ function assembleFlowShare(data) {
   // Audience-safe visible meta (NO prompt, NO model).
   var shareMeta = [
     meta.app || "",
-    meta.generatedAt || meta.date || "",
+    String(meta.generatedAt || meta.date || "").slice(0, 10),
     meta.pluginVersion ? "v" + meta.pluginVersion : "",
   ]
     .filter(Boolean)
@@ -174,7 +174,7 @@ function assembleFlowShare(data) {
     maskComment(meta.prompt || "") +
     "\n" +
     "  date:     " +
-    maskComment(meta.generatedAt || meta.date || "") +
+    maskComment(String(meta.generatedAt || meta.date || "").slice(0, 10)) +
     "\n" +
     "  duration: " +
     maskComment(meta.duration || "") +

--- a/plugins/actian-design-system/scripts/renderers/html-renderers/ds-screen-tree.js
+++ b/plugins/actian-design-system/scripts/renderers/html-renderers/ds-screen-tree.js
@@ -180,7 +180,7 @@ function chromeNodes(chrome, sidebarConfig, pageHeaderConfig, headerConfig) {
       props: {
         App: prof.headerApp,
         Search: c.search !== false,
-        Account: c.account || "VO",
+        Account: c.account || "JD",
         Context: c.context || "Catalog",
         ContextValue: c.contextValue || "Default",
       },

--- a/plugins/actian-design-system/scripts/renderers/html-renderers/render-node.css
+++ b/plugins/actian-design-system/scripts/renderers/html-renderers/render-node.css
@@ -18,6 +18,7 @@
 .fm-text {
   display: inline;
   line-height: 1.5;
+  color: var(--fm-text-primary);
 }
 .fm-ellipse {
   border-radius: 50%;

--- a/plugins/actian-design-system/scripts/transformers/merge-partials.js
+++ b/plugins/actian-design-system/scripts/transformers/merge-partials.js
@@ -219,6 +219,10 @@ function main() {
     if (args.type !== "flow")
       die("--incremental is only supported for --type flow");
     const result = mergeIncrementalFlow(args.partialsDir, args.screenList);
+    // Stamp stable screen ids (feature-slug-index) onto every screen,
+    // pending stubs included, so a later --scope single-unit:<id> refine
+    // has a handle even before that screen is generated.
+    require("../lib/screen-id.js").stampScreenIds(result);
     const outDir = path.dirname(args.output);
     if (outDir && !fs.existsSync(outDir)) {
       fs.mkdirSync(outDir, { recursive: true });

--- a/plugins/actian-design-system/scripts/transformers/merge-partials.js
+++ b/plugins/actian-design-system/scripts/transformers/merge-partials.js
@@ -254,6 +254,10 @@ function main() {
     fs.mkdirSync(outDir, { recursive: true });
   }
 
+  // Stamp stable screen ids on the plain flow merge too, so every write
+  // site (incremental and plain) leaves flow-data.json with ids to refine.
+  if (args.type === "flow") require("../lib/screen-id.js").stampScreenIds(result);
+
   fs.writeFileSync(args.output, JSON.stringify(result, null, 2));
 }
 

--- a/plugins/actian-design-system/scripts/validation/validate-flow-data.js
+++ b/plugins/actian-design-system/scripts/validation/validate-flow-data.js
@@ -344,13 +344,14 @@ function findBannedTextRaw(data) {
 
 function loadTokenNames() {
   // DS tokens are declared in tokens.css; Fat Marker (lo-fi) tokens are
-  // declared in the vendored renderer's own stylesheet, fm-base.css. Neither
-  // file declares the other kit's names, so both sources are read and their
-  // declared names unioned. The trailing "\s*:" requires a DECLARATION
-  // ("--x:"), not merely a var() usage: a name only ever referenced inside a
-  // var() call in either file used to count as known, which hid a token that
-  // is used but never defined anywhere.
-  var sources = [PATHS.tokens.css, PATHS.render.fmBaseCss];
+  // declared in the vendored renderer's own stylesheet, fm-base.css, read
+  // through the renderer accessor (scripts/lib/renderer.js) rather than a
+  // second direct path into the vendored renderer. Neither file declares
+  // the other kit's names, so both sources are read and their declared
+  // names unioned. The trailing "\s*:" requires a DECLARATION ("--x:"): it
+  // matches only a defined token name, never a var() reference to one.
+  var renderer = require("../lib/renderer.js");
+  var sources = [PATHS.tokens.css, renderer.cssPaths.fmBase];
   var names = {};
   var re = /(--(?:zen|fm)-[a-z0-9-]+)\s*:/g;
   sources.forEach(function (cssPath) {

--- a/plugins/actian-design-system/scripts/validation/validate-flow-data.js
+++ b/plugins/actian-design-system/scripts/validation/validate-flow-data.js
@@ -343,19 +343,29 @@ function findBannedTextRaw(data) {
 // ---------------------------------------------------------------------------
 
 function loadTokenNames() {
-  var cssPath = PATHS.tokens.css;
-  try {
-    var css = fs.readFileSync(cssPath, "utf8");
-    var names = {};
-    var re = /(--(?:zen|fm)-[a-z0-9-]+)/g;
+  // DS tokens are declared in tokens.css; Fat Marker (lo-fi) tokens are
+  // declared in the vendored renderer's own stylesheet, fm-base.css. Neither
+  // file declares the other kit's names, so both sources are read and their
+  // declared names unioned. The trailing "\s*:" requires a DECLARATION
+  // ("--x:"), not merely a var() usage: a name only ever referenced inside a
+  // var() call in either file used to count as known, which hid a token that
+  // is used but never defined anywhere.
+  var sources = [PATHS.tokens.css, PATHS.render.fmBaseCss];
+  var names = {};
+  var re = /(--(?:zen|fm)-[a-z0-9-]+)\s*:/g;
+  sources.forEach(function (cssPath) {
+    var css;
+    try {
+      css = fs.readFileSync(cssPath, "utf8");
+    } catch (e) {
+      return;
+    }
     var m;
     while ((m = re.exec(css)) !== null) {
       names[m[1]] = true;
     }
-    return names;
-  } catch (e) {
-    return null;
-  }
+  });
+  return names;
 }
 
 function extractTokenRefs(obj) {

--- a/plugins/actian-design-system/scripts/validation/validate-flow-data.js
+++ b/plugins/actian-design-system/scripts/validation/validate-flow-data.js
@@ -1196,9 +1196,7 @@ function checkRecipeAdherence(screen, findings) {
 // as a graceful chip (warning — telemetry for leaf prioritization).
 var BUILT_DS_SLUGS = (function () {
   try {
-    return (
-      require("../lib/renderer.js").dsHtmlMap.BUILT_SLUGS || []
-    );
+    return require("../lib/renderer.js").dsHtmlMap.BUILT_SLUGS || [];
   } catch (e) {
     return [];
   }
@@ -2146,6 +2144,10 @@ if (require.main === module) {
             "Filter findings by scope: 'full' (default) | 'single-unit:<id>' | 'multi-unit:[<id>,<id>]'",
         },
         { name: "--json", description: "Output issues as JSON" },
+        {
+          name: "--write-ids",
+          description: "Write the stamped screen ids back to the input file",
+        },
         { name: "--help", description: "Show this help" },
       ],
     };
@@ -2165,6 +2167,7 @@ if (require.main === module) {
   var skipTerminology = flags.indexOf("--skip-terminology") !== -1;
   var skipAvoidWords = flags.indexOf("--skip-avoid-words") !== -1;
   var jsonOutput = flags.indexOf("--json") !== -1;
+  var writeIds = flags.indexOf("--write-ids") !== -1;
   var scopeIdx = flags.indexOf("--scope");
   var scope =
     scopeIdx !== -1 && flags[scopeIdx + 1] ? flags[scopeIdx + 1] : "full";
@@ -2224,6 +2227,14 @@ if (require.main === module) {
     skipAvoidWords: skipAvoidWords,
     scope: scope,
   });
+
+  // validate() stamps stable screen ids onto `data` in place (B-refine.1).
+  // --write-ids persists that stamp back to the input file so a later
+  // --scope single-unit:<id> run has an id to name. This runs regardless of
+  // findings or exit code: ids land even when the flow has P0s.
+  if (writeIds) {
+    fs.writeFileSync(dataPath, JSON.stringify(data, null, 2));
+  }
 
   // Severity tier mapping for the legacy CLI shape:
   //   error   → P0 (blocking; exit 1)

--- a/plugins/actian-design-system/scripts/validation/validate-flow-data.js
+++ b/plugins/actian-design-system/scripts/validation/validate-flow-data.js
@@ -1645,6 +1645,17 @@ function checkChromeCoherence(screen, glossaryChrome, findings) {
 // thin adapters over validate() — see below.
 // ---------------------------------------------------------------------------
 
+// A required-override prop is authored under its exact hashed registry name
+// (e.g. "Label#1411:32") or under its base name before the "#" (e.g.
+// "Label"). The generate-flow skill's own Examples author the base name and
+// the renderer reads it the same way, so the missing-required-override check
+// (Pass 1 below) accepts either spelling as satisfying the override.
+function hasOverride(props, propName) {
+  if (props[propName] !== undefined) return true;
+  var base = propName.split("#")[0];
+  return base !== propName && props[base] !== undefined;
+}
+
 function validate(data, opts) {
   opts = opts || {};
   var findings = [];
@@ -1739,7 +1750,7 @@ function validate(data, opts) {
       var required = rules.getRequiredOverrideProps(componentDef);
       var props = instNode.props || {};
       for (var i = 0; i < required.length; i++) {
-        if (props[required[i].propName] === undefined) {
+        if (!hasOverride(props, required[i].propName)) {
           findings.push({
             kind: "missing-required-override",
             severity: "error",

--- a/plugins/actian-design-system/scripts/validation/validate-flow-data.js
+++ b/plugins/actian-design-system/scripts/validation/validate-flow-data.js
@@ -166,6 +166,22 @@ function walkStringValues(node, currentPath, callback, parentKey) {
   }
 }
 
+// Enum slots the schema itself fills with a placeholder-looking word (e.g.
+// navItems[].state = "Placeholder" marks a muted sidebar item). The
+// placeholder-text check (Pass 2, below) walks every string in the flow;
+// these keys hold a fixed vocabulary, not user-visible copy, so a value
+// that matches PLACEHOLDER_PATTERNS there is not a leak. This gate applies
+// only inside the placeholder-text branch, not to the other checks that
+// scan flow strings (banned-text, terminology, avoid-word, hardcoded-color
+// each read data.screens directly, not through walkStringValues).
+var PLACEHOLDER_SKIP_KEYS = { state: 1, variant: 1, template: 1, status: 1 };
+function isEnumSlot(pathSegs) {
+  var last = pathSegs[pathSegs.length - 1];
+  return (
+    PLACEHOLDER_SKIP_KEYS[last] === 1 || pathSegs.indexOf("navItems") !== -1
+  );
+}
+
 // ---------------------------------------------------------------------------
 // Banned placeholder strings (P0 — blocks push)
 // ---------------------------------------------------------------------------
@@ -1762,6 +1778,7 @@ function validate(data, opts) {
   // Pass 2: walk all string values in screens (excludes meta block by design)
   if (data.screens) {
     walkStringValues(data.screens, "screens", function (str, p) {
+      if (isEnumSlot(p.split(/[.[\]]+/).filter(Boolean))) return;
       if (rules.isPlaceholderDefault(str)) {
         findings.push({
           kind: "placeholder-text",

--- a/plugins/actian-design-system/scripts/validation/validate-flow-data.js
+++ b/plugins/actian-design-system/scripts/validation/validate-flow-data.js
@@ -2277,18 +2277,27 @@ if (require.main === module) {
       );
       for (var i = 0; i < allIssues.length; i++) {
         var issue = allIssues[i];
-        process.stderr.write(
+        var line =
           issue.severity +
-            " [" +
-            issue.check +
-            "] " +
-            issue.screen +
-            " → " +
-            issue.path +
-            " = " +
-            JSON.stringify(issue.value) +
-            "\n",
-        );
+          " [" +
+          issue.check +
+          "] " +
+          issue.screen +
+          " → " +
+          issue.path +
+          " = " +
+          JSON.stringify(issue.value);
+        if (typeof issue.found === "string" && issue.found.length > 0) {
+          line += ' (found "' + issue.found + '"';
+          if (
+            typeof issue.suggestion === "string" &&
+            issue.suggestion.length > 0
+          ) {
+            line += ", " + issue.suggestion;
+          }
+          line += ")";
+        }
+        process.stderr.write(line + "\n");
       }
     }
   }

--- a/plugins/actian-design-system/scripts/validation/validate-flow-data.js
+++ b/plugins/actian-design-system/scripts/validation/validate-flow-data.js
@@ -369,8 +369,14 @@ function loadTokenNames() {
   // the other kit's names, so both sources are read and their declared
   // names unioned. The trailing "\s*:" requires a DECLARATION ("--x:"): it
   // matches only a defined token name, never a var() reference to one.
-  var renderer = require("../lib/renderer.js");
-  var sources = [PATHS.tokens.css, renderer.cssPaths.fmBase];
+  var sources = [PATHS.tokens.css];
+  try {
+    sources.push(require("../lib/renderer.js").cssPaths.fmBase);
+  } catch (e) {
+    // Same degrade as the BUILT_DS_SLUGS accessor below: a vendored
+    // snapshot missing the render package leaves the DS token sheet as
+    // the sole source.
+  }
   var names = {};
   var re = /(--(?:zen|fm)-[a-z0-9-]+)\s*:/g;
   sources.forEach(function (cssPath) {

--- a/plugins/actian-design-system/scripts/validation/validate-flow-data.js
+++ b/plugins/actian-design-system/scripts/validation/validate-flow-data.js
@@ -1196,7 +1196,9 @@ function checkRecipeAdherence(screen, findings) {
 // as a graceful chip (warning — telemetry for leaf prioritization).
 var BUILT_DS_SLUGS = (function () {
   try {
-    return require("../lib/renderer.js").dsHtmlMap.BUILT_SLUGS || [];
+    return (
+      require("../lib/renderer.js").dsHtmlMap.BUILT_SLUGS || []
+    );
   } catch (e) {
     return [];
   }

--- a/plugins/actian-design-system/scripts/validation/validate-flow-data.js
+++ b/plugins/actian-design-system/scripts/validation/validate-flow-data.js
@@ -169,17 +169,20 @@ function walkStringValues(node, currentPath, callback, parentKey) {
 // Enum slots the schema itself fills with a placeholder-looking word (e.g.
 // navItems[].state = "Placeholder" marks a muted sidebar item). The
 // placeholder-text check (Pass 2, below) walks every string in the flow;
-// these keys hold a fixed vocabulary, not user-visible copy, so a value
-// that matches PLACEHOLDER_PATTERNS there is not a leak. This gate applies
-// only inside the placeholder-text branch, not to the other checks that
-// scan flow strings (banned-text, terminology, avoid-word, hardcoded-color
-// each read data.screens directly, not through walkStringValues).
-var PLACEHOLDER_SKIP_KEYS = { state: 1, variant: 1, template: 1, status: 1 };
+// a string whose own key is one of these holds a fixed vocabulary, not
+// user-visible copy, so a value that matches PLACEHOLDER_PATTERNS there is
+// not a leak. The rule keys on the slot itself, not on any ancestor: a
+// sibling string under the same parent (navItems[].label, for example) is
+// genuine copy and stays fully checked. This gate applies only inside the
+// placeholder-text branch, not to the other checks that scan flow strings
+// (banned-text, terminology, avoid-word, hardcoded-color each read
+// data.screens directly, not through walkStringValues). `variant` is not
+// listed here: walkStringValues already excludes it via
+// STRUCTURAL_FIELD_KEYS (its callback never runs for a `variant` string).
+var PLACEHOLDER_SKIP_KEYS = { state: 1, template: 1, status: 1 };
 function isEnumSlot(pathSegs) {
   var last = pathSegs[pathSegs.length - 1];
-  return (
-    PLACEHOLDER_SKIP_KEYS[last] === 1 || pathSegs.indexOf("navItems") !== -1
-  );
+  return PLACEHOLDER_SKIP_KEYS[last] === 1;
 }
 
 // ---------------------------------------------------------------------------

--- a/plugins/actian-design-system/skills/generate-flow/SKILL.md
+++ b/plugins/actian-design-system/skills/generate-flow/SKILL.md
@@ -118,7 +118,7 @@ step-by-step behavior.
     {project_working_directory}/flows/flow-data.json --type flow-share \
     -o {project_working_directory}/flows/[feature].html
   ```
-- **Sequential mode (<6):** author `flow-data.json` with one `{ "name": …, "template": …, "status": "pending" }` stub per screen (the skeleton), then run the same `assemble-preview.js … --type flow-share` render to `flows/[feature].html`.
+- **Sequential mode (<6):** author `flow-data.json` with one `{ "id": "<feature-slug>-<n>", "name": …, "template": …, "content": [], "status": "pending" }` stub per screen (the skeleton), then run the same `assemble-preview.js … --type flow-share` render to `flows/[feature].html`.
 - Tell the user: `Preview ready (skeleton) → {project_working_directory}/flows/[feature].html — open it in the browser (CLI/IDE) or it updates live in the Cowork panel.` **Fail-open:** any skeleton/render error is skipped — proceed to the build (no regression).
 
 5. Build `flow-data.json`
@@ -138,7 +138,8 @@ step-by-step behavior.
    ```bash
    source "${CLAUDE_PLUGIN_ROOT}/scripts/lib/resolve-node.sh"
    "$NODE_BIN" "${CLAUDE_PLUGIN_ROOT}/scripts/validation/validate-flow-data.js" \
-     {project_working_directory}/flows/flow-data.json
+     {project_working_directory}/flows/flow-data.json \
+     --write-ids
    ```
 
    - Exit 1 (P0s found): fix all banned placeholder text before pushing. Common P0s: `"Page Title"`, `"Button label"`, `"Description text"`, `"Label"`, `"Nav Item"`.
@@ -151,12 +152,14 @@ step-by-step behavior.
    # Single-screen refine
    "$NODE_BIN" "${CLAUDE_PLUGIN_ROOT}/scripts/validation/validate-flow-data.js" \
      {project_working_directory}/flows/flow-data.json \
-     --scope single-unit:notification-preferences-2
+     --scope single-unit:notification-preferences-2 \
+     --write-ids
 
    # Multi-screen refine
    "$NODE_BIN" "${CLAUDE_PLUGIN_ROOT}/scripts/validation/validate-flow-data.js" \
      {project_working_directory}/flows/flow-data.json \
-     --scope multi-unit:[notification-preferences-1,notification-preferences-3]
+     --scope multi-unit:[notification-preferences-1,notification-preferences-3] \
+     --write-ids
    ```
 
    Scope is a runtime flag, not a data field — flow-data.json itself does not carry scope. Set `meta.mode = "refine"` on the artifact when applicable (that's the artifact-level signal).

--- a/plugins/actian-design-system/templates/flow-prototype-wrapper.html
+++ b/plugins/actian-design-system/templates/flow-prototype-wrapper.html
@@ -23,14 +23,6 @@
       flex-direction: column;
     }
 
-    /* The dark top bar, screen nav, indicator and keyboard hint sit directly on the
-       dark #1a1d23 body background, so they alone need the near-white text color that
-       used to live on body (and leaked into every FM text node that had no color of
-       its own, rendering it near-invisible on the white screen canvas). */
-    .proto-topbar, .proto-nav, .proto-indicator, .proto-hint {
-      color: #f0f2f5;
-    }
-
     /* ─── Stage — holds all screens, scrolls horizontally if needed ─────────── */
     .proto-stage {
       display: flex;

--- a/plugins/actian-design-system/templates/flow-prototype-wrapper.html
+++ b/plugins/actian-design-system/templates/flow-prototype-wrapper.html
@@ -17,11 +17,18 @@
     /* ─── Base ───────────────────────────────────────────────────────────────── */
     body {
       background: #1a1d23;
-      color: #f0f2f5;
       font-family: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
       min-height: 100vh;
       display: flex;
       flex-direction: column;
+    }
+
+    /* The dark top bar, screen nav, indicator and keyboard hint sit directly on the
+       dark #1a1d23 body background, so they alone need the near-white text color that
+       used to live on body (and leaked into every FM text node that had no color of
+       its own, rendering it near-invisible on the white screen canvas). */
+    .proto-topbar, .proto-nav, .proto-indicator, .proto-hint {
+      color: #f0f2f5;
     }
 
     /* ─── Stage — holds all screens, scrolls horizontally if needed ─────────── */

--- a/plugins/actian-design-system/tests/helpers/validate-cli.js
+++ b/plugins/actian-design-system/tests/helpers/validate-cli.js
@@ -10,7 +10,10 @@
 //
 // validate(data) writes data to a fresh fs.mkdtempSync directory and runs the
 // validator with process.execPath (the Node binary already running this test,
-// so no NODE_BIN resolution is needed here).
+// so no NODE_BIN resolution is needed here). The temp directory is removed in
+// a finally block (tests/validation/validate-enum-typing.test.js sets the
+// precedent) so a leaf calling validate() repeatedly does not litter the OS
+// temp directory with fixtures.
 
 var fs = require("fs");
 var os = require("os");
@@ -29,8 +32,14 @@ function validate(data) {
   var dir = fs.mkdtempSync(path.join(os.tmpdir(), "val-"));
   var input = path.join(dir, "flow-data.json");
   fs.writeFileSync(input, JSON.stringify(data));
-  var r = spawnSync(process.execPath, [VALIDATE, input], { encoding: "utf8" });
-  return { status: r.status, out: r.stdout + r.stderr };
+  try {
+    var r = spawnSync(process.execPath, [VALIDATE, input], {
+      encoding: "utf8",
+    });
+    return { status: r.status, out: r.stdout + r.stderr };
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
 }
 
 function flowWithText(color) {

--- a/plugins/actian-design-system/tests/helpers/validate-cli.js
+++ b/plugins/actian-design-system/tests/helpers/validate-cli.js
@@ -1,0 +1,49 @@
+"use strict";
+
+// validate-cli.js: shared test helper. Runs scripts/validation/validate-flow-data.js
+// as a subprocess against a fresh temp fixture, and returns its combined output.
+//
+// Multiple leaf tests need "write a flow-data.json, run the validator CLI on it,
+// read the findings back" (token-source-fm.test.js is the first; more tasks in
+// this hardening slice reuse it). Centralizing here means the fixture shape and
+// the spawn plumbing are defined once instead of pasted into every leaf.
+//
+// validate(data) writes data to a fresh fs.mkdtempSync directory and runs the
+// validator with process.execPath (the Node binary already running this test,
+// so no NODE_BIN resolution is needed here).
+
+var fs = require("fs");
+var os = require("os");
+var path = require("path");
+var spawnSync = require("child_process").spawnSync;
+
+var PLUGIN_ROOT = path.resolve(__dirname, "..", "..");
+var VALIDATE = path.join(
+  PLUGIN_ROOT,
+  "scripts",
+  "validation",
+  "validate-flow-data.js",
+);
+
+function validate(data) {
+  var dir = fs.mkdtempSync(path.join(os.tmpdir(), "val-"));
+  var input = path.join(dir, "flow-data.json");
+  fs.writeFileSync(input, JSON.stringify(data));
+  var r = spawnSync(process.execPath, [VALIDATE, input], { encoding: "utf8" });
+  return { status: r.status, out: r.stdout + r.stderr };
+}
+
+function flowWithText(color) {
+  return {
+    meta: { feature: "T", app: "Studio" },
+    screens: [
+      {
+        name: "S1",
+        template: "studio",
+        content: [{ type: "TEXT", content: "Hello", color: color }],
+      },
+    ],
+  };
+}
+
+module.exports = { validate: validate, flowWithText: flowWithText };

--- a/plugins/actian-design-system/tests/integration/recipes.test.js
+++ b/plugins/actian-design-system/tests/integration/recipes.test.js
@@ -12,6 +12,7 @@
 const assert = require("node:assert");
 const fs = require("node:fs");
 const path = require("node:path");
+const PATHS = require("../../scripts/lib/paths.js");
 
 const RECIPES_DIR = path.resolve(__dirname, "..", "..", "recipes");
 const INDEX_PATH = path.join(RECIPES_DIR, "flow", "_index.json");
@@ -887,6 +888,180 @@ if (stickyTestErrors.length === 0) {
     "FAIL  sticky-footer.json destructiveSkeleton intent annotations",
   );
   stickyTestErrors.forEach((e) => console.log(`        ${e}`));
+  failed++;
+}
+
+// ── Task 0.12: no recipe fill under recipes/flow/ is a hex literal ─────
+
+var FLOW_FILES = fs
+  .readdirSync(path.join(RECIPES_DIR, "flow"))
+  .filter(function (f) {
+    return f.endsWith(".json") && f !== "_index.json";
+  })
+  .sort();
+
+var FILL_KEYS = ["fills", "fill", "color", "stroke", "background"];
+var HEX_LITERAL_RE = /#[0-9a-f]{3,8}\b/i;
+
+function collectHexFills(node, nodePath, out) {
+  if (node === null || typeof node !== "object") return;
+  if (Array.isArray(node)) {
+    node.forEach(function (child, i) {
+      collectHexFills(child, `${nodePath}[${i}]`, out);
+    });
+    return;
+  }
+  Object.keys(node).forEach(function (key) {
+    var val = node[key];
+    if (FILL_KEYS.indexOf(key) !== -1) {
+      if (typeof val === "string" && HEX_LITERAL_RE.test(val)) {
+        out.push({ path: `${nodePath}.${key}`, value: val });
+      } else if (Array.isArray(val)) {
+        val.forEach(function (v, i) {
+          if (typeof v === "string" && HEX_LITERAL_RE.test(v)) {
+            out.push({ path: `${nodePath}.${key}[${i}]`, value: v });
+          }
+        });
+      }
+    }
+    collectHexFills(val, `${nodePath}.${key}`, out);
+  });
+}
+
+var hexTestErrors = [];
+FLOW_FILES.forEach(function (file) {
+  var filePath = path.join(RECIPES_DIR, "flow", file);
+  var recipe;
+  try {
+    recipe = JSON.parse(fs.readFileSync(filePath, "utf8"));
+  } catch (err) {
+    hexTestErrors.push(`${file}: could not be parsed: ${err.message}`);
+    return;
+  }
+  var hits = [];
+  collectHexFills(recipe, "$", hits);
+  hits.forEach(function (hit) {
+    hexTestErrors.push(
+      `${file} ${hit.path}: hardcoded hex ${hit.value} (bind a var(--fm-*) token instead)`,
+    );
+  });
+});
+
+if (hexTestErrors.length === 0) {
+  console.log("PASS  no recipe fill under recipes/flow/ is a hex literal");
+  passed++;
+} else {
+  console.log("FAIL  no recipe fill under recipes/flow/ is a hex literal");
+  hexTestErrors.forEach((e) => console.log(`        ${e}`));
+  failed++;
+}
+
+// ── Task 0.12: every FM variant axis value exists in the fmkit registry ─
+
+// Mirrors scripts/lib/shared-constants.js `slugToRef` (also duplicated in
+// fm-coverage.test.js) so this gate stays dependency-free.
+function slugToFmRef(slug) {
+  var prefix = "fm";
+  var stripped =
+    slug.indexOf(prefix + "-") === 0 ? slug.slice(prefix.length + 1) : slug;
+  return (
+    prefix +
+    stripped.charAt(0).toUpperCase() +
+    stripped.slice(1).replace(/-([a-z])/g, function (_, c) {
+      return c.toUpperCase();
+    })
+  );
+}
+
+var fmkitRegistry = JSON.parse(
+  fs.readFileSync(PATHS.components.registries.fmkit, "utf8"),
+);
+var fmRefToVariants = {};
+Object.keys(fmkitRegistry.components).forEach(function (slug) {
+  if (slug.indexOf("fm-") !== 0) return;
+  fmRefToVariants[slugToFmRef(slug)] =
+    fmkitRegistry.components[slug].variants || {};
+});
+
+var axisTestErrors = [];
+
+function collectFmVariantIssues(node, nodePath, file) {
+  if (node === null || typeof node !== "object") return;
+  if (Array.isArray(node)) {
+    node.forEach(function (child, i) {
+      collectFmVariantIssues(child, `${nodePath}[${i}]`, file);
+    });
+    return;
+  }
+  if (
+    node.type === "INSTANCE" &&
+    typeof node.ref === "string" &&
+    node.ref.indexOf("fm") === 0 &&
+    typeof node.variant === "string"
+  ) {
+    var variants = fmRefToVariants[node.ref];
+    node.variant
+      .split(",")
+      .map(function (s) {
+        return s.trim();
+      })
+      .filter(Boolean)
+      .forEach(function (pair) {
+        var eq = pair.indexOf("=");
+        if (eq === -1) {
+          axisTestErrors.push(
+            `${file} ${nodePath} (${node.ref}): unparseable variant segment "${pair}"`,
+          );
+          return;
+        }
+        var axis = pair.slice(0, eq).trim();
+        var value = pair.slice(eq + 1).trim();
+        if (!variants) {
+          axisTestErrors.push(
+            `${file} ${nodePath}: ref "${node.ref}" not found in the fmkit registry`,
+          );
+          return;
+        }
+        if (!variants[axis]) {
+          axisTestErrors.push(
+            `${file} ${nodePath} (${node.ref}): axis "${axis}" does not exist (available: ${Object.keys(variants).join(", ")})`,
+          );
+          return;
+        }
+        if (variants[axis].indexOf(value) === -1) {
+          axisTestErrors.push(
+            `${file} ${nodePath} (${node.ref}): value "${axis}=${value}" not in the fmkit registry (available: ${variants[axis].join(", ")})`,
+          );
+        }
+      });
+  }
+  Object.keys(node).forEach(function (key) {
+    if (key === "variant") return;
+    collectFmVariantIssues(node[key], `${nodePath}.${key}`, file);
+  });
+}
+
+FLOW_FILES.forEach(function (file) {
+  var filePath = path.join(RECIPES_DIR, "flow", file);
+  var recipe;
+  try {
+    recipe = JSON.parse(fs.readFileSync(filePath, "utf8"));
+  } catch (err) {
+    return; // already reported above
+  }
+  collectFmVariantIssues(recipe, "$", file);
+});
+
+if (axisTestErrors.length === 0) {
+  console.log(
+    "PASS  every FM variant axis value in a recipe exists in the fmkit registry",
+  );
+  passed++;
+} else {
+  console.log(
+    "FAIL  every FM variant axis value in a recipe exists in the fmkit registry",
+  );
+  axisTestErrors.forEach((e) => console.log(`        ${e}`));
   failed++;
 }
 

--- a/plugins/actian-design-system/tests/integration/recipes.test.js
+++ b/plugins/actian-design-system/tests/integration/recipes.test.js
@@ -900,7 +900,15 @@ var FLOW_FILES = fs
   })
   .sort();
 
-var FILL_KEYS = ["fills", "fill", "color", "stroke", "background"];
+var FILL_KEYS = [
+  "fills",
+  "fill",
+  "color",
+  "stroke",
+  "background",
+  "backgroundColor",
+  "borderColor",
+];
 var HEX_LITERAL_RE = /#[0-9a-f]{3,8}\b/i;
 
 function collectHexFills(node, nodePath, out) {

--- a/plugins/actian-design-system/tests/lib/screen-id.test.js
+++ b/plugins/actian-design-system/tests/lib/screen-id.test.js
@@ -96,4 +96,49 @@ describe("stampScreenIds", function () {
     stampScreenIds(data);
     assert.strictEqual(data.screens[1].id, "test-2");
   });
+
+  it("a derived id skips one another screen already carries", function () {
+    var data = {
+      meta: { feature: "f" },
+      screens: [
+        { id: "f-1", name: "S1", content: [] },
+        { name: "S2", content: [] },
+        { id: "f-2", name: "S3", content: [] },
+      ],
+    };
+    stampScreenIds(data);
+    assert.strictEqual(data.screens[0].id, "f-1");
+    assert.strictEqual(data.screens[1].id, "f-3");
+    assert.strictEqual(data.screens[2].id, "f-2");
+  });
+
+  it("a flow with no ids still gets slug-1..slug-n", function () {
+    var data = {
+      meta: { feature: "f" },
+      screens: [
+        { name: "S1", content: [] },
+        { name: "S2", content: [] },
+        { name: "S3", content: [] },
+      ],
+    };
+    stampScreenIds(data);
+    assert.strictEqual(data.screens[0].id, "f-1");
+    assert.strictEqual(data.screens[1].id, "f-2");
+    assert.strictEqual(data.screens[2].id, "f-3");
+  });
+
+  it("stamping twice with a collision resolved is a no-op", function () {
+    var data = {
+      meta: { feature: "f" },
+      screens: [
+        { id: "f-1", name: "S1", content: [] },
+        { name: "S2", content: [] },
+        { id: "f-2", name: "S3", content: [] },
+      ],
+    };
+    stampScreenIds(data);
+    var snapshot = JSON.parse(JSON.stringify(data));
+    stampScreenIds(data);
+    assert.deepStrictEqual(data, snapshot);
+  });
 });

--- a/plugins/actian-design-system/tests/renderers/assemble-flow-share.test.js
+++ b/plugins/actian-design-system/tests/renderers/assemble-flow-share.test.js
@@ -28,4 +28,9 @@ describe("assembleFlowShare (direct)", function () {
     var html = assembleFlowShare({ meta: { feature: "E" }, screens: [] });
     assert.ok(html.indexOf("<!DOCTYPE html>") !== -1 && html.indexOf("proto-stage") !== -1, "valid shell");
   });
+  it("the visible date is a calendar date, not an ISO timestamp", function () {
+    var out = assembleFlowShare({ meta: { feature: "T", app: "Studio", generatedAt: "2026-09-08T11:18:41.503Z" }, screens: [] });
+    assert.match(out, /2026-09-08(?!T)/);
+    assert.doesNotMatch(out, /11:18:41\.503Z/);
+  });
 });

--- a/plugins/actian-design-system/tests/renderers/ds-screen-tree.test.js
+++ b/plugins/actian-design-system/tests/renderers/ds-screen-tree.test.js
@@ -252,6 +252,17 @@ test("chromeNodes — sidebar comma-list branch (no icons)", function () {
   assert.ok(nodes.sidebar.props.Items.indexOf("Catalog") >= 0);
 });
 
+test("chromeNodes: the header avatar does not default to a real person's initials", function () {
+  var chrome = chromeTree.resolveChrome({
+    name: "S",
+    template: "studio",
+    library: "ds",
+    content: [],
+  });
+  var nodes = chromeTree.chromeNodes(chrome, null, null, {});
+  assert.equal(nodes.header.props.Account, "JD");
+});
+
 // ---------------------------------------------------------------------------
 // (4) screenTree()
 // ---------------------------------------------------------------------------

--- a/plugins/actian-design-system/tests/renderers/fm-text-color.test.js
+++ b/plugins/actian-design-system/tests/renderers/fm-text-color.test.js
@@ -1,0 +1,34 @@
+#!/usr/bin/env node
+"use strict";
+var { describe, it } = require("node:test");
+var assert = require("node:assert");
+var fs = require("fs");
+var os = require("os");
+var path = require("path");
+var { spawnSync } = require("child_process");
+
+var PLUGIN_ROOT = path.resolve(__dirname, "..", "..");
+var ASSEMBLE = path.join(PLUGIN_ROOT, "scripts", "renderers", "assemble-preview.js");
+
+function renderFlow(data) {
+  var dir = fs.mkdtempSync(path.join(os.tmpdir(), "fm-text-"));
+  var input = path.join(dir, "flow-data.json");
+  var out = path.join(dir, "flow.html");
+  fs.writeFileSync(input, JSON.stringify(data));
+  var r = spawnSync(process.execPath, [ASSEMBLE, input, "--type", "flow-share", "-o", out]);
+  assert.strictEqual(r.status, 0, String(r.stderr));
+  return fs.readFileSync(out, "utf8");
+}
+
+describe("flow-share: FM text is visible without an explicit color", function () {
+  var html = renderFlow({
+    meta: { feature: "T", app: "Studio" },
+    screens: [{ name: "S1", template: "studio", content: [{ type: "TEXT", content: "Visible please" }] }],
+  });
+  it("the inlined flow CSS gives .fm-text an explicit color", function () {
+    assert.match(html, /\.fm-text\s*\{[^}]*color:\s*var\(--fm-text-primary\)/);
+  });
+  it("the wrapper's near-white body color is not on body any more", function () {
+    assert.doesNotMatch(html, /body\s*\{[^}]*color:\s*#f0f2f5/i);
+  });
+});

--- a/plugins/actian-design-system/tests/transformers/merge-partials-ids.test.js
+++ b/plugins/actian-design-system/tests/transformers/merge-partials-ids.test.js
@@ -1,0 +1,52 @@
+"use strict";
+var { describe, it } = require("node:test");
+var assert = require("node:assert");
+var fs = require("node:fs");
+var os = require("node:os");
+var path = require("node:path");
+var cp = require("node:child_process");
+
+var SCRIPT = path.resolve(
+  __dirname,
+  "../../scripts/transformers/merge-partials.js",
+);
+
+describe("merge-partials --incremental stamps screen ids", function () {
+  it("the incremental skeleton merge stamps ids", function () {
+    var dir = fs.mkdtempSync(path.join(os.tmpdir(), "merge-ids-"));
+    try {
+      var partialsDir = path.join(dir, ".partial");
+      fs.mkdirSync(partialsDir, { recursive: true });
+      var listPath = path.join(dir, "screen-list.json");
+      fs.writeFileSync(
+        listPath,
+        JSON.stringify({
+          meta: { feature: "Access request" },
+          screens: [{ name: "Marketplace", template: "browse" }],
+        }),
+      );
+      var out = path.join(dir, "flow-data.json");
+      var r = cp.spawnSync(
+        process.execPath,
+        [
+          SCRIPT,
+          "--type",
+          "flow",
+          "--incremental",
+          "--screen-list",
+          listPath,
+          "--partials-dir",
+          partialsDir,
+          "--output",
+          out,
+        ],
+        { encoding: "utf8" },
+      );
+      assert.equal(r.status, 0, r.stderr);
+      var merged = JSON.parse(fs.readFileSync(out, "utf8"));
+      assert.strictEqual(merged.screens[0].id, "access-request-1");
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});

--- a/plugins/actian-design-system/tests/transformers/merge-partials-incremental.test.js
+++ b/plugins/actian-design-system/tests/transformers/merge-partials-incremental.test.js
@@ -143,10 +143,20 @@ describe("merge-partials --incremental (flow skeleton-fill)", function () {
     );
     assert.equal(r2.status, 0, r2.stderr);
     var full = JSON.parse(fs.readFileSync(out2, "utf8"));
+    // The incremental path stamps screen ids (feature-slug-index) on every
+    // merge; the plain non-incremental merge does not. Set ids aside before
+    // comparing so this asserts parity on everything else.
+    assert.strictEqual(incr.screens[0].id, "cat-1");
+    assert.strictEqual(incr.screens[1].id, "cat-2");
+    var incrWithoutIds = incr.screens.map(function (s) {
+      var copy = Object.assign({}, s);
+      delete copy.id;
+      return copy;
+    });
     assert.deepEqual(
-      incr.screens,
+      incrWithoutIds,
       full.screens,
-      "incremental(all present) screens == non-incremental merge screens",
+      "incremental(all present) screens == non-incremental merge screens, ids aside",
     );
   });
 

--- a/plugins/actian-design-system/tests/transformers/merge-partials-incremental.test.js
+++ b/plugins/actian-design-system/tests/transformers/merge-partials-incremental.test.js
@@ -143,20 +143,10 @@ describe("merge-partials --incremental (flow skeleton-fill)", function () {
     );
     assert.equal(r2.status, 0, r2.stderr);
     var full = JSON.parse(fs.readFileSync(out2, "utf8"));
-    // The incremental path stamps screen ids (feature-slug-index) on every
-    // merge; the plain non-incremental merge does not. Set ids aside before
-    // comparing so this asserts parity on everything else.
-    assert.strictEqual(incr.screens[0].id, "cat-1");
-    assert.strictEqual(incr.screens[1].id, "cat-2");
-    var incrWithoutIds = incr.screens.map(function (s) {
-      var copy = Object.assign({}, s);
-      delete copy.id;
-      return copy;
-    });
     assert.deepEqual(
-      incrWithoutIds,
+      incr.screens,
       full.screens,
-      "incremental(all present) screens == non-incremental merge screens, ids aside",
+      "incremental(all present) screens == non-incremental merge screens",
     );
   });
 

--- a/plugins/actian-design-system/tests/validation/placeholder-walker-skips-state.test.js
+++ b/plugins/actian-design-system/tests/validation/placeholder-walker-skips-state.test.js
@@ -39,4 +39,20 @@ describe("placeholder-text walker", function () {
     });
     assert.match(r.out, /P0 \[placeholder-text\]/);
   });
+  it("navItems[].label reading Nav Item is still a leak (label is user-visible copy)", function () {
+    var r = validate({
+      meta: { feature: "T", app: "Studio" },
+      screens: [
+        {
+          name: "S1",
+          template: "studio",
+          navItems: [{ label: "Nav Item", state: "on" }],
+          content: [
+            { type: "TEXT", content: "Hello", color: "var(--fm-text-primary)" },
+          ],
+        },
+      ],
+    });
+    assert.match(r.out, /P0 \[placeholder-text\].*navItems\[0\]\.label/);
+  });
 });

--- a/plugins/actian-design-system/tests/validation/placeholder-walker-skips-state.test.js
+++ b/plugins/actian-design-system/tests/validation/placeholder-walker-skips-state.test.js
@@ -1,0 +1,42 @@
+#!/usr/bin/env node
+"use strict";
+var { describe, it } = require("node:test");
+var assert = require("node:assert");
+var { validate } = require("../helpers/validate-cli.js");
+
+describe("placeholder-text walker", function () {
+  it("navItems[].state = Placeholder is the schema's shape, not a leak", function () {
+    var r = validate({
+      meta: { feature: "T", app: "Studio" },
+      screens: [
+        {
+          name: "S1",
+          template: "studio",
+          navItems: [
+            { label: "Catalog", state: "on" },
+            { label: "Topics", state: "Placeholder" },
+          ],
+          content: [
+            { type: "TEXT", content: "Hello", color: "var(--fm-text-primary)" },
+          ],
+        },
+      ],
+    });
+    assert.doesNotMatch(r.out, /placeholder-text.*navItems/);
+  });
+  it("a TEXT node reading Page Title is still a leak (the check can fail)", function () {
+    var r = validate({
+      meta: { feature: "T", app: "Studio" },
+      screens: [
+        {
+          name: "S1",
+          template: "studio",
+          content: [
+            { type: "TEXT", content: "Page Title", color: "var(--fm-text-primary)" },
+          ],
+        },
+      ],
+    });
+    assert.match(r.out, /P0 \[placeholder-text\]/);
+  });
+});

--- a/plugins/actian-design-system/tests/validation/required-override-base-name.test.js
+++ b/plugins/actian-design-system/tests/validation/required-override-base-name.test.js
@@ -1,0 +1,21 @@
+#!/usr/bin/env node
+"use strict";
+var { describe, it } = require("node:test");
+var assert = require("node:assert");
+var { validate } = require("../helpers/validate-cli.js");
+
+describe("missing-required-override", function () {
+  var button = function (props) {
+    return { meta: { feature: "T", app: "Studio" },
+      screens: [{ name: "S1", template: "studio", content: [
+        { type: "INSTANCE", ref: "fmButton", variant: "Type=Primary, Size=md, Shape=Regular, State=Default", props: props } ] }] };
+  };
+  it("plain Label satisfies Label#1411:32", function () {
+    var r = validate(button({ Label: "Save changes", "👁 Leading Icon": false, "👁 Trailing Icon": false }));
+    assert.doesNotMatch(r.out, /missing-required-override/);
+  });
+  it("no label at all is still a P0 (the check can fail)", function () {
+    var r = validate(button({ "👁 Leading Icon": false, "👁 Trailing Icon": false }));
+    assert.match(r.out, /P0 \[missing-required-override\]/);
+  });
+});

--- a/plugins/actian-design-system/tests/validation/terminology-cli-prints-found.test.js
+++ b/plugins/actian-design-system/tests/validation/terminology-cli-prints-found.test.js
@@ -1,0 +1,31 @@
+#!/usr/bin/env node
+"use strict";
+var { describe, it } = require("node:test");
+var assert = require("node:assert");
+var { validate } = require("../helpers/validate-cli.js");
+
+describe("terminology-cli-prints-found", function () {
+  var flow = function (text) {
+    return {
+      meta: { feature: "T", app: "Studio" },
+      screens: [
+        {
+          name: "S1",
+          template: "studio",
+          content: [{ type: "TEXT", content: text }],
+        },
+      ],
+    };
+  };
+
+  it("prints the found word and the suggested fix on a terminology line", function () {
+    var r = validate(flow("Browse every dataset"));
+    assert.match(r.out, /found "dataset".*use "data product"/i);
+  });
+
+  it("leaves the printed line unchanged when the finding has no found word", function () {
+    var r = validate(flow("Page Title"));
+    assert.match(r.out, /P0 \[placeholder-text\]/);
+    assert.doesNotMatch(r.out, /\(found/);
+  });
+});

--- a/plugins/actian-design-system/tests/validation/token-source-fm.test.js
+++ b/plugins/actian-design-system/tests/validation/token-source-fm.test.js
@@ -1,0 +1,16 @@
+#!/usr/bin/env node
+"use strict";
+var { describe, it } = require("node:test");
+var assert = require("node:assert");
+var { validate, flowWithText } = require("../helpers/validate-cli.js");
+
+describe("validate-flow-data: token source", function () {
+  it("an FM token defined in fm-base.css is not a finding", function () {
+    var r = validate(flowWithText("var(--fm-text-tertiary)"));
+    assert.doesNotMatch(r.out, /\[token\].*--fm-text-tertiary/);
+  });
+  it("an undefined FM token is still a finding (the check can fail)", function () {
+    var r = validate(flowWithText("var(--fm-not-a-token)"));
+    assert.match(r.out, /\[token\].*--fm-not-a-token/);
+  });
+});

--- a/plugins/actian-design-system/tests/validation/write-ids.test.js
+++ b/plugins/actian-design-system/tests/validation/write-ids.test.js
@@ -3,6 +3,7 @@
 
 var { describe, it } = require("node:test");
 var assert = require("node:assert");
+var crypto = require("crypto");
 var fs = require("fs");
 var os = require("os");
 var path = require("path");
@@ -31,6 +32,34 @@ describe("validate-flow-data --write-ids", function () {
       spawnSync(process.execPath, [VALIDATE, input, "--write-ids"]);
       var after = JSON.parse(fs.readFileSync(input, "utf8"));
       assert.strictEqual(after.screens[0].id, "data-product-publishing-1");
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("without --write-ids the input file is left byte-identical", function () {
+    var dir = fs.mkdtempSync(path.join(os.tmpdir(), "ids-"));
+    try {
+      var input = path.join(dir, "flow-data.json");
+      fs.writeFileSync(
+        input,
+        JSON.stringify({
+          meta: { feature: "Data product publishing", app: "Studio" },
+          screens: [{ name: "S1", template: "studio", content: [] }],
+        }),
+      );
+      var before = crypto
+        .createHash("sha256")
+        .update(fs.readFileSync(input))
+        .digest("hex");
+      spawnSync(process.execPath, [VALIDATE, input]);
+      var after = crypto
+        .createHash("sha256")
+        .update(fs.readFileSync(input))
+        .digest("hex");
+      assert.strictEqual(after, before);
+      var parsed = JSON.parse(fs.readFileSync(input, "utf8"));
+      assert.strictEqual(parsed.screens[0].id, undefined);
     } finally {
       fs.rmSync(dir, { recursive: true, force: true });
     }

--- a/plugins/actian-design-system/tests/validation/write-ids.test.js
+++ b/plugins/actian-design-system/tests/validation/write-ids.test.js
@@ -1,0 +1,38 @@
+#!/usr/bin/env node
+"use strict";
+
+var { describe, it } = require("node:test");
+var assert = require("node:assert");
+var fs = require("fs");
+var os = require("os");
+var path = require("path");
+var { spawnSync } = require("node:child_process");
+
+var PLUGIN_ROOT = path.resolve(__dirname, "..", "..");
+var VALIDATE = path.join(
+  PLUGIN_ROOT,
+  "scripts",
+  "validation",
+  "validate-flow-data.js",
+);
+
+describe("validate-flow-data --write-ids", function () {
+  it("--write-ids stamps screen ids into the file", function () {
+    var dir = fs.mkdtempSync(path.join(os.tmpdir(), "ids-"));
+    try {
+      var input = path.join(dir, "flow-data.json");
+      fs.writeFileSync(
+        input,
+        JSON.stringify({
+          meta: { feature: "Data product publishing", app: "Studio" },
+          screens: [{ name: "S1", template: "studio", content: [] }],
+        }),
+      );
+      spawnSync(process.execPath, [VALIDATE, input, "--write-ids"]);
+      var after = JSON.parse(fs.readFileSync(input, "utf8"));
+      assert.strictEqual(after.screens[0].id, "data-product-publishing-1");
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});


### PR DESCRIPTION
## Summary

The lo-fi HTML deliverable is visible and the validator is quiet on a clean flow. FM text nodes authored without a colour inherited the share wrapper's near-white body colour and rendered invisible; `.fm-text` now reads `--fm-text-primary` and the wrapper sets no body colour. The validator resolves `--fm-*` tokens against the FM sheet (113 false P1s on the audit flow before), treats `state` / `template` / `status` values as enum slots rather than placeholder text, accepts a required override under its plain prop name (`Label` as well as `Label#1411:32`), writes stamped screen ids back with `--write-ids` (both merge paths stamp; a derived id never collides), and prints the offending word and the suggestion on terminology and avoid-word findings. The eight flow recipes carry `--fm-*` tokens instead of 57 hex literals, guarded by two repo-wide assertions (hex fills and unknown FM variant axes). The share view drops the specimen avatar initials and the millisecond timestamp. Slice 0, PR A of 2 (PR B stacks on this branch).

## Test plan

- [x] Full plugin test suite passes locally: 2229 tests, 2224 pass, 0 fail, 5 skipped (run on 64f057aa).
- [x] Doc-conventions test passes.
- [x] Ran the affected path on a real flow: the audit's own lo-fi and hi-fi `flow-data.json` re-validated and re-rendered with this branch (see Smoke evidence).
- [ ] Tokens / registries: N/A, untouched.

## Smoke evidence

- **Component / node ID smoked:** the 5-screen "Data product publishing" (Studio) lo-fi flow from the 2026-09-08 audit, re-rendered with `assemble-preview.js --type flow-share`, served on localhost:8765 and opened in Chrome. Not a Figma push: this PR is HTML-only.
- **AI used the new path? (proof):** the validator run on that flow-data reports 21 findings instead of 165 (20 `P1 [terminology]`, all now printed as `(found "dataset", use "Data product")`, plus 1 true `P2 [enum-not-typed]`); the hi-fi run reports 36 instead of 48 (all terminology). Zero `unresolved-token`, zero false `placeholder-text`, zero false `missing-required-override`.
- **Visual / metadata check:** screen 1 has 66 `.fm-text` nodes, 26 without an inline colour; all 26 compute to `rgb(16, 24, 40)` (`--fm-text-primary`), none near-white; body colour `rgb(0, 0, 0)`. Chrome, sidebar, filters, card titles and body copy are dark and legible; the topbar keeps its own white-on-dark rules.
- **Pre-existing surface still works (proof):** the hi-fi (DS-native) render of the same feature resolves every `var(--fm-*)` reference it inlines (20 distinct references against 24 declarations, set difference 0); `--write-ids` twice on a copy of the flow-data is byte-identical the second time and preserves a hand-written id; a run without the flag leaves the file byte-identical (sha256).

## Migration discipline

N/A: no push pattern or skill behaviour is retired or superseded.

## Version bump

- [x] `plugins/actian-design-system/.claude-plugin/plugin.json` bumped 2026.9.11 to 2026.9.12 via `bump-version.js ... calendar`; `check-version-bump.js` prints `base 2026.9.11 → head 2026.9.12 ... OK`.

## Out-of-scope / follow-up

- `render-node-figma.js` `hexToRgb()` has no `var()` branch, so token fills reach a Figma push as NaN channels. Outside this HTML-only slice; verify on the first real push when Figma testing starts.
- The remaining terminology warnings come from the vendored app-context `notUse` lists (they flag the correct term itself: "Input ports" on "input"; and pairs such as policy to Data contract, source to Input Port). A knowledge-repo issue; the plugin-side gate fix is planned in a later slice.
- The header avatar default (`VO` to `JD`) is data-level only: neither the lo-fi FM header nor the hi-fi DS header renders the Account prop in HTML.
- Avoid-word suggestions print as a bare example sentence (`(found "please", Contact Support)`); a `try "..."` prefix would read better.
- `--fm-text-primary` is undefined in the presentation bundle (falls back to inherit, unchanged behaviour); presentations are slated for retirement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Qzd8jSsTk92htT3jdEGJwU
