### PR TITLE
fix(skills): every skill resolves the plugin root inside the Cowork VM

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,6 +78,17 @@ are summarized at the release level.
 
 ### Fixed
 
+- **Every skill finds the plugin root inside the Cowork VM.** In Cowork, Read and Glob see the
+  Mac-side plugin path while bash runs in a VM where the plugin is mounted under a sessions
+  directory. A session on 2026-09-09 concluded the renderer scripts were not available and
+  hand-built its deliverable. Each `SKILL.md` now opens with one "Where the plugin lives" block
+  (canonical copy in `references/context/plugin-root.md`) whose bash line sets `CLAUDE_PLUGIN_ROOT`
+  by locating the mounted manifest, and `scripts/lib/plugin-root.sh` does the same for scripts.
+  A test runs the resolver in three simulated layouts and asserts every skill carries the block
+  verbatim.
+
+### Fixed
+
 - **Lo-fi text is visible again** ([#359](https://github.com/volivarii/Actian-DS-Claude-plugin/pull/359)). FM TEXT nodes authored without an explicit color inherited the
   share wrapper's near-white body color and rendered invisible on the white screen canvas.
   `.fm-text` now reads `--fm-text-primary` and the wrapper's `body` rule carries no color of its

--- a/USAGE.md
+++ b/USAGE.md
@@ -477,6 +477,10 @@ Click directly on elements in the preview instead of describing issues in text:
 
 **Change** = modify the element. **Note** = carry forward to Figma without changing.
 
+### Running in Cowork
+
+In the Cowork tab, bash runs inside a VM where the plugin is mounted under a sessions directory, not at the path the skill header names. Every skill now starts with a "Where the plugin lives" block that sets `CLAUDE_PLUGIN_ROOT` for that shell, so the renderer and validator scripts are found on the first try. If a run ever says the scripts are not available, run that block's bash line by hand and retry.
+
 ---
 
 ## Three Actian apps

--- a/plugins/actian-design-system/.claude-plugin/plugin.json
+++ b/plugins/actian-design-system/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "actian-design-system",
   "description": "Actian Design System toolkit — generate wireframe flows with prototype wiring, create component briefs, audit designs, compare flows, and build presentations. 8 skills (with tiered generation: recognized / adapted / improvised), 9 agents, 155 tokens (3 themes, 8 collections), WCAG 2.2 AA. DS knowledge vendored from volivarii/actian-ds-knowledge.",
-  "version": "2026.9.13",
+  "version": "2026.9.14",
   "author": {
     "name": "Actian UX Team"
   },

--- a/plugins/actian-design-system/agents/screen-generator.md
+++ b/plugins/actian-design-system/agents/screen-generator.md
@@ -18,6 +18,17 @@ tools: ["Read", "Grep", "Glob", "Write"]
 
 # Screen Generator
 
+<!-- plugin-root:begin -->
+## Where the plugin lives
+
+Bare `references/`, `vendor/`, `agents/`, `recipes/`, `templates/` and `scripts/` paths in this file are relative to the plugin root: the directory holding `.claude-plugin/plugin.json`, the parent of the `skills/` directory named in the base directory above. They are never relative to the project working directory. Every command in this file expects `CLAUDE_PLUGIN_ROOT` to name that root. In Cowork, bash runs inside a VM where the plugin is mounted under `/sessions/<vm>/mnt/.remote-plugins/<plugin id>/`, so set the variable once per shell before anything else:
+The line is idempotent: when a later bash call finds the variable empty, run the line again before the command.
+
+```bash
+{ [ -n "${CLAUDE_PLUGIN_ROOT:-}" ] && [ -f "${CLAUDE_PLUGIN_ROOT}/.claude-plugin/plugin.json" ]; } || export CLAUDE_PLUGIN_ROOT="$(for d in ${CLAUDE_REMOTE_PLUGINS_ROOT:-/sessions/*/mnt/.remote-plugins}/*/; do grep -qs '"name": *"actian-design-system"' "${d}.claude-plugin/plugin.json" && printf '%s' "${d%/}" && break; done)"; [ -n "$CLAUDE_PLUGIN_ROOT" ] || echo "plugin root not found: export CLAUDE_PLUGIN_ROOT=<the directory holding .claude-plugin/plugin.json>" >&2
+```
+<!-- plugin-root:end -->
+
 Generate a batch of flow screens and write the result as a partial JSON file.
 
 ## Input

--- a/plugins/actian-design-system/references/context/plugin-root.md
+++ b/plugins/actian-design-system/references/context/plugin-root.md
@@ -1,0 +1,22 @@
+# Where the plugin lives (canonical skill preamble)
+
+The block between the markers is copied verbatim into every `skills/<name>/SKILL.md`, directly after the
+H1 and before the first `##` heading. `tests/integration/plugin-root.test.js` asserts each copy is
+identical to this one and that the bash line resolves a simulated Cowork mount, so edit here first,
+then paste into the skills. `scripts/lib/plugin-root.sh` is the same logic for scripts that run
+without the variable (it adds a fallback to the script's own plugin and an error message).
+
+Why it exists: Cowork runs Read and Glob against the Mac-side plugin path named in the skill header,
+and bash inside a VM where the plugin is mounted under `/sessions/<vm>/mnt/.remote-plugins/<plugin id>/`.
+On 2026-09-09 a session concluded the renderer scripts "aren't materialized" and hand-built the
+deliverable. The line below removes the hunt.
+
+<!-- plugin-root:begin -->
+## Where the plugin lives
+
+Bare `references/`, `vendor/`, `agents/`, `recipes/`, `templates/` and `scripts/` paths in this file are relative to the plugin root: the directory holding `.claude-plugin/plugin.json`, the parent of the `skills/` directory named in the base directory above. They are never relative to the project working directory. Every command in this file expects `CLAUDE_PLUGIN_ROOT` to name that root. In Cowork, bash runs inside a VM where the plugin is mounted under `/sessions/<vm>/mnt/.remote-plugins/<plugin id>/`, so set the variable once per shell before anything else:
+
+```bash
+[ -n "${CLAUDE_PLUGIN_ROOT:-}" ] || export CLAUDE_PLUGIN_ROOT="$(for d in ${CLAUDE_REMOTE_PLUGINS_ROOT:-/sessions/*/mnt/.remote-plugins}/*/; do grep -qs '"actian-design-system"' "${d}.claude-plugin/plugin.json" && printf '%s' "${d%/}" && break; done)"; [ -n "$CLAUDE_PLUGIN_ROOT" ] || echo "plugin root not found: export CLAUDE_PLUGIN_ROOT=<the directory holding .claude-plugin/plugin.json>" >&2
+```
+<!-- plugin-root:end -->

--- a/plugins/actian-design-system/references/context/plugin-root.md
+++ b/plugins/actian-design-system/references/context/plugin-root.md
@@ -15,8 +15,9 @@ deliverable. The line below removes the hunt.
 ## Where the plugin lives
 
 Bare `references/`, `vendor/`, `agents/`, `recipes/`, `templates/` and `scripts/` paths in this file are relative to the plugin root: the directory holding `.claude-plugin/plugin.json`, the parent of the `skills/` directory named in the base directory above. They are never relative to the project working directory. Every command in this file expects `CLAUDE_PLUGIN_ROOT` to name that root. In Cowork, bash runs inside a VM where the plugin is mounted under `/sessions/<vm>/mnt/.remote-plugins/<plugin id>/`, so set the variable once per shell before anything else:
+The line is idempotent: when a later bash call finds the variable empty, run the line again before the command.
 
 ```bash
-[ -n "${CLAUDE_PLUGIN_ROOT:-}" ] || export CLAUDE_PLUGIN_ROOT="$(for d in ${CLAUDE_REMOTE_PLUGINS_ROOT:-/sessions/*/mnt/.remote-plugins}/*/; do grep -qs '"actian-design-system"' "${d}.claude-plugin/plugin.json" && printf '%s' "${d%/}" && break; done)"; [ -n "$CLAUDE_PLUGIN_ROOT" ] || echo "plugin root not found: export CLAUDE_PLUGIN_ROOT=<the directory holding .claude-plugin/plugin.json>" >&2
+{ [ -n "${CLAUDE_PLUGIN_ROOT:-}" ] && [ -f "${CLAUDE_PLUGIN_ROOT}/.claude-plugin/plugin.json" ]; } || export CLAUDE_PLUGIN_ROOT="$(for d in ${CLAUDE_REMOTE_PLUGINS_ROOT:-/sessions/*/mnt/.remote-plugins}/*/; do grep -qs '"name": *"actian-design-system"' "${d}.claude-plugin/plugin.json" && printf '%s' "${d%/}" && break; done)"; [ -n "$CLAUDE_PLUGIN_ROOT" ] || echo "plugin root not found: export CLAUDE_PLUGIN_ROOT=<the directory holding .claude-plugin/plugin.json>" >&2
 ```
 <!-- plugin-root:end -->

--- a/plugins/actian-design-system/scripts/lib/plugin-root.sh
+++ b/plugins/actian-design-system/scripts/lib/plugin-root.sh
@@ -2,35 +2,43 @@
 # plugin-root.sh: make CLAUDE_PLUGIN_ROOT name the plugin root in every shell,
 # including the Cowork VM, where bash runs beside a mount of the plugin at
 # /sessions/<vm>/mnt/.remote-plugins/<plugin id>/ and never sees the Mac-side
-# path the skill header names.
+# path the skill header names. bash only: an unmatched glob aborts zsh.
 #
 # Usage (sourced, never executed):  source "<plugin root>/scripts/lib/plugin-root.sh"
-# Order: keep CLAUDE_PLUGIN_ROOT if set; else the first directory under
-# ${CLAUDE_REMOTE_PLUGINS_ROOT:-/sessions/*/mnt/.remote-plugins}/*/ whose
-# .claude-plugin/plugin.json names actian-design-system; else the plugin that
-# contains this script; else one error naming both places, return 1.
+# Order: keep CLAUDE_PLUGIN_ROOT if it is set AND its .claude-plugin/plugin.json
+# exists (Cowork can export the Mac-side value into a VM shell where that path
+# does not exist, so an unmeasured value is never trusted); else the first
+# directory under ${CLAUDE_REMOTE_PLUGINS_ROOT:-/sessions/*/mnt/.remote-plugins}/*/
+# whose .claude-plugin/plugin.json names actian-design-system; else the plugin
+# that contains this script; else one error naming both places (and the
+# rejected value, if one was set), return 1.
 # The default glob and the manifest test are duplicated, on purpose and
 # byte-identical, in references/context/plugin-root.md (the skill preamble),
 # which cannot source this file before it knows the root.
-if [ -z "${CLAUDE_PLUGIN_ROOT:-}" ]; then
+if [ -z "${CLAUDE_PLUGIN_ROOT:-}" ] || [ ! -f "${CLAUDE_PLUGIN_ROOT}/.claude-plugin/plugin.json" ]; then
+  _apr_prior="${CLAUDE_PLUGIN_ROOT:-}"
   _apr_root=""
   for _apr_d in ${CLAUDE_REMOTE_PLUGINS_ROOT:-/sessions/*/mnt/.remote-plugins}/*/; do
-    if grep -qs '"actian-design-system"' "${_apr_d}.claude-plugin/plugin.json"; then
+    if grep -qs '"name": *"actian-design-system"' "${_apr_d}.claude-plugin/plugin.json"; then
       _apr_root="${_apr_d%/}"
       break
     fi
   done
   if [ -z "$_apr_root" ] && [ -n "${BASH_SOURCE[0]:-}" ]; then
     _apr_here="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." 2>/dev/null && pwd)"
-    if [ -n "$_apr_here" ] && grep -qs '"actian-design-system"' "$_apr_here/.claude-plugin/plugin.json"; then
+    if [ -n "$_apr_here" ] && grep -qs '"name": *"actian-design-system"' "$_apr_here/.claude-plugin/plugin.json"; then
       _apr_root="$_apr_here"
     fi
   fi
   if [ -z "$_apr_root" ]; then
-    echo "Error: plugin root not found. Looked for a .claude-plugin/plugin.json naming actian-design-system under ${CLAUDE_REMOTE_PLUGINS_ROOT:-/sessions/*/mnt/.remote-plugins}/*/ and at $(dirname "${BASH_SOURCE[0]:-$0}")/../.. . Export CLAUDE_PLUGIN_ROOT=<the directory holding .claude-plugin/plugin.json> and retry." >&2
-    unset _apr_root _apr_d _apr_here
+    if [ -n "$_apr_prior" ]; then
+      echo "Error: CLAUDE_PLUGIN_ROOT was \"$_apr_prior\" but that directory has no .claude-plugin/plugin.json naming actian-design-system. Looked for a replacement under ${CLAUDE_REMOTE_PLUGINS_ROOT:-/sessions/*/mnt/.remote-plugins}/*/ and at $(dirname "${BASH_SOURCE[0]:-$0}")/../.. . Export CLAUDE_PLUGIN_ROOT=<the directory holding .claude-plugin/plugin.json> and retry." >&2
+    else
+      echo "Error: plugin root not found. Looked for a .claude-plugin/plugin.json naming actian-design-system under ${CLAUDE_REMOTE_PLUGINS_ROOT:-/sessions/*/mnt/.remote-plugins}/*/ and at $(dirname "${BASH_SOURCE[0]:-$0}")/../.. . Export CLAUDE_PLUGIN_ROOT=<the directory holding .claude-plugin/plugin.json> and retry." >&2
+    fi
+    unset _apr_root _apr_d _apr_here _apr_prior
     if [ "${BASH_SOURCE[0]}" = "${0}" ]; then exit 1; else return 1; fi
   fi
   export CLAUDE_PLUGIN_ROOT="$_apr_root"
-  unset _apr_root _apr_d _apr_here
+  unset _apr_root _apr_d _apr_here _apr_prior
 fi

--- a/plugins/actian-design-system/scripts/lib/plugin-root.sh
+++ b/plugins/actian-design-system/scripts/lib/plugin-root.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+# plugin-root.sh: make CLAUDE_PLUGIN_ROOT name the plugin root in every shell,
+# including the Cowork VM, where bash runs beside a mount of the plugin at
+# /sessions/<vm>/mnt/.remote-plugins/<plugin id>/ and never sees the Mac-side
+# path the skill header names.
+#
+# Usage (sourced, never executed):  source "<plugin root>/scripts/lib/plugin-root.sh"
+# Order: keep CLAUDE_PLUGIN_ROOT if set; else the first directory under
+# ${CLAUDE_REMOTE_PLUGINS_ROOT:-/sessions/*/mnt/.remote-plugins}/*/ whose
+# .claude-plugin/plugin.json names actian-design-system; else the plugin that
+# contains this script; else one error naming both places, return 1.
+# The default glob and the manifest test are duplicated, on purpose and
+# byte-identical, in references/context/plugin-root.md (the skill preamble),
+# which cannot source this file before it knows the root.
+if [ -z "${CLAUDE_PLUGIN_ROOT:-}" ]; then
+  _apr_root=""
+  for _apr_d in ${CLAUDE_REMOTE_PLUGINS_ROOT:-/sessions/*/mnt/.remote-plugins}/*/; do
+    if grep -qs '"actian-design-system"' "${_apr_d}.claude-plugin/plugin.json"; then
+      _apr_root="${_apr_d%/}"
+      break
+    fi
+  done
+  if [ -z "$_apr_root" ] && [ -n "${BASH_SOURCE[0]:-}" ]; then
+    _apr_here="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." 2>/dev/null && pwd)"
+    if [ -n "$_apr_here" ] && grep -qs '"actian-design-system"' "$_apr_here/.claude-plugin/plugin.json"; then
+      _apr_root="$_apr_here"
+    fi
+  fi
+  if [ -z "$_apr_root" ]; then
+    echo "Error: plugin root not found. Looked for a .claude-plugin/plugin.json naming actian-design-system under ${CLAUDE_REMOTE_PLUGINS_ROOT:-/sessions/*/mnt/.remote-plugins}/*/ and at $(dirname "${BASH_SOURCE[0]:-$0}")/../.. . Export CLAUDE_PLUGIN_ROOT=<the directory holding .claude-plugin/plugin.json> and retry." >&2
+    unset _apr_root _apr_d _apr_here
+    if [ "${BASH_SOURCE[0]}" = "${0}" ]; then exit 1; else return 1; fi
+  fi
+  export CLAUDE_PLUGIN_ROOT="$_apr_root"
+  unset _apr_root _apr_d _apr_here
+fi

--- a/plugins/actian-design-system/skills/companion/SKILL.md
+++ b/plugins/actian-design-system/skills/companion/SKILL.md
@@ -6,6 +6,16 @@ argument-hint: "[Figma URL] [prose: instruction, question, or intent]"
 
 # DS Companion
 
+<!-- plugin-root:begin -->
+## Where the plugin lives
+
+Bare `references/`, `vendor/`, `agents/`, `recipes/`, `templates/` and `scripts/` paths in this file are relative to the plugin root: the directory holding `.claude-plugin/plugin.json`, the parent of the `skills/` directory named in the base directory above. They are never relative to the project working directory. Every command in this file expects `CLAUDE_PLUGIN_ROOT` to name that root. In Cowork, bash runs inside a VM where the plugin is mounted under `/sessions/<vm>/mnt/.remote-plugins/<plugin id>/`, so set the variable once per shell before anything else:
+
+```bash
+[ -n "${CLAUDE_PLUGIN_ROOT:-}" ] || export CLAUDE_PLUGIN_ROOT="$(for d in ${CLAUDE_REMOTE_PLUGINS_ROOT:-/sessions/*/mnt/.remote-plugins}/*/; do grep -qs '"actian-design-system"' "${d}.claude-plugin/plugin.json" && printf '%s' "${d%/}" && break; done)"; [ -n "$CLAUDE_PLUGIN_ROOT" ] || echo "plugin root not found: export CLAUDE_PLUGIN_ROOT=<the directory holding .claude-plugin/plugin.json>" >&2
+```
+<!-- plugin-root:end -->
+
 Design system teammate on the Actian UX team. Handles anything design-related — from fixing a wrong token to generating a full user flow.
 
 > **Always pass `skillNames: "figma-use"` on every `mcp__claude_ai_Figma__use_figma` invocation.** This is mandatory per Figma's official contract — the `figma-use` skill carries the load-bearing Plugin API rules (atomic-on-error, color 0–1 range, HUG-after-append, font preload, await-all-promises, page-context-reset, return-all-IDs, explicit `variable.scopes`). Skipping it produces hard-to-debug failures.

--- a/plugins/actian-design-system/skills/companion/SKILL.md
+++ b/plugins/actian-design-system/skills/companion/SKILL.md
@@ -10,9 +10,10 @@ argument-hint: "[Figma URL] [prose: instruction, question, or intent]"
 ## Where the plugin lives
 
 Bare `references/`, `vendor/`, `agents/`, `recipes/`, `templates/` and `scripts/` paths in this file are relative to the plugin root: the directory holding `.claude-plugin/plugin.json`, the parent of the `skills/` directory named in the base directory above. They are never relative to the project working directory. Every command in this file expects `CLAUDE_PLUGIN_ROOT` to name that root. In Cowork, bash runs inside a VM where the plugin is mounted under `/sessions/<vm>/mnt/.remote-plugins/<plugin id>/`, so set the variable once per shell before anything else:
+The line is idempotent: when a later bash call finds the variable empty, run the line again before the command.
 
 ```bash
-[ -n "${CLAUDE_PLUGIN_ROOT:-}" ] || export CLAUDE_PLUGIN_ROOT="$(for d in ${CLAUDE_REMOTE_PLUGINS_ROOT:-/sessions/*/mnt/.remote-plugins}/*/; do grep -qs '"actian-design-system"' "${d}.claude-plugin/plugin.json" && printf '%s' "${d%/}" && break; done)"; [ -n "$CLAUDE_PLUGIN_ROOT" ] || echo "plugin root not found: export CLAUDE_PLUGIN_ROOT=<the directory holding .claude-plugin/plugin.json>" >&2
+{ [ -n "${CLAUDE_PLUGIN_ROOT:-}" ] && [ -f "${CLAUDE_PLUGIN_ROOT}/.claude-plugin/plugin.json" ]; } || export CLAUDE_PLUGIN_ROOT="$(for d in ${CLAUDE_REMOTE_PLUGINS_ROOT:-/sessions/*/mnt/.remote-plugins}/*/; do grep -qs '"name": *"actian-design-system"' "${d}.claude-plugin/plugin.json" && printf '%s' "${d%/}" && break; done)"; [ -n "$CLAUDE_PLUGIN_ROOT" ] || echo "plugin root not found: export CLAUDE_PLUGIN_ROOT=<the directory holding .claude-plugin/plugin.json>" >&2
 ```
 <!-- plugin-root:end -->
 

--- a/plugins/actian-design-system/skills/compare-flows/SKILL.md
+++ b/plugins/actian-design-system/skills/compare-flows/SKILL.md
@@ -10,9 +10,10 @@ argument-hint: "[Figma URL 1] [Figma URL 2]"
 ## Where the plugin lives
 
 Bare `references/`, `vendor/`, `agents/`, `recipes/`, `templates/` and `scripts/` paths in this file are relative to the plugin root: the directory holding `.claude-plugin/plugin.json`, the parent of the `skills/` directory named in the base directory above. They are never relative to the project working directory. Every command in this file expects `CLAUDE_PLUGIN_ROOT` to name that root. In Cowork, bash runs inside a VM where the plugin is mounted under `/sessions/<vm>/mnt/.remote-plugins/<plugin id>/`, so set the variable once per shell before anything else:
+The line is idempotent: when a later bash call finds the variable empty, run the line again before the command.
 
 ```bash
-[ -n "${CLAUDE_PLUGIN_ROOT:-}" ] || export CLAUDE_PLUGIN_ROOT="$(for d in ${CLAUDE_REMOTE_PLUGINS_ROOT:-/sessions/*/mnt/.remote-plugins}/*/; do grep -qs '"actian-design-system"' "${d}.claude-plugin/plugin.json" && printf '%s' "${d%/}" && break; done)"; [ -n "$CLAUDE_PLUGIN_ROOT" ] || echo "plugin root not found: export CLAUDE_PLUGIN_ROOT=<the directory holding .claude-plugin/plugin.json>" >&2
+{ [ -n "${CLAUDE_PLUGIN_ROOT:-}" ] && [ -f "${CLAUDE_PLUGIN_ROOT}/.claude-plugin/plugin.json" ]; } || export CLAUDE_PLUGIN_ROOT="$(for d in ${CLAUDE_REMOTE_PLUGINS_ROOT:-/sessions/*/mnt/.remote-plugins}/*/; do grep -qs '"name": *"actian-design-system"' "${d}.claude-plugin/plugin.json" && printf '%s' "${d%/}" && break; done)"; [ -n "$CLAUDE_PLUGIN_ROOT" ] || echo "plugin root not found: export CLAUDE_PLUGIN_ROOT=<the directory holding .claude-plugin/plugin.json>" >&2
 ```
 <!-- plugin-root:end -->
 

--- a/plugins/actian-design-system/skills/compare-flows/SKILL.md
+++ b/plugins/actian-design-system/skills/compare-flows/SKILL.md
@@ -6,6 +6,16 @@ argument-hint: "[Figma URL 1] [Figma URL 2]"
 
 # Compare Flows
 
+<!-- plugin-root:begin -->
+## Where the plugin lives
+
+Bare `references/`, `vendor/`, `agents/`, `recipes/`, `templates/` and `scripts/` paths in this file are relative to the plugin root: the directory holding `.claude-plugin/plugin.json`, the parent of the `skills/` directory named in the base directory above. They are never relative to the project working directory. Every command in this file expects `CLAUDE_PLUGIN_ROOT` to name that root. In Cowork, bash runs inside a VM where the plugin is mounted under `/sessions/<vm>/mnt/.remote-plugins/<plugin id>/`, so set the variable once per shell before anything else:
+
+```bash
+[ -n "${CLAUDE_PLUGIN_ROOT:-}" ] || export CLAUDE_PLUGIN_ROOT="$(for d in ${CLAUDE_REMOTE_PLUGINS_ROOT:-/sessions/*/mnt/.remote-plugins}/*/; do grep -qs '"actian-design-system"' "${d}.claude-plugin/plugin.json" && printf '%s' "${d%/}" && break; done)"; [ -n "$CLAUDE_PLUGIN_ROOT" ] || echo "plugin root not found: export CLAUDE_PLUGIN_ROOT=<the directory holding .claude-plugin/plugin.json>" >&2
+```
+<!-- plugin-root:end -->
+
 Compare two Figma flows or screens and provide structured UX recommendations. Runs autonomously — fetch both designs, analyze, output full report. Only pause if user provides just one URL (ask for second).
 
 > **Always pass `skillNames: "figma-use"` on every `mcp__claude_ai_Figma__use_figma` invocation.** This is mandatory per Figma's official contract — the `figma-use` skill carries the load-bearing Plugin API rules (atomic-on-error, color 0–1 range, HUG-after-append, font preload, await-all-promises, page-context-reset, return-all-IDs, explicit `variable.scopes`). Skipping it produces hard-to-debug failures.

--- a/plugins/actian-design-system/skills/component-brief/SKILL.md
+++ b/plugins/actian-design-system/skills/component-brief/SKILL.md
@@ -6,6 +6,16 @@ argument-hint: "[Figma URL or component name] [generate N,N,N] [research all|<li
 
 # Component Brief
 
+<!-- plugin-root:begin -->
+## Where the plugin lives
+
+Bare `references/`, `vendor/`, `agents/`, `recipes/`, `templates/` and `scripts/` paths in this file are relative to the plugin root: the directory holding `.claude-plugin/plugin.json`, the parent of the `skills/` directory named in the base directory above. They are never relative to the project working directory. Every command in this file expects `CLAUDE_PLUGIN_ROOT` to name that root. In Cowork, bash runs inside a VM where the plugin is mounted under `/sessions/<vm>/mnt/.remote-plugins/<plugin id>/`, so set the variable once per shell before anything else:
+
+```bash
+[ -n "${CLAUDE_PLUGIN_ROOT:-}" ] || export CLAUDE_PLUGIN_ROOT="$(for d in ${CLAUDE_REMOTE_PLUGINS_ROOT:-/sessions/*/mnt/.remote-plugins}/*/; do grep -qs '"actian-design-system"' "${d}.claude-plugin/plugin.json" && printf '%s' "${d%/}" && break; done)"; [ -n "$CLAUDE_PLUGIN_ROOT" ] || echo "plugin root not found: export CLAUDE_PLUGIN_ROOT=<the directory holding .claude-plugin/plugin.json>" >&2
+```
+<!-- plugin-root:end -->
+
 Generate a structured component brief with HTML spec page and Figma output. Pipeline: research → data model → present options → push.
 
 > **Always pass `skillNames: "figma-use"` on every `mcp__claude_ai_Figma__use_figma` invocation.** This is mandatory per Figma's official contract — the `figma-use` skill carries the load-bearing Plugin API rules (atomic-on-error, color 0–1 range, HUG-after-append, font preload, await-all-promises, page-context-reset, return-all-IDs, explicit `variable.scopes`). Skipping it produces hard-to-debug failures.

--- a/plugins/actian-design-system/skills/component-brief/SKILL.md
+++ b/plugins/actian-design-system/skills/component-brief/SKILL.md
@@ -10,9 +10,10 @@ argument-hint: "[Figma URL or component name] [generate N,N,N] [research all|<li
 ## Where the plugin lives
 
 Bare `references/`, `vendor/`, `agents/`, `recipes/`, `templates/` and `scripts/` paths in this file are relative to the plugin root: the directory holding `.claude-plugin/plugin.json`, the parent of the `skills/` directory named in the base directory above. They are never relative to the project working directory. Every command in this file expects `CLAUDE_PLUGIN_ROOT` to name that root. In Cowork, bash runs inside a VM where the plugin is mounted under `/sessions/<vm>/mnt/.remote-plugins/<plugin id>/`, so set the variable once per shell before anything else:
+The line is idempotent: when a later bash call finds the variable empty, run the line again before the command.
 
 ```bash
-[ -n "${CLAUDE_PLUGIN_ROOT:-}" ] || export CLAUDE_PLUGIN_ROOT="$(for d in ${CLAUDE_REMOTE_PLUGINS_ROOT:-/sessions/*/mnt/.remote-plugins}/*/; do grep -qs '"actian-design-system"' "${d}.claude-plugin/plugin.json" && printf '%s' "${d%/}" && break; done)"; [ -n "$CLAUDE_PLUGIN_ROOT" ] || echo "plugin root not found: export CLAUDE_PLUGIN_ROOT=<the directory holding .claude-plugin/plugin.json>" >&2
+{ [ -n "${CLAUDE_PLUGIN_ROOT:-}" ] && [ -f "${CLAUDE_PLUGIN_ROOT}/.claude-plugin/plugin.json" ]; } || export CLAUDE_PLUGIN_ROOT="$(for d in ${CLAUDE_REMOTE_PLUGINS_ROOT:-/sessions/*/mnt/.remote-plugins}/*/; do grep -qs '"name": *"actian-design-system"' "${d}.claude-plugin/plugin.json" && printf '%s' "${d%/}" && break; done)"; [ -n "$CLAUDE_PLUGIN_ROOT" ] || echo "plugin root not found: export CLAUDE_PLUGIN_ROOT=<the directory holding .claude-plugin/plugin.json>" >&2
 ```
 <!-- plugin-root:end -->
 

--- a/plugins/actian-design-system/skills/convert-to-hifi/SKILL.md
+++ b/plugins/actian-design-system/skills/convert-to-hifi/SKILL.md
@@ -10,9 +10,10 @@ argument-hint: "<figma-url> [--ref <figma-url>[,<figma-url>]] [--no-prompt]"
 ## Where the plugin lives
 
 Bare `references/`, `vendor/`, `agents/`, `recipes/`, `templates/` and `scripts/` paths in this file are relative to the plugin root: the directory holding `.claude-plugin/plugin.json`, the parent of the `skills/` directory named in the base directory above. They are never relative to the project working directory. Every command in this file expects `CLAUDE_PLUGIN_ROOT` to name that root. In Cowork, bash runs inside a VM where the plugin is mounted under `/sessions/<vm>/mnt/.remote-plugins/<plugin id>/`, so set the variable once per shell before anything else:
+The line is idempotent: when a later bash call finds the variable empty, run the line again before the command.
 
 ```bash
-[ -n "${CLAUDE_PLUGIN_ROOT:-}" ] || export CLAUDE_PLUGIN_ROOT="$(for d in ${CLAUDE_REMOTE_PLUGINS_ROOT:-/sessions/*/mnt/.remote-plugins}/*/; do grep -qs '"actian-design-system"' "${d}.claude-plugin/plugin.json" && printf '%s' "${d%/}" && break; done)"; [ -n "$CLAUDE_PLUGIN_ROOT" ] || echo "plugin root not found: export CLAUDE_PLUGIN_ROOT=<the directory holding .claude-plugin/plugin.json>" >&2
+{ [ -n "${CLAUDE_PLUGIN_ROOT:-}" ] && [ -f "${CLAUDE_PLUGIN_ROOT}/.claude-plugin/plugin.json" ]; } || export CLAUDE_PLUGIN_ROOT="$(for d in ${CLAUDE_REMOTE_PLUGINS_ROOT:-/sessions/*/mnt/.remote-plugins}/*/; do grep -qs '"name": *"actian-design-system"' "${d}.claude-plugin/plugin.json" && printf '%s' "${d%/}" && break; done)"; [ -n "$CLAUDE_PLUGIN_ROOT" ] || echo "plugin root not found: export CLAUDE_PLUGIN_ROOT=<the directory holding .claude-plugin/plugin.json>" >&2
 ```
 <!-- plugin-root:end -->
 

--- a/plugins/actian-design-system/skills/convert-to-hifi/SKILL.md
+++ b/plugins/actian-design-system/skills/convert-to-hifi/SKILL.md
@@ -6,6 +6,16 @@ argument-hint: "<figma-url> [--ref <figma-url>[,<figma-url>]] [--no-prompt]"
 
 # Convert to HiFi
 
+<!-- plugin-root:begin -->
+## Where the plugin lives
+
+Bare `references/`, `vendor/`, `agents/`, `recipes/`, `templates/` and `scripts/` paths in this file are relative to the plugin root: the directory holding `.claude-plugin/plugin.json`, the parent of the `skills/` directory named in the base directory above. They are never relative to the project working directory. Every command in this file expects `CLAUDE_PLUGIN_ROOT` to name that root. In Cowork, bash runs inside a VM where the plugin is mounted under `/sessions/<vm>/mnt/.remote-plugins/<plugin id>/`, so set the variable once per shell before anything else:
+
+```bash
+[ -n "${CLAUDE_PLUGIN_ROOT:-}" ] || export CLAUDE_PLUGIN_ROOT="$(for d in ${CLAUDE_REMOTE_PLUGINS_ROOT:-/sessions/*/mnt/.remote-plugins}/*/; do grep -qs '"actian-design-system"' "${d}.claude-plugin/plugin.json" && printf '%s' "${d%/}" && break; done)"; [ -n "$CLAUDE_PLUGIN_ROOT" ] || echo "plugin root not found: export CLAUDE_PLUGIN_ROOT=<the directory holding .claude-plugin/plugin.json>" >&2
+```
+<!-- plugin-root:end -->
+
 Upgrade a Fat Marker wireframe to a high-fidelity DS Kit frame. Three-stage pipeline: extract FM tree from Figma → deterministic transform → LLM polish + push. Runs autonomously after Stage 2 confirmation — no other pauses.
 
 > **Always pass `skillNames: "figma-use"` on every `mcp__claude_ai_Figma__use_figma` invocation.** This is mandatory per Figma's official contract — the `figma-use` skill carries the load-bearing Plugin API rules (atomic-on-error, color 0–1 range, HUG-after-append, font preload, await-all-promises, page-context-reset, return-all-IDs, explicit `variable.scopes`). Skipping it produces hard-to-debug failures.

--- a/plugins/actian-design-system/skills/create-component/SKILL.md
+++ b/plugins/actian-design-system/skills/create-component/SKILL.md
@@ -10,9 +10,10 @@ argument-hint: "[component description or Figma URL]"
 ## Where the plugin lives
 
 Bare `references/`, `vendor/`, `agents/`, `recipes/`, `templates/` and `scripts/` paths in this file are relative to the plugin root: the directory holding `.claude-plugin/plugin.json`, the parent of the `skills/` directory named in the base directory above. They are never relative to the project working directory. Every command in this file expects `CLAUDE_PLUGIN_ROOT` to name that root. In Cowork, bash runs inside a VM where the plugin is mounted under `/sessions/<vm>/mnt/.remote-plugins/<plugin id>/`, so set the variable once per shell before anything else:
+The line is idempotent: when a later bash call finds the variable empty, run the line again before the command.
 
 ```bash
-[ -n "${CLAUDE_PLUGIN_ROOT:-}" ] || export CLAUDE_PLUGIN_ROOT="$(for d in ${CLAUDE_REMOTE_PLUGINS_ROOT:-/sessions/*/mnt/.remote-plugins}/*/; do grep -qs '"actian-design-system"' "${d}.claude-plugin/plugin.json" && printf '%s' "${d%/}" && break; done)"; [ -n "$CLAUDE_PLUGIN_ROOT" ] || echo "plugin root not found: export CLAUDE_PLUGIN_ROOT=<the directory holding .claude-plugin/plugin.json>" >&2
+{ [ -n "${CLAUDE_PLUGIN_ROOT:-}" ] && [ -f "${CLAUDE_PLUGIN_ROOT}/.claude-plugin/plugin.json" ]; } || export CLAUDE_PLUGIN_ROOT="$(for d in ${CLAUDE_REMOTE_PLUGINS_ROOT:-/sessions/*/mnt/.remote-plugins}/*/; do grep -qs '"name": *"actian-design-system"' "${d}.claude-plugin/plugin.json" && printf '%s' "${d%/}" && break; done)"; [ -n "$CLAUDE_PLUGIN_ROOT" ] || echo "plugin root not found: export CLAUDE_PLUGIN_ROOT=<the directory holding .claude-plugin/plugin.json>" >&2
 ```
 <!-- plugin-root:end -->
 

--- a/plugins/actian-design-system/skills/create-component/SKILL.md
+++ b/plugins/actian-design-system/skills/create-component/SKILL.md
@@ -6,6 +6,16 @@ argument-hint: "[component description or Figma URL]"
 
 # Create Component
 
+<!-- plugin-root:begin -->
+## Where the plugin lives
+
+Bare `references/`, `vendor/`, `agents/`, `recipes/`, `templates/` and `scripts/` paths in this file are relative to the plugin root: the directory holding `.claude-plugin/plugin.json`, the parent of the `skills/` directory named in the base directory above. They are never relative to the project working directory. Every command in this file expects `CLAUDE_PLUGIN_ROOT` to name that root. In Cowork, bash runs inside a VM where the plugin is mounted under `/sessions/<vm>/mnt/.remote-plugins/<plugin id>/`, so set the variable once per shell before anything else:
+
+```bash
+[ -n "${CLAUDE_PLUGIN_ROOT:-}" ] || export CLAUDE_PLUGIN_ROOT="$(for d in ${CLAUDE_REMOTE_PLUGINS_ROOT:-/sessions/*/mnt/.remote-plugins}/*/; do grep -qs '"actian-design-system"' "${d}.claude-plugin/plugin.json" && printf '%s' "${d%/}" && break; done)"; [ -n "$CLAUDE_PLUGIN_ROOT" ] || echo "plugin root not found: export CLAUDE_PLUGIN_ROOT=<the directory holding .claude-plugin/plugin.json>" >&2
+```
+<!-- plugin-root:end -->
+
 Create a new Figma component (with variants) from a text description or by extending an existing component. Pipeline: understand → check existing → research (optional) → build plan gate → resolve dependencies → build via interpreter → cleanup → parity check.
 
 > **Always pass `skillNames: "figma-use"` on every `mcp__claude_ai_Figma__use_figma` invocation.** This is mandatory per Figma's official contract — the `figma-use` skill carries the load-bearing Plugin API rules (atomic-on-error, color 0–1 range, HUG-after-append, font preload, await-all-promises, page-context-reset, return-all-IDs, explicit `variable.scopes`). Skipping it produces hard-to-debug failures.

--- a/plugins/actian-design-system/skills/design-audit/SKILL.md
+++ b/plugins/actian-design-system/skills/design-audit/SKILL.md
@@ -6,6 +6,16 @@ argument-hint: "[Figma URL] [--scope copy|tokens|a11y|heuristic|all] [--fix <id|
 
 # Design System Audit
 
+<!-- plugin-root:begin -->
+## Where the plugin lives
+
+Bare `references/`, `vendor/`, `agents/`, `recipes/`, `templates/` and `scripts/` paths in this file are relative to the plugin root: the directory holding `.claude-plugin/plugin.json`, the parent of the `skills/` directory named in the base directory above. They are never relative to the project working directory. Every command in this file expects `CLAUDE_PLUGIN_ROOT` to name that root. In Cowork, bash runs inside a VM where the plugin is mounted under `/sessions/<vm>/mnt/.remote-plugins/<plugin id>/`, so set the variable once per shell before anything else:
+
+```bash
+[ -n "${CLAUDE_PLUGIN_ROOT:-}" ] || export CLAUDE_PLUGIN_ROOT="$(for d in ${CLAUDE_REMOTE_PLUGINS_ROOT:-/sessions/*/mnt/.remote-plugins}/*/; do grep -qs '"actian-design-system"' "${d}.claude-plugin/plugin.json" && printf '%s' "${d%/}" && break; done)"; [ -n "$CLAUDE_PLUGIN_ROOT" ] || echo "plugin root not found: export CLAUDE_PLUGIN_ROOT=<the directory holding .claude-plugin/plugin.json>" >&2
+```
+<!-- plugin-root:end -->
+
 Audit a Figma file or section against the Actian Design System 2026 and/or Fat Marker conventions. Determine which library the file uses (FM = Workflow A, DS Kit = Workflow B), then apply corresponding rules.
 
 > **Always pass `skillNames: "figma-use"` on every `mcp__claude_ai_Figma__use_figma` invocation.** This is mandatory per Figma's official contract — the `figma-use` skill carries the load-bearing Plugin API rules (atomic-on-error, color 0–1 range, HUG-after-append, font preload, await-all-promises, page-context-reset, return-all-IDs, explicit `variable.scopes`). Skipping it produces hard-to-debug failures.

--- a/plugins/actian-design-system/skills/design-audit/SKILL.md
+++ b/plugins/actian-design-system/skills/design-audit/SKILL.md
@@ -10,9 +10,10 @@ argument-hint: "[Figma URL] [--scope copy|tokens|a11y|heuristic|all] [--fix <id|
 ## Where the plugin lives
 
 Bare `references/`, `vendor/`, `agents/`, `recipes/`, `templates/` and `scripts/` paths in this file are relative to the plugin root: the directory holding `.claude-plugin/plugin.json`, the parent of the `skills/` directory named in the base directory above. They are never relative to the project working directory. Every command in this file expects `CLAUDE_PLUGIN_ROOT` to name that root. In Cowork, bash runs inside a VM where the plugin is mounted under `/sessions/<vm>/mnt/.remote-plugins/<plugin id>/`, so set the variable once per shell before anything else:
+The line is idempotent: when a later bash call finds the variable empty, run the line again before the command.
 
 ```bash
-[ -n "${CLAUDE_PLUGIN_ROOT:-}" ] || export CLAUDE_PLUGIN_ROOT="$(for d in ${CLAUDE_REMOTE_PLUGINS_ROOT:-/sessions/*/mnt/.remote-plugins}/*/; do grep -qs '"actian-design-system"' "${d}.claude-plugin/plugin.json" && printf '%s' "${d%/}" && break; done)"; [ -n "$CLAUDE_PLUGIN_ROOT" ] || echo "plugin root not found: export CLAUDE_PLUGIN_ROOT=<the directory holding .claude-plugin/plugin.json>" >&2
+{ [ -n "${CLAUDE_PLUGIN_ROOT:-}" ] && [ -f "${CLAUDE_PLUGIN_ROOT}/.claude-plugin/plugin.json" ]; } || export CLAUDE_PLUGIN_ROOT="$(for d in ${CLAUDE_REMOTE_PLUGINS_ROOT:-/sessions/*/mnt/.remote-plugins}/*/; do grep -qs '"name": *"actian-design-system"' "${d}.claude-plugin/plugin.json" && printf '%s' "${d%/}" && break; done)"; [ -n "$CLAUDE_PLUGIN_ROOT" ] || echo "plugin root not found: export CLAUDE_PLUGIN_ROOT=<the directory holding .claude-plugin/plugin.json>" >&2
 ```
 <!-- plugin-root:end -->
 

--- a/plugins/actian-design-system/skills/generate-flow/SKILL.md
+++ b/plugins/actian-design-system/skills/generate-flow/SKILL.md
@@ -10,9 +10,10 @@ argument-hint: "[feature description or Figma URL] [prose instruction] [--hifi -
 ## Where the plugin lives
 
 Bare `references/`, `vendor/`, `agents/`, `recipes/`, `templates/` and `scripts/` paths in this file are relative to the plugin root: the directory holding `.claude-plugin/plugin.json`, the parent of the `skills/` directory named in the base directory above. They are never relative to the project working directory. Every command in this file expects `CLAUDE_PLUGIN_ROOT` to name that root. In Cowork, bash runs inside a VM where the plugin is mounted under `/sessions/<vm>/mnt/.remote-plugins/<plugin id>/`, so set the variable once per shell before anything else:
+The line is idempotent: when a later bash call finds the variable empty, run the line again before the command.
 
 ```bash
-[ -n "${CLAUDE_PLUGIN_ROOT:-}" ] || export CLAUDE_PLUGIN_ROOT="$(for d in ${CLAUDE_REMOTE_PLUGINS_ROOT:-/sessions/*/mnt/.remote-plugins}/*/; do grep -qs '"actian-design-system"' "${d}.claude-plugin/plugin.json" && printf '%s' "${d%/}" && break; done)"; [ -n "$CLAUDE_PLUGIN_ROOT" ] || echo "plugin root not found: export CLAUDE_PLUGIN_ROOT=<the directory holding .claude-plugin/plugin.json>" >&2
+{ [ -n "${CLAUDE_PLUGIN_ROOT:-}" ] && [ -f "${CLAUDE_PLUGIN_ROOT}/.claude-plugin/plugin.json" ]; } || export CLAUDE_PLUGIN_ROOT="$(for d in ${CLAUDE_REMOTE_PLUGINS_ROOT:-/sessions/*/mnt/.remote-plugins}/*/; do grep -qs '"name": *"actian-design-system"' "${d}.claude-plugin/plugin.json" && printf '%s' "${d%/}" && break; done)"; [ -n "$CLAUDE_PLUGIN_ROOT" ] || echo "plugin root not found: export CLAUDE_PLUGIN_ROOT=<the directory holding .claude-plugin/plugin.json>" >&2
 ```
 <!-- plugin-root:end -->
 

--- a/plugins/actian-design-system/skills/generate-flow/SKILL.md
+++ b/plugins/actian-design-system/skills/generate-flow/SKILL.md
@@ -6,6 +6,16 @@ argument-hint: "[feature description or Figma URL] [prose instruction] [--hifi -
 
 # Generate Fat Marker Flow
 
+<!-- plugin-root:begin -->
+## Where the plugin lives
+
+Bare `references/`, `vendor/`, `agents/`, `recipes/`, `templates/` and `scripts/` paths in this file are relative to the plugin root: the directory holding `.claude-plugin/plugin.json`, the parent of the `skills/` directory named in the base directory above. They are never relative to the project working directory. Every command in this file expects `CLAUDE_PLUGIN_ROOT` to name that root. In Cowork, bash runs inside a VM where the plugin is mounted under `/sessions/<vm>/mnt/.remote-plugins/<plugin id>/`, so set the variable once per shell before anything else:
+
+```bash
+[ -n "${CLAUDE_PLUGIN_ROOT:-}" ] || export CLAUDE_PLUGIN_ROOT="$(for d in ${CLAUDE_REMOTE_PLUGINS_ROOT:-/sessions/*/mnt/.remote-plugins}/*/; do grep -qs '"actian-design-system"' "${d}.claude-plugin/plugin.json" && printf '%s' "${d%/}" && break; done)"; [ -n "$CLAUDE_PLUGIN_ROOT" ] || echo "plugin root not found: export CLAUDE_PLUGIN_ROOT=<the directory holding .claude-plugin/plugin.json>" >&2
+```
+<!-- plugin-root:end -->
+
 Build one or more lo-fi screens (n≥1, single-screen output is first-class). HTML-first: the deliverable is one encapsulated, offline `flows/[feature].html` (two-view — clickable Prototype + all-screens Overview). Figma push is **opt-in**. FM components, Inter font, FM palette.
 
 > **Always pass `skillNames: "figma-use"` on every `mcp__claude_ai_Figma__use_figma` invocation.** This is mandatory per Figma's official contract — the `figma-use` skill carries the load-bearing Plugin API rules (atomic-on-error, color 0–1 range, HUG-after-append, font preload, await-all-promises, page-context-reset, return-all-IDs, explicit `variable.scopes`). Skipping it produces hard-to-debug failures.

--- a/plugins/actian-design-system/skills/generate-presentation/SKILL.md
+++ b/plugins/actian-design-system/skills/generate-presentation/SKILL.md
@@ -10,9 +10,10 @@ argument-hint: "[topic, file path, Figma URL, or description of content]"
 ## Where the plugin lives
 
 Bare `references/`, `vendor/`, `agents/`, `recipes/`, `templates/` and `scripts/` paths in this file are relative to the plugin root: the directory holding `.claude-plugin/plugin.json`, the parent of the `skills/` directory named in the base directory above. They are never relative to the project working directory. Every command in this file expects `CLAUDE_PLUGIN_ROOT` to name that root. In Cowork, bash runs inside a VM where the plugin is mounted under `/sessions/<vm>/mnt/.remote-plugins/<plugin id>/`, so set the variable once per shell before anything else:
+The line is idempotent: when a later bash call finds the variable empty, run the line again before the command.
 
 ```bash
-[ -n "${CLAUDE_PLUGIN_ROOT:-}" ] || export CLAUDE_PLUGIN_ROOT="$(for d in ${CLAUDE_REMOTE_PLUGINS_ROOT:-/sessions/*/mnt/.remote-plugins}/*/; do grep -qs '"actian-design-system"' "${d}.claude-plugin/plugin.json" && printf '%s' "${d%/}" && break; done)"; [ -n "$CLAUDE_PLUGIN_ROOT" ] || echo "plugin root not found: export CLAUDE_PLUGIN_ROOT=<the directory holding .claude-plugin/plugin.json>" >&2
+{ [ -n "${CLAUDE_PLUGIN_ROOT:-}" ] && [ -f "${CLAUDE_PLUGIN_ROOT}/.claude-plugin/plugin.json" ]; } || export CLAUDE_PLUGIN_ROOT="$(for d in ${CLAUDE_REMOTE_PLUGINS_ROOT:-/sessions/*/mnt/.remote-plugins}/*/; do grep -qs '"name": *"actian-design-system"' "${d}.claude-plugin/plugin.json" && printf '%s' "${d%/}" && break; done)"; [ -n "$CLAUDE_PLUGIN_ROOT" ] || echo "plugin root not found: export CLAUDE_PLUGIN_ROOT=<the directory holding .claude-plugin/plugin.json>" >&2
 ```
 <!-- plugin-root:end -->
 

--- a/plugins/actian-design-system/skills/generate-presentation/SKILL.md
+++ b/plugins/actian-design-system/skills/generate-presentation/SKILL.md
@@ -6,6 +6,16 @@ argument-hint: "[topic, file path, Figma URL, or description of content]"
 
 # Generate Presentation
 
+<!-- plugin-root:begin -->
+## Where the plugin lives
+
+Bare `references/`, `vendor/`, `agents/`, `recipes/`, `templates/` and `scripts/` paths in this file are relative to the plugin root: the directory holding `.claude-plugin/plugin.json`, the parent of the `skills/` directory named in the base directory above. They are never relative to the project working directory. Every command in this file expects `CLAUDE_PLUGIN_ROOT` to name that root. In Cowork, bash runs inside a VM where the plugin is mounted under `/sessions/<vm>/mnt/.remote-plugins/<plugin id>/`, so set the variable once per shell before anything else:
+
+```bash
+[ -n "${CLAUDE_PLUGIN_ROOT:-}" ] || export CLAUDE_PLUGIN_ROOT="$(for d in ${CLAUDE_REMOTE_PLUGINS_ROOT:-/sessions/*/mnt/.remote-plugins}/*/; do grep -qs '"actian-design-system"' "${d}.claude-plugin/plugin.json" && printf '%s' "${d%/}" && break; done)"; [ -n "$CLAUDE_PLUGIN_ROOT" ] || echo "plugin root not found: export CLAUDE_PLUGIN_ROOT=<the directory holding .claude-plugin/plugin.json>" >&2
+```
+<!-- plugin-root:end -->
+
 Generate a structured Figma presentation deck using official Actian slide templates. Pipeline: gather content → research gate → outline with gate → build slide-data.json → push to Figma. HTML preview is opt-in ("preview").
 
 > **Always pass `skillNames: "figma-use"` on every `mcp__claude_ai_Figma__use_figma` invocation.** This is mandatory per Figma's official contract — the `figma-use` skill carries the load-bearing Plugin API rules (atomic-on-error, color 0–1 range, HUG-after-append, font preload, await-all-promises, page-context-reset, return-all-IDs, explicit `variable.scopes`). Skipping it produces hard-to-debug failures.

--- a/plugins/actian-design-system/tests/integration/plugin-root.test.js
+++ b/plugins/actian-design-system/tests/integration/plugin-root.test.js
@@ -17,13 +17,19 @@ var PLUGIN_ROOT = fs.realpathSync(path.resolve(__dirname, "..", ".."));
 var SCRIPT = path.join(PLUGIN_ROOT, "scripts", "lib", "plugin-root.sh");
 var CANON = path.join(PLUGIN_ROOT, "references", "context", "plugin-root.md");
 var SKILLS_DIR = path.join(PLUGIN_ROOT, "skills");
+var AGENTS_DIR = path.join(PLUGIN_ROOT, "agents");
 
 function bash(cmd, envOverrides) {
   var env = Object.assign({}, process.env, envOverrides || {});
   delete env.CLAUDE_PLUGIN_ROOT;
-  if (envOverrides && envOverrides.CLAUDE_PLUGIN_ROOT) env.CLAUDE_PLUGIN_ROOT = envOverrides.CLAUDE_PLUGIN_ROOT;
+  if (envOverrides && envOverrides.CLAUDE_PLUGIN_ROOT)
+    env.CLAUDE_PLUGIN_ROOT = envOverrides.CLAUDE_PLUGIN_ROOT;
   var r = spawnSync("bash", ["-c", cmd], { env: env, encoding: "utf8" });
-  return { status: r.status, out: (r.stdout || "").trim(), err: r.stderr || "" };
+  return {
+    status: r.status,
+    out: (r.stdout || "").trim(),
+    err: r.stderr || "",
+  };
 }
 
 // A fake Cowork mount: the decoy sorts FIRST so a match by position would pick
@@ -35,35 +41,72 @@ function fakeRemoteTree() {
   var ours = path.join(remote, "plugin_02OURS");
   fs.mkdirSync(path.join(decoy, ".claude-plugin"), { recursive: true });
   fs.mkdirSync(path.join(ours, ".claude-plugin"), { recursive: true });
-  fs.writeFileSync(path.join(decoy, ".claude-plugin", "plugin.json"), JSON.stringify({ name: "figma", version: "2.2.107" }));
-  fs.writeFileSync(path.join(ours, ".claude-plugin", "plugin.json"), JSON.stringify({ name: "actian-design-system", version: "0.0.0" }));
+  fs.writeFileSync(
+    path.join(decoy, ".claude-plugin", "plugin.json"),
+    JSON.stringify({ name: "figma", version: "2.2.107" }),
+  );
+  fs.writeFileSync(
+    path.join(ours, ".claude-plugin", "plugin.json"),
+    JSON.stringify({ name: "actian-design-system", version: "0.0.0" }),
+  );
   return { tmp: tmp, remote: remote, ours: fs.realpathSync(ours) };
 }
 
 function canonicalBlock() {
   var md = fs.readFileSync(CANON, "utf8");
-  var m = md.match(/<!-- plugin-root:begin -->[\s\S]*?<!-- plugin-root:end -->/);
-  assert.ok(m, "references/context/plugin-root.md must carry the plugin-root:begin/end markers");
+  var m = md.match(
+    /<!-- plugin-root:begin -->[\s\S]*?<!-- plugin-root:end -->/,
+  );
+  assert.ok(
+    m,
+    "references/context/plugin-root.md must carry the plugin-root:begin/end markers",
+  );
   return m[0];
 }
 
+function escapeRegex(s) {
+  return s.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
 describe("scripts/lib/plugin-root.sh", function () {
-  it("keeps CLAUDE_PLUGIN_ROOT when it is already set", function () {
-    var r = bash('source "' + SCRIPT + '" && printf "%s" "$CLAUDE_PLUGIN_ROOT"', { CLAUDE_PLUGIN_ROOT: "/already/set" });
+  it("keeps CLAUDE_PLUGIN_ROOT when it is already set and its manifest exists", function () {
+    var r = bash(
+      'source "' + SCRIPT + '" && printf "%s" "$CLAUDE_PLUGIN_ROOT"',
+      { CLAUDE_PLUGIN_ROOT: PLUGIN_ROOT },
+    );
     assert.equal(r.status, 0, r.err);
-    assert.equal(r.out, "/already/set");
+    assert.equal(r.out, PLUGIN_ROOT);
+  });
+
+  it("replaces a set value whose manifest does not exist here", function () {
+    var t = fakeRemoteTree();
+    var r = bash(
+      'source "' + SCRIPT + '" && printf "%s" "$CLAUDE_PLUGIN_ROOT"',
+      {
+        CLAUDE_PLUGIN_ROOT: "/nope/plugin_01X",
+        CLAUDE_REMOTE_PLUGINS_ROOT: t.remote,
+      },
+    );
+    assert.equal(r.status, 0, r.err);
+    assert.equal(fs.realpathSync(r.out), t.ours);
   });
 
   it("resolves the mounted plugin by manifest name under CLAUDE_REMOTE_PLUGINS_ROOT, skipping other plugins", function () {
     var t = fakeRemoteTree();
-    var r = bash('source "' + SCRIPT + '" && printf "%s" "$CLAUDE_PLUGIN_ROOT"', { CLAUDE_REMOTE_PLUGINS_ROOT: t.remote });
+    var r = bash(
+      'source "' + SCRIPT + '" && printf "%s" "$CLAUDE_PLUGIN_ROOT"',
+      { CLAUDE_REMOTE_PLUGINS_ROOT: t.remote },
+    );
     assert.equal(r.status, 0, r.err);
     assert.equal(fs.realpathSync(r.out), t.ours);
   });
 
   it("falls back to the plugin that contains the script when no mount matches", function () {
     var empty = fs.mkdtempSync(path.join(os.tmpdir(), "plugin-root-empty-"));
-    var r = bash('source "' + SCRIPT + '" && printf "%s" "$CLAUDE_PLUGIN_ROOT"', { CLAUDE_REMOTE_PLUGINS_ROOT: empty });
+    var r = bash(
+      'source "' + SCRIPT + '" && printf "%s" "$CLAUDE_PLUGIN_ROOT"',
+      { CLAUDE_REMOTE_PLUGINS_ROOT: empty },
+    );
     assert.equal(r.status, 0, r.err);
     assert.equal(fs.realpathSync(r.out), PLUGIN_ROOT);
   });
@@ -74,11 +117,47 @@ describe("scripts/lib/plugin-root.sh", function () {
     fs.mkdirSync(path.dirname(copy), { recursive: true });
     fs.copyFileSync(SCRIPT, copy);
     var empty = fs.mkdtempSync(path.join(os.tmpdir(), "plugin-root-empty-"));
-    var r = bash('source "' + copy + '" || exit 7; printf "%s" "$CLAUDE_PLUGIN_ROOT"', { CLAUDE_REMOTE_PLUGINS_ROOT: empty });
+    var r = bash(
+      'source "' + copy + '" || exit 7; printf "%s" "$CLAUDE_PLUGIN_ROOT"',
+      { CLAUDE_REMOTE_PLUGINS_ROOT: empty },
+    );
     assert.equal(r.status, 7, "source must return 1 so the caller can stop");
-    assert.ok(r.err.indexOf(empty) !== -1, "error names the remote root it searched: " + r.err);
-    assert.ok(r.err.indexOf("plugin.json") !== -1, "error names the manifest it looked for: " + r.err);
-    assert.ok(r.err.indexOf("CLAUDE_PLUGIN_ROOT") !== -1, "error tells the reader what to export: " + r.err);
+    assert.ok(
+      r.err.indexOf(empty) !== -1,
+      "error names the remote root it searched: " + r.err,
+    );
+    assert.ok(
+      r.err.indexOf("plugin.json") !== -1,
+      "error names the manifest it looked for: " + r.err,
+    );
+    assert.ok(
+      r.err.indexOf("CLAUDE_PLUGIN_ROOT") !== -1,
+      "error tells the reader what to export: " + r.err,
+    );
+  });
+
+  it("names the rejected value when a set CLAUDE_PLUGIN_ROOT has no manifest and no mount replaces it", function () {
+    var tmp = fs.mkdtempSync(path.join(os.tmpdir(), "plugin-root-nowhere-"));
+    var copy = path.join(tmp, "scripts", "lib", "plugin-root.sh");
+    fs.mkdirSync(path.dirname(copy), { recursive: true });
+    fs.copyFileSync(SCRIPT, copy);
+    var empty = fs.mkdtempSync(path.join(os.tmpdir(), "plugin-root-empty-"));
+    var r = bash(
+      'source "' + copy + '" || exit 7; printf "%s" "$CLAUDE_PLUGIN_ROOT"',
+      {
+        CLAUDE_PLUGIN_ROOT: "/nope/plugin_01X",
+        CLAUDE_REMOTE_PLUGINS_ROOT: empty,
+      },
+    );
+    assert.equal(r.status, 7, "source must return 1 so the caller can stop");
+    assert.ok(
+      r.err.indexOf("/nope/plugin_01X") !== -1,
+      "error names the rejected value: " + r.err,
+    );
+    assert.ok(
+      r.err.indexOf("CLAUDE_PLUGIN_ROOT") !== -1,
+      "error tells the reader what to export: " + r.err,
+    );
   });
 });
 
@@ -88,23 +167,137 @@ describe("the skill preamble (references/context/plugin-root.md)", function () {
     var fence = block.match(/```bash\n([\s\S]*?)\n```/);
     assert.ok(fence, "the canonical block carries one bash fence");
     var t = fakeRemoteTree();
-    var r = bash(fence[1] + '\nprintf "%s" "$CLAUDE_PLUGIN_ROOT"', { CLAUDE_REMOTE_PLUGINS_ROOT: t.remote });
+    var r = bash(fence[1] + '\nprintf "%s" "$CLAUDE_PLUGIN_ROOT"', {
+      CLAUDE_REMOTE_PLUGINS_ROOT: t.remote,
+    });
     assert.equal(r.status, 0, r.err);
     assert.equal(fs.realpathSync(r.out), t.ours);
   });
 
-  it("is copied verbatim, exactly once, into every skills/*/SKILL.md", function () {
+  it("its bash one-liner keeps a pre-set CLAUDE_PLUGIN_ROOT when its manifest exists", function () {
+    var block = canonicalBlock();
+    var fence = block.match(/```bash\n([\s\S]*?)\n```/);
+    assert.ok(fence, "the canonical block carries one bash fence");
+    var r = bash(fence[1] + '\nprintf "%s" "$CLAUDE_PLUGIN_ROOT"', {
+      CLAUDE_PLUGIN_ROOT: PLUGIN_ROOT,
+    });
+    assert.equal(r.status, 0, r.err);
+    assert.equal(r.out, PLUGIN_ROOT);
+  });
+
+  it("its bash one-liner replaces a pre-set CLAUDE_PLUGIN_ROOT whose manifest does not exist", function () {
+    var block = canonicalBlock();
+    var fence = block.match(/```bash\n([\s\S]*?)\n```/);
+    assert.ok(fence, "the canonical block carries one bash fence");
+    var t = fakeRemoteTree();
+    var r = bash(fence[1] + '\nprintf "%s" "$CLAUDE_PLUGIN_ROOT"', {
+      CLAUDE_PLUGIN_ROOT: "/nope/plugin_01X",
+      CLAUDE_REMOTE_PLUGINS_ROOT: t.remote,
+    });
+    assert.equal(r.status, 0, r.err);
+    assert.equal(fs.realpathSync(r.out), t.ours);
+  });
+
+  it("is copied verbatim, exactly once, after the H1 of every skills/*/SKILL.md and any agents/*.md that runs a plugin script", function () {
     var block = canonicalBlock();
     var dirs = fs.readdirSync(SKILLS_DIR).filter(function (d) {
       return fs.existsSync(path.join(SKILLS_DIR, d, "SKILL.md"));
     });
-    assert.ok(dirs.length >= 6, "expected the skill set to be present, found " + dirs.length);
-    dirs.forEach(function (d) {
-      var src = fs.readFileSync(path.join(SKILLS_DIR, d, "SKILL.md"), "utf8");
-      var count = src.split(block).length - 1;
-      assert.equal(count, 1, d + "/SKILL.md must carry the canonical plugin-root block exactly once (found " + count + ")");
-      var h1 = src.indexOf("\n# ");
-      assert.ok(src.indexOf(block) > h1, d + "/SKILL.md: the block sits after the H1");
+    assert.ok(
+      dirs.length >= 6,
+      "expected the skill set to be present, found " + dirs.length,
+    );
+
+    var files = dirs.map(function (d) {
+      return {
+        path: path.join(SKILLS_DIR, d, "SKILL.md"),
+        label: "skills/" + d + "/SKILL.md",
+      };
     });
+
+    fs.readdirSync(AGENTS_DIR).forEach(function (f) {
+      if (!/\.md$/.test(f)) return;
+      var full = path.join(AGENTS_DIR, f);
+      var text = fs.readFileSync(full, "utf8");
+      if (text.indexOf("${CLAUDE_PLUGIN_ROOT}/scripts") !== -1) {
+        files.push({ path: full, label: "agents/" + f });
+      }
+    });
+    assert.ok(
+      files.some(function (f) {
+        return f.label.indexOf("agents/") === 0;
+      }),
+      "expected at least one agents/*.md that names ${CLAUDE_PLUGIN_ROOT}/scripts",
+    );
+
+    files.forEach(function (f) {
+      var src = fs.readFileSync(f.path, "utf8");
+      var count = src.split(block).length - 1;
+      assert.equal(
+        count,
+        1,
+        f.label +
+          " must carry the canonical plugin-root block exactly once (found " +
+          count +
+          ")",
+      );
+      var h1 = src.indexOf("\n# ");
+      assert.ok(
+        src.indexOf(block) > h1,
+        f.label + ": the block sits after the H1",
+      );
+    });
+  });
+});
+
+describe("the default glob and the tightened manifest pattern are pinned identically in both copies", function () {
+  it("scripts/lib/plugin-root.sh and the canonical block share the same substrings, non-empty", function () {
+    var scriptText = fs.readFileSync(SCRIPT, "utf8");
+    var block = canonicalBlock();
+
+    var globLiteral =
+      "${CLAUDE_REMOTE_PLUGINS_ROOT:-/sessions/*/mnt/.remote-plugins}/*/";
+    var globRe = new RegExp(escapeRegex(globLiteral));
+    var scriptGlob = scriptText.match(globRe);
+    var blockGlob = block.match(globRe);
+    assert.ok(
+      scriptGlob,
+      "scripts/lib/plugin-root.sh must carry the default glob substring",
+    );
+    assert.ok(
+      blockGlob,
+      "the canonical block must carry the default glob substring",
+    );
+    assert.ok(
+      scriptGlob[0].length > 0 && blockGlob[0].length > 0,
+      "captured glob substrings must be non-empty",
+    );
+    assert.equal(
+      scriptGlob[0],
+      blockGlob[0],
+      "the default glob must be byte-identical in both copies",
+    );
+
+    var manifestLiteral = '"name": *"actian-design-system"';
+    var manifestRe = new RegExp(escapeRegex(manifestLiteral));
+    var scriptManifest = scriptText.match(manifestRe);
+    var blockManifest = block.match(manifestRe);
+    assert.ok(
+      scriptManifest,
+      "scripts/lib/plugin-root.sh must carry the tightened manifest grep pattern",
+    );
+    assert.ok(
+      blockManifest,
+      "the canonical block must carry the tightened manifest grep pattern",
+    );
+    assert.ok(
+      scriptManifest[0].length > 0 && blockManifest[0].length > 0,
+      "captured manifest substrings must be non-empty",
+    );
+    assert.equal(
+      scriptManifest[0],
+      blockManifest[0],
+      "the manifest grep pattern must be byte-identical in both copies",
+    );
   });
 });

--- a/plugins/actian-design-system/tests/integration/plugin-root.test.js
+++ b/plugins/actian-design-system/tests/integration/plugin-root.test.js
@@ -1,0 +1,110 @@
+"use strict";
+/**
+ * plugin-root.test.js: scripts/lib/plugin-root.sh must make CLAUDE_PLUGIN_ROOT
+ * name the plugin root in every shell, including the Cowork VM where bash sees
+ * the plugin under /sessions/<vm>/mnt/.remote-plugins/<id>/ and not the Mac
+ * path the skill header names. Three layouts + the error path, run in real bash.
+ * Run: "$NODE_BIN" --test tests/integration/plugin-root.test.js
+ */
+var { describe, it } = require("node:test");
+var assert = require("node:assert");
+var fs = require("fs");
+var os = require("os");
+var path = require("path");
+var { spawnSync } = require("node:child_process");
+
+var PLUGIN_ROOT = fs.realpathSync(path.resolve(__dirname, "..", ".."));
+var SCRIPT = path.join(PLUGIN_ROOT, "scripts", "lib", "plugin-root.sh");
+var CANON = path.join(PLUGIN_ROOT, "references", "context", "plugin-root.md");
+var SKILLS_DIR = path.join(PLUGIN_ROOT, "skills");
+
+function bash(cmd, envOverrides) {
+  var env = Object.assign({}, process.env, envOverrides || {});
+  delete env.CLAUDE_PLUGIN_ROOT;
+  if (envOverrides && envOverrides.CLAUDE_PLUGIN_ROOT) env.CLAUDE_PLUGIN_ROOT = envOverrides.CLAUDE_PLUGIN_ROOT;
+  var r = spawnSync("bash", ["-c", cmd], { env: env, encoding: "utf8" });
+  return { status: r.status, out: (r.stdout || "").trim(), err: r.stderr || "" };
+}
+
+// A fake Cowork mount: the decoy sorts FIRST so a match by position would pick
+// the wrong plugin; only a match by manifest name picks ours.
+function fakeRemoteTree() {
+  var tmp = fs.mkdtempSync(path.join(os.tmpdir(), "plugin-root-"));
+  var remote = path.join(tmp, "sessions", "vm-a", "mnt", ".remote-plugins");
+  var decoy = path.join(remote, "plugin_01OTHER");
+  var ours = path.join(remote, "plugin_02OURS");
+  fs.mkdirSync(path.join(decoy, ".claude-plugin"), { recursive: true });
+  fs.mkdirSync(path.join(ours, ".claude-plugin"), { recursive: true });
+  fs.writeFileSync(path.join(decoy, ".claude-plugin", "plugin.json"), JSON.stringify({ name: "figma", version: "2.2.107" }));
+  fs.writeFileSync(path.join(ours, ".claude-plugin", "plugin.json"), JSON.stringify({ name: "actian-design-system", version: "0.0.0" }));
+  return { tmp: tmp, remote: remote, ours: fs.realpathSync(ours) };
+}
+
+function canonicalBlock() {
+  var md = fs.readFileSync(CANON, "utf8");
+  var m = md.match(/<!-- plugin-root:begin -->[\s\S]*?<!-- plugin-root:end -->/);
+  assert.ok(m, "references/context/plugin-root.md must carry the plugin-root:begin/end markers");
+  return m[0];
+}
+
+describe("scripts/lib/plugin-root.sh", function () {
+  it("keeps CLAUDE_PLUGIN_ROOT when it is already set", function () {
+    var r = bash('source "' + SCRIPT + '" && printf "%s" "$CLAUDE_PLUGIN_ROOT"', { CLAUDE_PLUGIN_ROOT: "/already/set" });
+    assert.equal(r.status, 0, r.err);
+    assert.equal(r.out, "/already/set");
+  });
+
+  it("resolves the mounted plugin by manifest name under CLAUDE_REMOTE_PLUGINS_ROOT, skipping other plugins", function () {
+    var t = fakeRemoteTree();
+    var r = bash('source "' + SCRIPT + '" && printf "%s" "$CLAUDE_PLUGIN_ROOT"', { CLAUDE_REMOTE_PLUGINS_ROOT: t.remote });
+    assert.equal(r.status, 0, r.err);
+    assert.equal(fs.realpathSync(r.out), t.ours);
+  });
+
+  it("falls back to the plugin that contains the script when no mount matches", function () {
+    var empty = fs.mkdtempSync(path.join(os.tmpdir(), "plugin-root-empty-"));
+    var r = bash('source "' + SCRIPT + '" && printf "%s" "$CLAUDE_PLUGIN_ROOT"', { CLAUDE_REMOTE_PLUGINS_ROOT: empty });
+    assert.equal(r.status, 0, r.err);
+    assert.equal(fs.realpathSync(r.out), PLUGIN_ROOT);
+  });
+
+  it("returns 1 and names both places it looked when nothing matches", function () {
+    var tmp = fs.mkdtempSync(path.join(os.tmpdir(), "plugin-root-nowhere-"));
+    var copy = path.join(tmp, "scripts", "lib", "plugin-root.sh");
+    fs.mkdirSync(path.dirname(copy), { recursive: true });
+    fs.copyFileSync(SCRIPT, copy);
+    var empty = fs.mkdtempSync(path.join(os.tmpdir(), "plugin-root-empty-"));
+    var r = bash('source "' + copy + '" || exit 7; printf "%s" "$CLAUDE_PLUGIN_ROOT"', { CLAUDE_REMOTE_PLUGINS_ROOT: empty });
+    assert.equal(r.status, 7, "source must return 1 so the caller can stop");
+    assert.ok(r.err.indexOf(empty) !== -1, "error names the remote root it searched: " + r.err);
+    assert.ok(r.err.indexOf("plugin.json") !== -1, "error names the manifest it looked for: " + r.err);
+    assert.ok(r.err.indexOf("CLAUDE_PLUGIN_ROOT") !== -1, "error tells the reader what to export: " + r.err);
+  });
+});
+
+describe("the skill preamble (references/context/plugin-root.md)", function () {
+  it("its bash one-liner resolves the same fake mount without sourcing anything", function () {
+    var block = canonicalBlock();
+    var fence = block.match(/```bash\n([\s\S]*?)\n```/);
+    assert.ok(fence, "the canonical block carries one bash fence");
+    var t = fakeRemoteTree();
+    var r = bash(fence[1] + '\nprintf "%s" "$CLAUDE_PLUGIN_ROOT"', { CLAUDE_REMOTE_PLUGINS_ROOT: t.remote });
+    assert.equal(r.status, 0, r.err);
+    assert.equal(fs.realpathSync(r.out), t.ours);
+  });
+
+  it("is copied verbatim, exactly once, into every skills/*/SKILL.md", function () {
+    var block = canonicalBlock();
+    var dirs = fs.readdirSync(SKILLS_DIR).filter(function (d) {
+      return fs.existsSync(path.join(SKILLS_DIR, d, "SKILL.md"));
+    });
+    assert.ok(dirs.length >= 6, "expected the skill set to be present, found " + dirs.length);
+    dirs.forEach(function (d) {
+      var src = fs.readFileSync(path.join(SKILLS_DIR, d, "SKILL.md"), "utf8");
+      var count = src.split(block).length - 1;
+      assert.equal(count, 1, d + "/SKILL.md must carry the canonical plugin-root block exactly once (found " + count + ")");
+      var h1 = src.indexOf("\n# ");
+      assert.ok(src.indexOf(block) > h1, d + "/SKILL.md: the block sits after the H1");
+    });
+  });
+});


### PR DESCRIPTION
## Summary

In Cowork, Read and Glob see the Mac-side plugin path while bash runs in a VM where the plugin is
mounted under a sessions directory. A session on 2026-09-09 concluded the renderer scripts were
not available and hand-built its deliverable instead of using the pipeline. Each `SKILL.md` now
opens with one "Where the plugin lives" block (canonical copy in `references/context/plugin-root.md`)
whose bash line sets `CLAUDE_PLUGIN_ROOT` by locating the mounted manifest, and
`scripts/lib/plugin-root.sh` does the same for scripts, with a test that runs the resolver in
three simulated layouts and asserts every skill carries the block verbatim.

A final review found four gaps, all closed in the same PR: a pre-set `CLAUDE_PLUGIN_ROOT` is now
kept only when `"$CLAUDE_PLUGIN_ROOT/.claude-plugin/plugin.json"` exists as a file (Cowork can
export the Mac-side value into a VM shell where that path does not exist, and an unmeasured value
was previously trusted and kept, making the whole fix a no-op on that path); the block's prose now
says the resolve line is idempotent and safe to run again in a later bash call once the variable
is found empty; `agents/screen-generator.md` (the only agent that runs a plugin script) now carries
the same preamble after its H1, since a subagent's shell does not inherit the parent's export; and
a new test pins the default glob and the tightened manifest grep pattern identically in both copies
so neither can drift unnoticed.

## Test plan

- [x] Full plugin test suite passes locally: `2257 tests, 2252 pass, 0 fail, 5 skipped` (from
      `plugins/actian-design-system/`, `node --test 'tests/**/*.test.js'`).
- [x] `tests/integration/plugin-root.test.js` alone: `11 tests, 11 pass, 0 fail` - covers keep-only-
      if-valid (script and one-liner, both directions), the rejected-value error message, the
      agent preamble copy, and the pinned glob/manifest substrings.
- [x] `claude plugin validate plugins/actian-design-system` passes (one pre-existing warning,
      unrelated: plugin-root `CLAUDE.md` is not loaded as project context).
- [x] `claude plugin validate --strict .claude-plugin/marketplace.json` passes clean.
- [x] `node .github/workflows/scripts/check-version-bump.js` reports `base 2026.9.13 -> head
      2026.9.14`, `OK`.
- [x] Guard-can-fail proof (Task 2): mutating `once per shell` in `compare-flows/SKILL.md`'s
      "Where the plugin lives" block made the verbatim-copy test fail; restoring the exact text
      made it pass again, confirming the test actually checks the block's content rather than
      just its presence.
- [x] By-hand proof of the keep-only-if-valid resolution order: with `CLAUDE_PLUGIN_ROOT` set to a
      nonexistent path and no fallback mount, the resolver falls back to the plugin dir; with the
      same invalid value and `CLAUDE_REMOTE_PLUGINS_ROOT` pointed at a fake mount, it resolves to
      the mount instead of keeping the rejected value.
- [x] Doc-conventions test passes (catches bare `node` / `$PLUGIN_ROOT` / unresolved `$NODE_BIN`) -
      covered by the full suite run above, not run in isolation.
- [ ] First Cowork run after the build: print `echo "[$CLAUDE_PLUGIN_ROOT]"` before anything else to
      record what the VM shell exports.

## Smoke evidence

N/A: no push pattern or renderer touched; the Cowork run is the acceptance and happens after the
marketplace build appears.

## Migration discipline

N/A: no push pattern or skill behavior is retired, deleted, or superseded. The "Where the plugin
lives" block is additive at the top of each `SKILL.md`.

## Version bump

- [x] `plugins/actian-design-system/.claude-plugin/plugin.json` bumped `2026.9.13` ->
      `2026.9.14` (calendar versioning, same month, PATCH+1).

## Out-of-scope / follow-up

- PR 3 (hiding `generate-presentation` and `convert-to-hifi`) is a separate branch,
  `chore/hide-presentation-and-hifi`, not stacked on this one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016KGXooJNCQAqxp6PvpKeLT
