### PR TITLE
docs(generate-flow): the authoring references say what the vendored leaves read

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,18 @@ are summarized at the release level.
 
 ## [Unreleased]
 
+### Fixed
+
+- **The authoring references say what the vendored leaves read.** ([#368](https://github.com/volivarii/Actian-DS-Claude-plugin/pull/368)) Rerunning the
+  generate-flow audit on knowledge v0.34.207 and looking at the HTML found a doubled drawer on the
+  hi-fi flow: the drawer note still said "header strip only, author the body as frames", while the
+  leaf has drawn the whole panel from thirteen props since v0.34.205 and reads no children. The note
+  now lists the props and says where a checklist goes. Three more rows caught by the same look: the
+  `progress-bar-small` leaf prints its own percent (authors were adding a second one), and the FM
+  Dialog and FM Empty State renderers read `Title`/`Body` and `Headline`/`Body`/`Cta` rather than
+  printing fixed words. The generate-flow skill now names the valid `template` values, which no skill
+  file stated before.
+
 ### Added
 
 - **A design proposal board for component-scale tickets.** ([#365](https://github.com/volivarii/Actian-DS-Claude-plugin/pull/365)) `/design-proposal` frames the ticket, offers

--- a/plugins/actian-design-system/.claude-plugin/plugin.json
+++ b/plugins/actian-design-system/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "actian-design-system",
   "description": "Actian Design System toolkit: generate wireframe flows with prototype wiring, create component briefs, propose component-scale designs as offline boards, audit designs, compare flows. 7 skills (with tiered generation: recognized / adapted / improvised), 8 agents, 155 tokens (3 themes, 8 collections), WCAG 2.2 AA. DS knowledge vendored from volivarii/actian-ds-knowledge.",
-  "version": "2026.9.18",
+  "version": "2026.9.19",
   "author": {
     "name": "Actian UX Team"
   },

--- a/plugins/actian-design-system/references/generate-flow/ds-components-authoring.md
+++ b/plugins/actian-design-system/references/generate-flow/ds-components-authoring.md
@@ -509,12 +509,35 @@ as the Figma property contract.
   "library": "ds",
   "dsSlug": "drawer",
   "variant": "App=Studio",
-  "props": { "Name": "Q1 Revenue Forecast", "Type": "Dataset", "Show Back": false }
+  "props": {
+    "Name": "Q1 Revenue Forecast",
+    "Type": "Dataset",
+    "Show Back": false,
+    "Technical name": "q1_revenue_forecast",
+    "Catalog": "Default",
+    "Category": "Finance",
+    "Connection": "snowflake_prod",
+    "Last updated": "Sep 8",
+    "Fields": "12 fields",
+    "Completion": 62,
+    "Glossary items": "Revenue, Forecast",
+    "Description": "Quarterly revenue forecast by region and product line."
+  }
 }
 ```
 
 - `props.Name`: the header title. `props.Type`: item-type badge (`Dataset`, `Category`, `Data process`, `Data product`, `Field`, `Output port`, `Use case`, `Visualization`; unknown values keep their own text but take the Dataset badge style (the renderer clamps only the CSS class and prints the raw value)). `props["Show Back"]`: default-true, set `false` to hide the back button.
-- **Header strip only.** The renderer draws a real header from these props, then a fixed specimen body ("Technical name: able_agency", a Finance/24-7/Powerbi meta line, a hardcoded date and description) that no prop or child reaches. Author the drawer's actual content as frame content in the screen rather than through `drawer` props.
+- **The leaf draws the whole panel, and only from props.** Body facts come from `Technical name`, `Catalog`, `Category`, `Connection`; the meta row from `Last updated`, `Fields`, `Completion` (0 to 100, drives the bar); the sections from `Glossary items`, `Description`, `Source description`. Every one is optional and its element is omitted when absent. The tab strip (Overview / Lineage / Quality), the `Shared` pill, the favourite button and the close button are fixed.
+- **The leaf reads no children.** A FRAME placed under a `drawer` INSTANCE renders below the panel, outside it, and the screen shows two stacked drawers. Do not author a "drawer body" frame. Content the props cannot carry (a checklist, a form) belongs in a plain panel FRAME styled as a side sheet, without the `drawer` leaf.
+
+### `progress-bar-small`
+
+```json
+{ "type": "INSTANCE", "library": "ds", "dsSlug": "progress-bar-small", "variant": "Size=Default", "props": { "Percent": 62 } }
+```
+
+- `props.Percent` (0 to 100) sets the fill and the printed label; it overrides the `Completeness` variant, which only offers 0%, 50% and 100%.
+- **The leaf prints its own percent label** (`62%`) to the right of the track. Do not add a TEXT beside it; the screen would read "62% 62%".
 
 ### `empty-state`
 

--- a/plugins/actian-design-system/references/generate-flow/html-reference.md
+++ b/plugins/actian-design-system/references/generate-flow/html-reference.md
@@ -37,7 +37,7 @@ These exist in the FM Kit Figma library and can be imported with `getComponentBy
 | **FM Chip** | Outline: False / True | — | |
 | **FM Alert** | Type: Success / Error / Warning | — | Persistent inline feedback. Left color bar indicates type. For brief confirmations use FM Toast instead |
 | **FM Banner** | Single component (no variants) | — | Page-level persistent notice bar. Import via `importComponentByKeyAsync` |
-| **FM Dialog** | Single component (no variants) | — | **Compose from frames instead of this component.** The `fmDialog` HTML renderer prints the literal title "Dialog" and an empty body, reading no text props. Build the dialog as a `FRAME` with title and body `TEXT` children plus FM Button instances, at 484px width. |
+| **FM Dialog** | Single component (no variants) | `Title`, `Body` | The `fmDialog` HTML renderer prints `Title` (also read as `Heading` or `Label`) and `Body` (also `Text` or `Message`); without them it prints an empty panel. It renders no buttons: put the FM Button instances in a footer `FRAME` under it. |
 | **FM Stepper** | State: Active / Complete / Upcoming | — | Step indicator for wizard flows. One instance per step in a horizontal row. Complete shows checkmark |
 | **FM Menu** | Single component (no variants) | — | Dropdown menu container. Use with FM Menu item children |
 | **FM Rich text field** | Single component (no variants) | `Input Text` | Multi-line rich text input with formatting |
@@ -49,7 +49,7 @@ These exist in the FM Kit Figma library and can be imported with `getComponentBy
 | **FM Side navigation bar** | Property 1: Default / Slim | — | |
 | **FM Side navigation item** | State: On / Off / Placeholder | `Label` | On = active page, Placeholder = filler items |
 | **FM Tab** | State: On / Off / Placeholder | — | On = active tab, Placeholder = future tabs. **No text override** — set label via `findOne(n => n.type === "TEXT").characters` in Figma, or inner text in HTML |
-| **FM Empty State** | Property 1: Default / Variant2 | — | **Compose from frames instead of this component.** The `fmEmptyState` HTML renderer always prints "No items", reading no text props. Build the empty state as a `FRAME` with an icon child, headline `TEXT`, and an FM Button for the CTA. |
+| **FM Empty State** | Property 1: Default / Variant2 | `Headline`, `Body`, `Cta` | The `fmEmptyState` HTML renderer prints `Headline` (also `Title`, `Text` or `Label`), `Body` (also `Description`) and a primary button from `Cta` (also `Action` or `Button`); each part is omitted when its prop is empty, so without props it prints only the icon. |
 | **FM Placeholder** | Type: Label+1line / Label+3lines / Label+6lines / Label+avatars / metric | — | For non-essential content areas in wireframes |
 | **FM Progress bar** | Completion: 10% through 100% | — | |
 | **FM Menu item** | State: Default / Hover / Active | — | |

--- a/plugins/actian-design-system/skills/generate-flow/SKILL.md
+++ b/plugins/actian-design-system/skills/generate-flow/SKILL.md
@@ -116,7 +116,7 @@ step-by-step behavior.
 
 5.0. **Skeleton — render the encapsulated deliverable immediately.** As soon as the screen list is approved (Gate 3), render the structure to the canonical artifact so the user sees it instantly instead of an empty panel:
 
-- Write the ordered screen list to `{project_working_directory}/flows/screen-list.json` as `{ "meta": {…}, "screens": [{ "name": "<screen name>", "template": "<template>" }, …] }` (one entry per approved screen, in final order; carry the known `meta`).
+- Write the ordered screen list to `{project_working_directory}/flows/screen-list.json` as `{ "meta": {…}, "screens": [{ "name": "<screen name>", "template": "<template>" }, …] }` (one entry per approved screen, in final order; carry the known `meta`). `template` is one of `studio`, `explorer`, `admin` (alias `administration`), `no-sidebar`, `bare`, `compact`, `mobile`, `tablet`, `custom` (the chrome vocabulary in `scripts/renderers/html-renderers/ds-screen-tree.js`); any other value, such as an archetype name like `browse-search`, falls back to the legacy `appHeader`/`sidebar` fields and a screen carrying neither renders no chrome.
 - **Parallel mode (6+):** merge the screen list into `flow-data.json` (pending stubs) via the incremental merge against the (empty) partials dir, then render `--type flow-share`:
   ```bash
   source "${CLAUDE_PLUGIN_ROOT}/scripts/lib/resolve-node.sh"


### PR DESCRIPTION
## Why

Rerunning the two generate-flow audit prompts on knowledge v0.34.207 (plugin 2026.9.18) and opening the HTML found a doubled drawer on the hi-fi flow: the authoring note still said "header strip only, author the body as frames", while the `drawer` leaf has drawn the whole panel from thirteen props since v0.34.205 and reads no children. The author obeyed the note, so the page showed the leaf's card and a second, unframed drawer under it. Three more rows were wrong in the same way: the `progress-bar-small` leaf prints its own percent (authors added a second one, "62% 62%"), and the FM Dialog and FM Empty State renderers read `Title`/`Body` and `Headline`/`Body`/`Cta` rather than printing fixed words. The `template` vocabulary was stated by no skill file, so an author who guessed an archetype name got a screen without chrome.

## What

- `references/generate-flow/ds-components-authoring.md`: drawer worked example lists the thirteen props, says the leaf reads no children and where a checklist goes; new `progress-bar-small` worked example. Both outside the generated regions (the regeneration scripts leave the file unchanged).
- `references/generate-flow/html-reference.md`: FM Dialog and FM Empty State rows name the props their renderers read and what prints without them.
- `skills/generate-flow/SKILL.md`: Step 5.0 names the valid `template` values and the fallback for any other value (still 491 lines).
- `CHANGELOG.md` Unreleased, `plugin.json` 2026.9.19.

## Proof

Reran the hi-fi prompt against this branch with the product's own word, "Share a data product to the Explorer marketplace in Studio --hifi", and looked at all five screens in Chrome: one drawer with no body stacked under it, one percent per bar, an Actions menu with the product's real items and no invented primary button, Output ports as cards under an info banner, a centred modal on a scrim. 9 minutes, 21 validator findings on the final pass, all terminology noise.

Reviewed by a fresh-context agent against the vendored renderers before push: one wrong version tag and six wording gaps, all folded in. Suite 2309 tests, 0 failures.

## Filed upstream from the same look

Knowledge #705 (checkbox ignores `Show label`), #706 (data-product status enum vs Share and lifecycle stage), #707 (Studio side rail shape), #708 (drawer leaf slots), #709 (menu-dropdown lays out in flow).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016rjfTZPzSoPCL6KHFx8T6i