### PR TITLE
fix(tests): the vendor refresh no longer goes red on facts the substrate changed on purpose

### DIFF
--- a/.github/workflows/vendor-snapshot.yml
+++ b/.github/workflows/vendor-snapshot.yml
@@ -198,6 +198,38 @@ jobs:
         run: |
           node scripts/renderers/ds-coverage-report.js --write-baseline
 
+      - name: Re-capture the renderer goldens
+        id: goldens
+        # Only on a night the vendor changed, like the bank above.
+        if: steps.diff.outputs.changed == 'true'
+        # The goldens are byte copies of what the vendored renderer emits for a
+        # fixed input, kept so a plugin-side refactor cannot change that output
+        # unnoticed. A refresh changes the output on purpose (knowledge owns the
+        # render facts), so the refresh re-captures them the way it re-banks the
+        # baseline, and the PR diff shows every golden that moved. Without this
+        # a glyph or leaf change upstream left the refresh red on goldens no PR
+        # could update (#358, #363). The PR auto-merges, so the list of goldens
+        # that moved goes to the PR body (through this step's `notes` output,
+        # like the bank's) and not only to the run summary.
+        working-directory: plugins/actian-design-system
+        run: |
+          npm run update-snapshots
+          stat="$(git diff --stat -- tests/renderers/__goldens__ tests/renderers/fixtures)"
+          if [ -z "$stat" ]; then stat="no golden moved"; fi
+          {
+            echo "### Renderer goldens re-captured"
+            echo '```'
+            echo "$stat"
+            echo '```'
+          } > goldens-notes.md
+          cat goldens-notes.md >> "$GITHUB_STEP_SUMMARY"
+          {
+            echo "notes<<GOLDENS_NOTES"
+            cat goldens-notes.md
+            echo "GOLDENS_NOTES"
+          } >> "$GITHUB_OUTPUT"
+          rm goldens-notes.md
+
       - name: Auto-bump plugin.json (calendar)
         if: steps.diff.outputs.changed == 'true'
         # Calendar versioning (YYYY.MM.PATCH) — same month bumps PATCH, a new
@@ -229,6 +261,8 @@ jobs:
             Auto-bumps plugin.json (calendar `YYYY.MM.PATCH`) so the marketplace cache propagates the new content to designers.
 
             ${{ steps.bank.outputs.notes }}
+
+            ${{ steps.goldens.outputs.notes }}
           branch: "vendor/refresh-${{ steps.target.outputs.short_sha }}"
           labels: vendor,knowledge-snapshot,auto-merge
           delete-branch: true
@@ -244,6 +278,8 @@ jobs:
             plugins/actian-design-system/references/figma/figma-push-patterns.md
             plugins/actian-design-system/references/generate-flow/ds-components-authoring.md
             plugins/actian-design-system/tests/renderers/blank-box-baseline.json
+            plugins/actian-design-system/tests/renderers/__goldens__/**
+            plugins/actian-design-system/tests/renderers/fixtures/**
 
       - name: Enable auto-merge
         if: steps.diff.outputs.changed == 'true' && steps.cpr.outputs.pull-request-number

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,6 +67,20 @@ are summarized at the release level.
 
 ### Fixed
 
+- **The vendor refresh no longer goes red on facts the substrate changed on purpose.**
+  ([#366](https://github.com/volivarii/Actian-DS-Claude-plugin/pull/366)) Knowledge v0.34.202 built
+  the last 14 leaves and v0.34.205 redrew the global header with per-app lockups, built the plain card
+  family on a single `Slot` prop, and made the FM dialog and empty state read their copy from props.
+  Eighteen plugin tests pinned the older facts, so #358 and #363 stayed red and the nightly could not
+  self-heal. The tests now read the contract they run against: the header tests feature-detect a
+  captured lockup, the card family escapes through `Slot`, the FM tests author the copy they assert,
+  and the blank-box positive control asks the anatomy loader directly once every slug is built (its
+  bank tests feed the command a recorded measurement through `BLANK_BOX_MEASURE`, since a fully built
+  renderer has no chip or blank box left to lend). The workflow gained a "Re-capture the renderer
+  goldens" step after the baseline re-bank, so a refresh carries the goldens it changes instead of
+  failing on them. The one real gap the refresh found, four drawer classes emitted without a CSS
+  rule, is fixed upstream in knowledge and stays refused here until a tag carries it.
+
 - **The companion's ship-ready route emits a valid flag pair** ([#360](https://github.com/volivarii/Actian-DS-Claude-plugin/pull/360)). Row 3 routed `--hifi --audit
   --no-prompt`, a pair generate-flow declares incompatible. It now routes `--hifi --no-prompt` for a
   hi-fi HTML deliverable, `--push` adds a Figma artifact, and the interactive-gates reference follows

--- a/plugins/actian-design-system/.claude-plugin/plugin.json
+++ b/plugins/actian-design-system/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "actian-design-system",
   "description": "Actian Design System toolkit: generate wireframe flows with prototype wiring, create component briefs, propose component-scale designs as offline boards, audit designs, compare flows. 7 skills (with tiered generation: recognized / adapted / improvised), 8 agents, 155 tokens (3 themes, 8 collections), WCAG 2.2 AA. DS knowledge vendored from volivarii/actian-ds-knowledge.",
-  "version": "2026.9.16",
+  "version": "2026.9.17",
   "author": {
     "name": "Actian UX Team"
   },

--- a/plugins/actian-design-system/scripts/renderers/ds-coverage-report.js
+++ b/plugins/actian-design-system/scripts/renderers/ds-coverage-report.js
@@ -972,9 +972,35 @@ if (require.main === module) {
     }
     var m;
     try {
-      m = measureBlankBoxes();
+      // BLANK_BOX_MEASURE hands the command a recorded measurement in place of
+      // a live render, so a test can drive the bank's newcomer and regression
+      // paths on a pin whose real output has no chip and no blank box left
+      // (every slug built since knowledge v0.34.202). Same family of seam as
+      // BLANK_BOX_BASELINE and BLANK_BOX_LEDGER below; the workflow never sets
+      // it.
+      m = process.env.BLANK_BOX_MEASURE
+        ? JSON.parse(
+            fsW.readFileSync(
+              pathW.resolve(process.env.BLANK_BOX_MEASURE),
+              "utf8",
+            ),
+          )
+        : measureBlankBoxes();
     } catch (e) {
       refuse(e.message);
+    }
+    if (
+      !m ||
+      typeof m.perSlug !== "object" ||
+      !Array.isArray(m.slugs) ||
+      !Array.isArray(m.chipSlugs)
+    ) {
+      refuse(
+        (process.env.BLANK_BOX_MEASURE
+          ? "BLANK_BOX_MEASURE " + process.env.BLANK_BOX_MEASURE
+          : "the live render") +
+          " does not carry a measurement (perSlug, slugs, chipSlugs)",
+      );
     }
     // BLANK_BOX_BASELINE points the read and the write elsewhere, so a test
     // that drives this command never touches the committed record.

--- a/plugins/actian-design-system/tests/renderers/blank-box-budget.test.js
+++ b/plugins/actian-design-system/tests/renderers/blank-box-budget.test.js
@@ -85,14 +85,51 @@ function ratchetHint() {
 describe("blank-box budget", function () {
   it("POSITIVE CONTROL: the anatomy doc map is actually live", function () {
     // Without this, a broken/unset doc map chips every slug, emits zero blank
-    // boxes, and the budget below passes while measuring NOTHING. Assert the
-    // anatomy marker attribute (data-ds-slug=) is present in real output.
+    // boxes, and the budget below passes while measuring NOTHING. The anatomy
+    // path only runs for slugs without a built leaf, so the control has two
+    // real shapes. While any slug is unbuilt, its render must carry the
+    // anatomy marker attribute (data-ds-slug=). Once every slug is built
+    // (knowledge v0.34.202 built the last 14) nothing goes through that path,
+    // and the control asserts that the loader the path would read through
+    // still resolves the measured slugs, so a later demotion is measured
+    // against a live map and not chipped by an empty one. The map builder
+    // skips built slugs itself, so it is asked with an empty built list: every
+    // slug then goes through the loader and the R2 ratio gate, and a dead or
+    // unset loader resolves none.
     var r = renderAll();
-    assert.ok(
-      r.anyAnatomy,
-      "no slug rendered anatomy markup, so the doc map is not live and the " +
-        "blank-box budget would pass vacuously",
-    );
+    var unbuilt = r.slugs.filter(function (s) {
+      return r.builtSlugs.indexOf(s) === -1;
+    });
+    if (unbuilt.length) {
+      assert.ok(
+        r.anyAnatomy,
+        "no slug rendered anatomy markup (" +
+          unbuilt.length +
+          " unbuilt), so the doc map is not live and the blank-box budget " +
+          "would pass vacuously",
+      );
+    } else {
+      var docMap =
+        require("../../scripts/lib/renderer.js").dsAnatomyMap.buildDsAnatomyDocMap(
+          r.slugs,
+          { builtSlugs: [] },
+        );
+      var resolved = r.slugs.filter(function (s) {
+        return docMap && docMap[s];
+      });
+      // A majority floor, not "any": a loader that lost most of its docs (a
+      // moved anatomy directory, a mis-tuned ratio gate) resolves a few and
+      // would pass a floor of one. 58 of 74 resolved on knowledge v0.34.205.
+      assert.ok(
+        resolved.length * 2 > r.slugs.length,
+        "every slug is built, so the anatomy path is idle on this pin; the " +
+          "doc map it would read resolves only " +
+          resolved.length +
+          " of " +
+          r.slugs.length +
+          " slugs, which is not live",
+      );
+    }
   });
 
   it("the authorable vocabulary is non-empty (guards a silent parse break)", function () {
@@ -264,7 +301,10 @@ describe("blank-box budget", function () {
   // Drives the real --write-baseline against a COPY of the committed record,
   // via BLANK_BOX_BASELINE, so the committed file is never touched, and
   // removes the copy afterwards.
-  function runBank(edit, env) {
+  // `measure`, when given, is handed to the command as BLANK_BOX_MEASURE in
+  // place of a live render, so a test can put a chip or a blank box in front
+  // of the bank on a pin whose real output has none.
+  function runBank(edit, env, measure) {
     var spawnSync = require("node:child_process").spawnSync;
     var fs = require("node:fs");
     var os = require("node:os");
@@ -272,6 +312,8 @@ describe("blank-box budget", function () {
     var copy = path.join(dir, "baseline.json");
     var summary = path.join(dir, "summary.md");
     var output = path.join(dir, "output.txt");
+    var measurePath = path.join(dir, "measure.json");
+    if (measure) fs.writeFileSync(measurePath, JSON.stringify(measure) + "\n");
     var record = JSON.parse(JSON.stringify(BASELINE));
     var written = edit(record);
     if (written !== false)
@@ -298,11 +340,17 @@ describe("blank-box budget", function () {
         ],
         {
           encoding: "utf8",
-          env: Object.assign({}, process.env, env || {}, {
-            GITHUB_STEP_SUMMARY: summary,
-            GITHUB_OUTPUT: output,
-            BLANK_BOX_BASELINE: copy,
-          }),
+          env: Object.assign(
+            {},
+            process.env,
+            env || {},
+            {
+              GITHUB_STEP_SUMMARY: summary,
+              GITHUB_OUTPUT: output,
+              BLANK_BOX_BASELINE: copy,
+            },
+            measure ? { BLANK_BOX_MEASURE: measurePath } : {},
+          ),
         },
       );
       return {
@@ -323,14 +371,17 @@ describe("blank-box budget", function () {
     // Plugin #318. The vendor job rewrites the baseline before the tests run,
     // so a newcomer never reaches a failing assertion; the run summary and the
     // PR body (fed from the step output) are where a reader sees it.
-    var chip = BASELINE.chipSlugs[0];
-    assert.ok(chip, "the committed baseline lists at least one chip to forget");
-    var r = runBank(function (record) {
-      delete record.perSlug[chip];
-      record.chipSlugs = record.chipSlugs.filter(function (s) {
-        return s !== chip;
-      });
-    });
+    //
+    // The newcomer is put into the MEASUREMENT (a copy of the live one plus one
+    // chip the record has never seen), not taken from the committed record:
+    // since knowledge v0.34.202 every slug is built and the record lists no
+    // chip, so the real render has no positive to lend.
+    var chip = "zz-newcomer-chip";
+    var measured = JSON.parse(JSON.stringify(renderAll()));
+    measured.slugs = measured.slugs.concat([chip]);
+    measured.perSlug[chip] = 0;
+    measured.chipSlugs = measured.chipSlugs.concat([chip]);
+    var r = runBank(function () {}, null, measured);
     assert.equal(r.status, 0, r.stderr);
     assert.ok(
       r.stdout.indexOf("bare chip") !== -1 &&
@@ -345,23 +396,27 @@ describe("blank-box budget", function () {
     );
     assert.deepEqual(
       JSON.parse(r.after).chipSlugs,
-      BASELINE.chipSlugs,
+      measured.chipSlugs,
       "the copy was rewritten with the chip banked",
     );
   });
 
   it("refuses a regression through the real command, leaves the record untouched, and exits 1", function () {
-    var slug = Object.keys(BASELINE.perSlug).filter(function (s) {
-      return BASELINE.perSlug[s] > 0;
-    })[0];
-    assert.ok(
-      slug,
-      "the committed baseline has a slug with blank boxes to under-record",
+    // Same shape as the newcomer above: the regression is a slug the record
+    // holds at zero and the measurement (a copy of the live one) reports at
+    // three, because the committed record has no slug with blank boxes left.
+    var slug = "zz-regressed-leaf";
+    var measured = JSON.parse(JSON.stringify(renderAll()));
+    measured.slugs = measured.slugs.concat([slug]);
+    measured.perSlug[slug] = 3;
+    measured.total += 3;
+    var r = runBank(
+      function (record) {
+        record.perSlug[slug] = 0;
+      },
+      null,
+      measured,
     );
-    var r = runBank(function (record) {
-      record.perSlug[slug] = 0;
-      record.total -= BASELINE.perSlug[slug];
-    });
     assert.equal(r.status, 1, r.stdout);
     assert.match(r.stderr, /REFUSING/);
     assert.ok(r.stderr.indexOf(slug) !== -1, r.stderr);
@@ -720,17 +775,26 @@ describe("the built-slug record's own input", function () {
       Array.isArray(real) && real.length > 0,
       "the real export must be non-empty, or this control proves nothing",
     );
-    var stub = { slugs: ["button"], render: function () { return "<div></div>"; } };
+    var stub = {
+      slugs: ["button"],
+      render: function () {
+        return "<div></div>";
+      },
+    };
     try {
       dsMap.BUILT_SLUGS = [];
       assert.throws(
-        function () { measureBlankBoxes(stub); },
+        function () {
+          measureBlankBoxes(stub);
+        },
         /no BUILT_SLUGS \(empty array\)/,
         "an empty export must refuse, not measure",
       );
       dsMap.BUILT_SLUGS = undefined;
       assert.throws(
-        function () { measureBlankBoxes(stub); },
+        function () {
+          measureBlankBoxes(stub);
+        },
         /no BUILT_SLUGS \(undefined\)/,
         "a missing export must refuse too",
       );

--- a/plugins/actian-design-system/tests/renderers/ds-html-map.test.js
+++ b/plugins/actian-design-system/tests/renderers/ds-html-map.test.js
@@ -679,13 +679,20 @@ describe("ds-html-map: built card family (leaf + hostile heading)", function () 
     var props = contract[slug].props.map(function (p) {
       return p.name;
     });
-    var heading = ["Title", "Name", "Label"].filter(function (p) {
+    // The plain card family (card, checkbox-card, radio-card, built in
+    // knowledge v0.34.205) is a surface for somebody else's content and
+    // exposes one prop, Slot, which the leaf escapes like a heading; it is the
+    // injection point where no heading prop exists.
+    var heading = ["Title", "Name", "Label", "Slot"].filter(function (p) {
       return props.indexOf(p) !== -1;
     })[0];
     it(
       slug + " renders a leaf, not a chip, and escapes a hostile " + heading,
       function () {
-        assert.ok(heading, slug + " exposes no Title/Name/Label prop to test");
+        assert.ok(
+          heading,
+          slug + " exposes no Title/Name/Label/Slot prop to test",
+        );
         var hostile = {};
         hostile[heading] = "<svg onload=1>";
         var html = render({ dsSlug: slug, variant: "", props: hostile });
@@ -702,6 +709,22 @@ describe("ds-html-map: built card family (leaf + hostile heading)", function () 
 });
 
 describe("ds-html-map: global-header", function () {
+  // Since knowledge v0.34.205 the brand block DRAWS the app: the three apps
+  // with a captured lockup (components/src/graphics-svg.json, slugs
+  // zeenea-logo-studio, -admin, -explorer) render the lockup and no text
+  // label, an app without one keeps the Actian mark plus the text label, and
+  // the App prop left the render contract. Older pins draw the mark and always
+  // write the label. Which contract this checkout carries is read from the
+  // vendored graphics map, so each assertion below states the state it found
+  // instead of pinning one pin's markup.
+  var GRAPHICS = JSON.parse(
+    fs.readFileSync(PATHS.components.graphics.svg, "utf8"),
+  ).graphics;
+  function lockupOf(app) {
+    var slug = "zeenea-logo-" + String(app).toLowerCase();
+    return GRAPHICS[slug] ? slug : null;
+  }
+
   it("default: emits a <header> with brand, center, actions, and avatar", function () {
     var html = render({
       dsSlug: "global-header",
@@ -714,38 +737,76 @@ describe("ds-html-map: global-header", function () {
     );
     assert.ok(html.indexOf("ds-header__brand") !== -1, "has brand");
     assert.ok(html.indexOf("ds-header__logo") !== -1, "has logo");
-    assert.ok(html.indexOf("ds-header__app") !== -1, "has app label");
+    if (lockupOf("Studio")) {
+      assert.ok(
+        html.indexOf("ds-header__app") === -1,
+        "the drawn Studio lockup names the app; no text label beside it",
+      );
+    } else {
+      assert.ok(html.indexOf("ds-header__app") !== -1, "has app label");
+    }
     assert.ok(html.indexOf("ds-header__center") !== -1, "has center block");
     assert.ok(html.indexOf("ds-header__actions") !== -1, "has actions");
     assert.ok(html.indexOf("ds-header__avatar") !== -1, "has avatar");
     assert.ok(html.indexOf("</header>") !== -1, "closes header tag");
   });
 
-  it("App label defaults to the App type variant value", function () {
-    var html = render({
+  it("the App type variant names the app: a drawn lockup where one is captured, a text label otherwise", function () {
+    var explorer = render({
       dsSlug: "global-header",
       variant: "App type=Explorer",
       props: {},
     });
-    assert.ok(html.indexOf(">Explorer</span>") !== -1, "uses App type value");
+    if (lockupOf("Explorer")) {
+      var admin = render({
+        dsSlug: "global-header",
+        variant: "App type=Admin",
+        props: {},
+      });
+      assert.ok(explorer.indexOf("ds-header__app") === -1, "no text label");
+      // Not "an <svg> is present": the header draws icons on every pin. The
+      // Explorer lockup's own artwork, read from the graphics map, must land.
+      assert.ok(explorer.indexOf('class="ds-graphic"') !== -1, "a graphic");
+      assert.ok(
+        explorer.indexOf(GRAPHICS[lockupOf("Explorer")].body) !== -1,
+        "the Explorer lockup artwork is drawn",
+      );
+      assert.notStrictEqual(
+        explorer,
+        admin,
+        "Explorer and Admin draw different lockups",
+      );
+    } else {
+      assert.ok(
+        explorer.indexOf(">Explorer</span>") !== -1,
+        "uses App type value",
+      );
+    }
   });
 
-  it("App prop overrides the App type variant value", function () {
+  it("an app without a captured lockup keeps the text label", function () {
     var html = render({
       dsSlug: "global-header",
-      variant: "App type=Studio",
-      props: { App: "My Workspace" },
+      variant: "App type=Marketplace",
+      props: {},
     });
-    assert.ok(html.indexOf("My Workspace") !== -1, "renders App prop");
     assert.ok(
-      html.indexOf(">Studio</span>") === -1,
-      "App prop wins over variant",
+      html.indexOf('<span class="ds-header__app">Marketplace</span>') !== -1,
+      "a fourth app is never unnamed",
     );
   });
 
-  it("falls back to 'Studio' when neither App prop nor variant present", function () {
+  it("falls back to 'Studio' when no App type variant is present", function () {
     var html = render({ dsSlug: "global-header", variant: "", props: {} });
-    assert.ok(html.indexOf(">Studio</span>") !== -1, "default app label");
+    var studio = render({
+      dsSlug: "global-header",
+      variant: "App type=Studio",
+      props: {},
+    });
+    assert.strictEqual(html, studio, "the default app is Studio");
+    if (!lockupOf("Studio")) {
+      assert.ok(html.indexOf(">Studio</span>") !== -1, "default app label");
+    }
   });
 
   it("Account prop sets the avatar initials; defaults to 'AU'", function () {
@@ -763,11 +824,16 @@ describe("ds-html-map: global-header", function () {
     assert.ok(html2.indexOf(">AU</span>") !== -1, "default avatar initials");
   });
 
-  it("escapes a hostile App label", function () {
+  it("escapes a hostile app name", function () {
+    // The name reaches the text label through the App type variant, which is
+    // the one path every pin still writes (an unknown app has no lockup). The
+    // payload carries no "=" or ",": parseVariant splits on both and drops an
+    // axis with more than one "=", which would fall back to Studio and prove
+    // nothing.
     var html = render({
       dsSlug: "global-header",
-      variant: "App type=Studio",
-      props: { App: "<img src=x onerror=1>" },
+      variant: "App type=<img src onerror>",
+      props: {},
     });
     assert.ok(html.indexOf("&lt;img") !== -1, "app label escaped");
     assert.ok(html.indexOf("<img") === -1, "no raw injection");
@@ -2287,10 +2353,7 @@ describe("ds-html-map: toast (Task 4)", function () {
         Action: "View",
       },
     });
-    assert.ok(
-      html.indexOf("ds-toast") !== -1,
-      "toast built leaf class",
-    );
+    assert.ok(html.indexOf("ds-toast") !== -1, "toast built leaf class");
     assert.ok(html.indexOf("ds-component") === -1, "toast not a chip");
     assert.ok(html.indexOf("Your export is ready") !== -1, "message text");
     assert.ok(
@@ -2307,10 +2370,7 @@ describe("ds-html-map: toast (Task 4)", function () {
       variant: "Type=Critical",
       props: { Message: "Pipeline failed." },
     });
-    assert.ok(
-      html.indexOf("ds-toast--critical") !== -1,
-      "critical modifier",
-    );
+    assert.ok(html.indexOf("ds-toast--critical") !== -1, "critical modifier");
     assert.ok(html.indexOf('role="alert"') !== -1, "critical uses role=alert");
   });
 
@@ -2372,7 +2432,10 @@ describe("ds-html-map: tooltip-default (Task 4)", function () {
       html.indexOf('class="ds-tooltip-default"') !== -1,
       "tooltip-default built leaf class",
     );
-    assert.ok(html.indexOf("ds-component") === -1, "tooltip-default not a chip");
+    assert.ok(
+      html.indexOf("ds-component") === -1,
+      "tooltip-default not a chip",
+    );
     assert.ok(html.indexOf("Only admins") !== -1, "body text present");
     assert.ok(html.indexOf('role="tooltip"') !== -1, "has tooltip role");
   });
@@ -2387,10 +2450,7 @@ describe("ds-html-map: calendar (Task 4)", function () {
       variant: "Type=Single date,States=Enabled",
       props: { Label: "Start date", Helper: "MM/DD/YYYY" },
     });
-    assert.ok(
-      html.indexOf("ds-calendar") !== -1,
-      "calendar built leaf class",
-    );
+    assert.ok(html.indexOf("ds-calendar") !== -1, "calendar built leaf class");
     assert.ok(html.indexOf("ds-component") === -1, "calendar not a chip");
     assert.ok(html.indexOf("Start date") !== -1, "label text");
     assert.ok(
@@ -2435,8 +2495,14 @@ describe("ds-html-map: rich-text-froala (Task 4)", function () {
       html.indexOf("ds-rich-text-froala") !== -1,
       "rich-text-froala built leaf class",
     );
-    assert.ok(html.indexOf("ds-component") === -1, "rich-text-froala not a chip");
-    assert.ok(html.indexOf("ds-rich-text-froala__toolbar") !== -1, "toolbar present");
+    assert.ok(
+      html.indexOf("ds-component") === -1,
+      "rich-text-froala not a chip",
+    );
+    assert.ok(
+      html.indexOf("ds-rich-text-froala__toolbar") !== -1,
+      "toolbar present",
+    );
     assert.ok(html.indexOf("ds-icon") !== -1, "toolbar control glyphs");
   });
 
@@ -3003,10 +3069,19 @@ describe("ds-html-map: calendar-data-selector (A1)", function () {
       variant: "Selection=Single",
       props: {},
     });
-    assert.ok(html.indexOf("ds-calendar-data-selector") !== -1, "calendar leaf class");
+    assert.ok(
+      html.indexOf("ds-calendar-data-selector") !== -1,
+      "calendar leaf class",
+    );
     assert.ok(html.indexOf("ds-component") === -1, "calendar not a chip");
-    assert.ok(html.indexOf("ds-calendar-data-selector__month") !== -1, "month header");
-    assert.ok(html.indexOf("ds-calendar-data-selector__weekdays") !== -1, "weekday row");
+    assert.ok(
+      html.indexOf("ds-calendar-data-selector__month") !== -1,
+      "month header",
+    );
+    assert.ok(
+      html.indexOf("ds-calendar-data-selector__weekdays") !== -1,
+      "weekday row",
+    );
     assert.ok(html.indexOf("is-selected") !== -1, "a selected day");
     assert.ok(html.indexOf(">15</button>") !== -1, "renders day cells");
     assert.ok(html.indexOf("ds-icon") !== -1, "nav chevrons");

--- a/plugins/actian-design-system/tests/renderers/fm-html-map.test.js
+++ b/plugins/actian-design-system/tests/renderers/fm-html-map.test.js
@@ -302,15 +302,35 @@ assertContains(banner, "fm-banner", "banner class");
 
 section("fmDialog");
 
+// Authored with a Title and a Body: since knowledge v0.34.205 the leaf reads
+// both and prints nothing for a dialog authored with neither (it used to print
+// the word "Dialog" and an empty body whatever the caller passed), so a bare
+// render no longer proves the two parts exist.
 const dialog = renderFMComponent({
+  type: "INSTANCE",
+  ref: "fmDialog",
+  variant: "",
+  props: { Title: "Delete this dataset?", Body: "This cannot be undone." },
+});
+assertContains(dialog, "fm-dialog", "dialog class");
+assertContains(dialog, "fm-dialog__title", "dialog title");
+assertContains(dialog, "fm-dialog__body", "dialog body");
+assertNotContains(dialog, "undefined", "no literal undefined in a dialog");
+// Which contract this pin carries is read from a bare render: the leaf that
+// reads its props emits no title element for a dialog authored without one,
+// the older leaf prints "Dialog" whatever it is given. On the reading leaf
+// the authored copy must land, or a leaf that ignores its props and prints a
+// literal would pass on the very pin this guards.
+const bareDialog = renderFMComponent({
   type: "INSTANCE",
   ref: "fmDialog",
   variant: "",
   props: {},
 });
-assertContains(dialog, "fm-dialog", "dialog class");
-assertContains(dialog, "fm-dialog__title", "dialog title");
-assertContains(dialog, "fm-dialog__body", "dialog body");
+if (bareDialog.indexOf("fm-dialog__title") === -1) {
+  assertContains(dialog, "Delete this dataset?", "authored dialog title");
+  assertContains(dialog, "This cannot be undone.", "authored dialog body");
+}
 
 // ---------------------------------------------------------------------------
 // fmStepper
@@ -431,15 +451,32 @@ assertContains(toastStd, "fm-toast--standard", "standard toast");
 
 section("fmEmptyState");
 
+// Authored with a Headline: since knowledge v0.34.205 the leaf reads Headline,
+// Body and Cta and renders the icon well alone without them (it used to print
+// "No items" whatever the caller passed), so the text element is asserted on
+// an authored headline rather than on the old literal.
 const empty = renderFMComponent({
+  type: "INSTANCE",
+  ref: "fmEmptyState",
+  variant: "",
+  props: { Headline: "No datasets yet" },
+});
+assertContains(empty, "fm-empty-state", "empty state class");
+assertContains(empty, "fm-empty-state__icon", "icon element");
+assertContains(empty, "fm-empty-state__text", "headline element");
+assertNotContains(empty, "undefined", "no literal undefined in an empty state");
+// Same detection as the dialog above: the reading leaf emits no text element
+// for an empty state authored without a headline, and on that leaf the
+// authored headline must land.
+const bareEmpty = renderFMComponent({
   type: "INSTANCE",
   ref: "fmEmptyState",
   variant: "",
   props: {},
 });
-assertContains(empty, "fm-empty-state", "empty state class");
-assertContains(empty, "fm-empty-state__icon", "icon element");
-assertContains(empty, "No items", "default text");
+if (bareEmpty.indexOf("fm-empty-state__text") === -1) {
+  assertContains(empty, "No datasets yet", "authored headline");
+}
 
 // ---------------------------------------------------------------------------
 // fmPlaceholder


### PR DESCRIPTION
## Why

The nightly vendor refresh has been red since v0.34.202 (#358) and again on v0.34.205 (#363, alarm #364): 18 plugin tests pinned facts the substrate changed on purpose. A red vendor PR does not self-heal, so the plugin was stuck on v0.34.191 while knowledge shipped the last 14 leaves, the per-app header lockups and the drawer body fix. Same shape as #355: fix on main so the suite passes on both pins, and the next nightly rebuild goes green.

## What changed

Six lanes, one root cause each. The full suite was run on the current pin (v0.34.191: 2306 tests, 0 failures) and on this branch head with the v0.34.205 vendor dropped in, the workflow's regeneration steps applied (component reference, doc counts, authoring table and props, baseline re-bank, golden re-capture) and the knowledge CSS fix below vendored (2309 tests, 0 failures). Reviewed before push; the four Important findings (a vacuous lockup assertion, unasserted FM copy, a number measured on a stand-in, golden notes reaching only the run summary) are folded in.

| lane | upstream fact | fix |
| --- | --- | --- |
| global-header (5 tests) | the brand block draws a per-app lockup for Studio, Admin and Explorer and writes no text label; `props.App` left the contract | the tests feature-detect the lockup in the vendored graphics map and assert the state they find; "App prop overrides" became "an app without a lockup keeps the text label"; the hostile name travels through the `App type` variant (the parser drops an axis whose value carries a second `=`, so the payload carries none) |
| card family (3) | `card`, `checkbox-card`, `radio-card` are built on a single `Slot` prop, escaped | the injection lookup includes `Slot` |
| fm-html-map (3) | fmDialog and fmEmptyState read their copy from props and print nothing for copy they were not given | the tests author the copy and assert the elements, plus no literal `undefined` |
| blank-box budget (3) | every slug is built, so nothing goes through the anatomy path: `anyAnatomy` is false and the record lists no chip and no blank box | the positive control asks the loader directly (`buildDsAnatomyDocMap` with an empty built list); the two bank tests feed the command a recorded measurement through a new `BLANK_BOX_MEASURE` seam carrying a synthetic newcomer chip and a synthetic regression |
| goldens (5) | the header lockup changed the bytes on purpose; a byte golden cannot pass two pins | `vendor-snapshot.yml` gained a "Re-capture the renderer goldens" step after the baseline re-bank (`npm run update-snapshots`; the diff stat goes to the step summary and, through the step's `notes` output, into the refresh PR body, since that PR auto-merges), and `__goldens__/**` plus `fixtures/**` in the PR's add-paths, so a refresh carries the goldens it changes |
| css-staleness (1) | a real gap: the drawer leaf emits `ds-drawer__meta-label`, `__meta-value`, `__technical-name`, `__facts` and nothing styles them | fixed upstream in knowledge (`fix/drawer-meta-css`); this gate keeps refusing the refresh until a knowledge tag carries the rule, as it should |

Nothing was silenced: the CSS gate found a real defect and the fix is upstream.

## Sequencing

1. Merge this. The next nightly rebuilds #363 on main and re-captures the goldens; it stays red on the CSS gate alone.
2. Merge the knowledge PR and let CI tag it. The following nightly opens a refresh on that tag, which should be green.

## Also in this PR

- `CHANGELOG.md` entry under Unreleased, `plugin.json` 2026.9.16 to 2026.9.17.
- `BLANK_BOX_MEASURE` is a test seam only; the workflow never sets it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016KGXooJNCQAqxp6PvpKeLT
